### PR TITLE
Implement missing wires in tracker geometry

### DIFF
--- a/resources/config/snemo/demonstrator/geometry/4.0/models/tracker_geom_models.lis
+++ b/resources/config/snemo/demonstrator/geometry/4.0/models/tracker_geom_models.lis
@@ -11,7 +11,9 @@
 @falaise:config/snemo/demonstrator/geometry/4.0/models/tracker_modules/gveto.geom
 @falaise:config/snemo/common/geometry/4.0/models/tracker_drift_cell_core.geom
 @falaise:config/snemo/common/geometry/4.0/models/tracker_drift_cell.geom
+@falaise:config/snemo/demonstrator/geometry/4.0/models/tracker_modules/missing_wires.geom
 @falaise:config/snemo/demonstrator/geometry/4.0/models/tracker_modules/tracker_layers.geom
+@falaise:config/snemo/demonstrator/geometry/4.0/models/tracker_modules/tracker_layers_missing_wires.geom
 @falaise:config/snemo/demonstrator/geometry/4.0/models/tracker_modules/tracker_volumes.geom
 @falaise:config/snemo/demonstrator/geometry/4.0/models/tracker_modules/tracker_submodules.geom
 

--- a/resources/config/snemo/demonstrator/geometry/4.0/models/tracker_modules/missing_wires.geom
+++ b/resources/config/snemo/demonstrator/geometry/4.0/models/tracker_modules/missing_wires.geom
@@ -1,0 +1,1020 @@
+# -*- mode: conf-unix; -*-
+# missing_wires.geom
+
+#@description The geometry models that compose the drift cell (with field wires)
+#@key_label   "name"
+#@meta_label  "type"
+
+
+###############################################################
+[name="anode_wire_missing.model" type="geomtools::simple_shaped_model"]
+
+#@config Geometric description of a drift cell anode wire
+
+#######################
+# Geometry parameters #
+#######################
+
+#@description The name of the volume shape
+shape_type : string = "cylinder"
+
+#@description The diameter of the wire
+diameter : real as length = 0.01 um
+
+#@description The length of the wire
+z : real as length = 2866.0 mm
+
+#######################
+# Material parameters #
+#######################
+
+#@description The name of the material
+material.ref : string = "tracking_gas"
+
+#########################
+# Visibility parameters #
+#########################
+
+#visibility.hidden : boolean = true
+visibility.color          : string = "blue"
+
+
+
+##############################################################
+[name="drift_cell_core_missing.model" type="geomtools::stacked_model"]
+
+#@config Geometric description of the core volume of a drift cell
+#
+#   base bottom                                   base top
+#      -----  ring bottom                 ring top -----
+#      |   |-----                             -----|   |
+# - - -|   |=====)                           (=====|   |- - - - - -> z
+#      |   |-----    anode wire (missing)     -----|   |
+#      -----                                       -----
+#
+
+
+#######################
+# Geometry parameters #
+#######################
+
+#@description X dimension of the stack mother box
+x : real as length = 43.950 mm
+
+#@description Y dimension of the stack mother box
+y : real as length = 43.950 mm
+
+#@description Z dimension of the stack mother box
+z : real as length = 3030   mm
+
+#@description The stacking axis
+stacked.axis : string = "z"
+
+#@description The number of stacked volumes
+stacked.number_of_items : integer = 9
+
+#@description The geometry model stacked at position #8
+stacked.model_8     : string = "drift_cell_base.model"
+
+#@description The label of the volume stacked at position #8
+stacked.label_8     : string = "top_base"
+
+#@description The min limit for stacking associated to the volume stacked at position #8
+stacked.limit_min_8 : real as length = +37.00 mm # allowed Z-shift for stacking
+
+stacked.model_7     : string = "anode_bus_bar.model"
+stacked.label_7     : string = "top_anode_bus_bar"
+stacked.limit_min_7 : real as length = -9.0 mm # allowed Z-shift for stacking
+
+stacked.model_6     : string = "cathode_bus_bar.model"
+stacked.label_6     : string = "top_cathode_bus_bar"
+stacked.limit_min_6 : real as length =  -6.5 mm # allowed Z-shift for stacking
+
+stacked.model_5     : string = "drift_cell_ring.model"
+stacked.label_5     : string = "top_ring"
+stacked.limit_min_5 : real as length =  +6.25 mm # allowed Z-shift for stacking
+
+stacked.model_4     : string = "anode_wire_missing.model"
+stacked.label_4     : string = "anode_wire_missing"
+
+stacked.model_3     : string = "drift_cell_ring.model"
+stacked.label_3     : string = "bottom_ring"
+stacked.limit_max_3 : real as length = -6.25 mm # allowed Z-shift for stacking
+
+stacked.model_2     : string = "cathode_bus_bar.model"
+stacked.label_2     : string = "bottom_cathode_bus_bar"
+stacked.limit_max_2 : real as length = +6.5 mm # allowed Z-shift for stacking
+
+stacked.model_1     : string = "anode_bus_bar.model"
+stacked.label_1     : string = "bottom_anode_bus_bar"
+stacked.limit_max_1 : real as length = +9.0 mm # allowed Z-shift for stacking
+
+stacked.model_0     : string = "drift_cell_base.model"
+stacked.label_0     : string = "bottom_base"
+stacked.limit_max_0 : real as length = -37.00 mm # allowed Z-shift for stacking
+
+#######################
+# Material parameters #
+#######################
+
+#@description The name of the material
+material.ref : string = "tracking_gas"
+
+#########################
+# Visibility parameters #
+#########################
+
+# visibility.hidden_envelope  : boolean = false
+visibility.color              : string = "green"
+visibility.daughters.hidden : boolean = true
+# visibility.daughters.top_ring.shown    : boolean = true
+# visibility.daughters.bottom_ring.shown : boolean = true
+
+#################################
+# Sensitive detector parameters #
+#################################
+
+#@description The name of the sensitive detector category
+sensitive.category : string = "tracker_SD"
+
+######################
+# Mapping parameters #
+######################
+
+mapping.daughter_id.bottom_base : string = "[drift_cell_base:base=0]"
+mapping.daughter_id.top_base    : string = "[drift_cell_base:base=1]"
+mapping.daughter_id.bottom_ring : string = "[drift_cell_cathodic_ring:ring=0]"
+mapping.daughter_id.top_ring    : string = "[drift_cell_cathodic_ring:ring=1]"
+
+
+
+
+
+####
+[name="x_field_wires_missing_gap.model" type="geomtools::simple_shaped_model"]
+
+#@description The name of the volume shape
+shape_type : string = "box"
+
+#@description The radius of the cylinder
+x            : real as length = 9.115 mm
+
+#@description Cylinder diameter
+y : real as length = 50.0 um
+
+#@description Cylinder height
+z : real as length = 2920.0 mm
+
+#######################
+# Material parameters #
+#######################
+
+#@description The name of the material
+material.ref : string = "tracking_gas"
+####
+[name="x_field_wires_nonmissing_wires.model" type="geomtools::replicated_model"]
+#@description The replication axis
+replicated.axis : string = "x"
+
+#@description The number of replicated volumes
+replicated.number_of_items : integer = 2
+
+#@description The model of the replicated volumes
+replicated.model           : string = "field_wire.model"
+
+#@description The label associated to the replicated volumes
+replicated.label           : string = "field_wires"
+
+#@description The step between replicated volumes
+replicated.step            : real as length = 9.115 mm
+
+#######################
+# Material parameters #
+#######################
+
+#@description Name of the material (may be a material alias)
+material.ref : string = "tracking_gas"
+
+#########################
+# Visibility parameters #
+#########################
+
+# visibility.hidden            : boolean = false
+# visibility.hidden_envelope   : boolean = false
+# visibility.daughters.hidden  : boolean = false
+visibility.color             : string = "cyan"
+
+######################
+# Mapping parameters #
+######################
+
+mapping.daughter_id.field_wires : string = "[drift_cell_field_wire:wire+0]"
+
+
+
+###################################################################
+[name="x_field_wires_set_miss0.model" type="geomtools::stacked_model"]
+
+#@config Geometric description of a set of 3 field wires on core cell X-side
+
+# A set of field wires along the X axis:
+#
+#  (missing)
+#  wire #0      ^ y        wire #2
+#     \         :         /
+#    +-\-----------------/-+      ^
+#  - | --- - - -o- - - -o- |- - tiny - -> x
+#    +-----------\---------+      v
+#               : \
+#                  wire #1
+#       <- 18mm +23um ->
+#
+
+
+
+
+stacked.axis             : string = "x"
+stacked.number_of_items  : integer = 2
+stacked.model_0          : string = "x_field_wires_missing_gap.model"
+stacked.label_0          : string = "missing_gap"
+stacked.model_1          : string = "x_field_wires_nonmissing_wires.model"
+stacked.label_1          : string = "wires"
+
+
+
+
+
+
+#######################
+# Material parameters #
+#######################
+
+#@description Name of the material (may be a material alias)
+material.ref : string = "tracking_gas"
+
+#########################
+# Visibility parameters #
+#########################
+
+# visibility.hidden            : boolean = false
+# visibility.hidden_envelope   : boolean = false
+# visibility.daughters.hidden  : boolean = false
+visibility.color             : string = "cyan"
+
+###################################################################
+[name="x_field_wires_set_miss1.model" type="geomtools::replicated_model"]
+
+#@config Geometric description of a set of 3 field wires on core cell X-side
+
+# A set of field wires along the X axis:
+#
+#  wire #0      ^ y        wire #2
+#     \         :         /
+#    +-\-----------------/-+      ^
+#  - | -o- - - --- - - -o- |- - tiny - -> x
+#    +-----------\---------+      v
+#               : \
+#                  wire #1
+#       <- 18mm +23um ->
+#
+
+#######################
+# Geometry parameters #
+#######################
+
+#@description The replication axis
+replicated.axis : string = "x"
+
+#@description The number of replicated volumes
+replicated.number_of_items : integer = 2
+
+#@description The model of the replicated volumes
+replicated.model           : string = "field_wire.model"
+
+#@description The label associated to the replicated volumes
+replicated.label           : string = "field_wires"
+
+#@description The step between replicated volumes
+replicated.step            : real as length = 18.23 mm
+
+#######################
+# Material parameters #
+#######################
+
+#@description Name of the material (may be a material alias)
+material.ref : string = "tracking_gas"
+
+#########################
+# Visibility parameters #
+#########################
+
+# visibility.hidden            : boolean = false
+# visibility.hidden_envelope   : boolean = false
+# visibility.daughters.hidden  : boolean = false
+visibility.color             : string = "cyan"
+
+######################
+# Mapping parameters #
+######################
+
+mapping.daughter_id.field_wires : string = "[drift_cell_field_wire:wire+0]"
+
+###################################################################
+[name="x_field_wires_set_miss2.model" type="geomtools::stacked_model"]
+#@config Geometric description of a set of 3 field wires on core cell X-side
+
+# A set of field wires along the X axis:
+#
+#  wire #0      ^ y        wire #2
+#     \         :         /
+#    +-\-----------------/-+      ^
+#  - | -o- - - -o- - - --- |- - tiny - -> x
+#    +-----------\---------+      v
+#               : \
+#                  wire #1
+#       <- 18mm +23um ->
+#
+
+#######################
+# Geometry parameters #
+#######################
+
+
+stacked.axis             : string = "x"
+stacked.number_of_items  : integer = 2
+stacked.model_1          : string = "x_field_wires_missing_gap.model"
+stacked.label_1          : string = "missing_gap"
+stacked.model_0          : string = "x_field_wires_nonmissing_wires.model"
+stacked.label_0          : string = "wires"
+
+
+
+#######################
+# Material parameters #
+#######################
+
+#@description Name of the material (may be a material alias)
+material.ref : string = "tracking_gas"
+
+#########################
+# Visibility parameters #
+#########################
+
+# visibility.hidden            : boolean = false
+# visibility.hidden_envelope   : boolean = false
+# visibility.daughters.hidden  : boolean = false
+visibility.color             : string = "cyan"
+
+######################
+# Mapping parameters #
+######################
+
+
+
+
+
+[name="y_field_wires_missing_gap.model" type="geomtools::simple_shaped_model"]
+
+#@description The name of the volume shape
+shape_type : string = "box"
+
+#@description The radius of the cylinder
+y            : real as length = 9.115 mm
+
+#@description Cylinder diameter
+x : real as length = 50.0 um
+
+#@description Cylinder height
+z : real as length = 2920.0 mm
+
+#######################
+# Material parameters #
+#######################
+
+#@description The name of the material
+material.ref : string = "tracking_gas"
+####
+[name="y_field_wires_nonmissing_wires.model" type="geomtools::replicated_model"]
+#@description The replication axis
+replicated.axis : string = "y"
+
+#@description The number of replicated volumes
+replicated.number_of_items : integer = 2
+
+#@description The model of the replicated volumes
+replicated.model           : string = "field_wire.model"
+
+#@description The label associated to the replicated volumes
+replicated.label           : string = "field_wires"
+
+#@description The step between replicated volumes
+replicated.step            : real as length = 9.115 mm
+
+#######################
+# Material parameters #
+#######################
+
+#@description Name of the material (may be a material alias)
+material.ref : string = "tracking_gas"
+
+#########################
+# Visibility parameters #
+#########################
+
+# visibility.hidden            : boolean = false
+# visibility.hidden_envelope   : boolean = false
+# visibility.daughters.hidden  : boolean = false
+visibility.color             : string = "cyan"
+
+######################
+# Mapping parameters #
+######################
+
+mapping.daughter_id.field_wires : string = "[drift_cell_field_wire:wire+0]"
+
+
+
+
+
+
+
+
+
+###################################################################
+[name="y_field_wires_set_miss0.model" type="geomtools::stacked_model"]
+
+#@config Geometric description of a set of 3 field wires on core cell Y-side
+
+# A set of field wires along the Y axis
+#
+#              ^ y
+#              :
+#            +---+
+#            | : |
+#        ^   | o-|----- wire #2
+#        :   | : |
+#        :   | : |         x
+#  18 mm :- -|-o-|- - - ->
+#  +     :   | :`|----- wire #1
+#  23 um :   | : |
+#        v   | :-|----- wire #0
+#            | : |
+#            +---+
+#              :
+#              :
+#            <tiny>
+#
+#
+
+#######################
+# Geometry parameters #
+#######################
+
+stacked.axis             : string = "y"
+stacked.number_of_items  : integer = 2
+stacked.model_0          : string = "y_field_wires_missing_gap.model"
+stacked.label_0          : string = "missing_gap"
+stacked.model_1          : string = "y_field_wires_nonmissing_wires.model"
+stacked.label_1          : string = "wires"
+
+#######################
+# Material parameters #
+#######################
+
+#@description Name of the material (may be a material alias)
+material.ref : string = "tracking_gas"
+
+#########################
+# Visibility parameters #
+#########################
+
+# visibility.hidden           : boolean = false
+# visibility.hidden_envelope  : boolean = false
+# visibility.daughters.hidden : boolean = false
+visibility.color            : string = "cyan"
+
+###################################################################
+[name="y_field_wires_set_miss1.model" type="geomtools::replicated_model"]
+
+#@config Geometric description of a set of 3 field wires on core cell Y-side
+
+# A set of field wires along the Y axis
+#
+#              ^ y
+#              :
+#            +---+
+#            | : |
+#        ^   | o-|----- wire #2
+#        :   | : |
+#        :   | : |         x
+#  18 mm :- -|-:-|- - - ->
+#  +     :   | :`|----- wire #1
+#  23 um :   | : |
+#        v   | o-|----- wire #0
+#            | : |
+#            +---+
+#              :
+#              :
+#            <tiny>
+#
+#
+
+#######################
+# Geometry parameters #
+#######################
+
+#@description The replication axis
+replicated.axis : string = "y"
+
+#@description The number of replicated volumes
+replicated.number_of_items : integer = 2
+
+#@description The model of the replicated volumes
+replicated.model : string = "field_wire.model"
+
+#@description The label associated to the replicated volumes
+replicated.label : string = "field_wires"
+
+#@description The step between replicated volumes
+replicated.step  : real as length = 18.23 mm
+
+#######################
+# Material parameters #
+#######################
+
+#@description Name of the material (may be a material alias)
+material.ref : string = "tracking_gas"
+
+#########################
+# Visibility parameters #
+#########################
+
+# visibility.hidden           : boolean = false
+# visibility.hidden_envelope  : boolean = false
+# visibility.daughters.hidden : boolean = false
+visibility.color            : string = "cyan"
+
+######################
+# Mapping parameters #
+######################
+
+mapping.daughter_id.field_wires : string = "[drift_cell_field_wire:wire+0]"
+
+
+###################################################################
+[name="y_field_wires_set_miss2.model" type="geomtools::stacked_model"]
+
+#@config Geometric description of a set of 3 field wires on core cell Y-side
+
+# A set of field wires along the Y axis
+#
+#              ^ y
+#              :
+#            +---+
+#            | : |
+#        ^   | :-|----- wire #2
+#        :   | : |
+#        :   | : |         x
+#  18 mm :- -|-o-|- - - ->
+#  +     :   | :`|----- wire #1
+#  23 um :   | : |
+#        v   | o-|----- wire #0
+#            | : |
+#            +---+
+#              :
+#              :
+#            <tiny>
+#
+#
+
+#######################
+# Geometry parameters #
+#######################
+
+
+stacked.axis             : string = "y"
+stacked.number_of_items  : integer = 2
+stacked.model_1          : string = "y_field_wires_missing_gap.model"
+stacked.label_1          : string = "missing_gap"
+stacked.model_0          : string = "y_field_wires_nonmissing_wires.model"
+stacked.label_0          : string = "wires"
+
+#######################
+# Material parameters #
+#######################
+
+#@description Name of the material (may be a material alias)
+material.ref : string = "tracking_gas"
+
+#########################
+# Visibility parameters #
+#########################
+
+# visibility.hidden           : boolean = false
+# visibility.hidden_envelope  : boolean = false
+# visibility.daughters.hidden : boolean = false
+visibility.color            : string = "cyan"
+
+############################################################################
+[name="drift_cell_node_0123_miss.model" type="geomtools::surrounded_boxed_model"]
+
+#@config A cell equipped with field wire sets on 4 sides
+#
+#                    y
+#                     ^       'core cell' model
+#           right (3) :        /
+#              +-------------+/
+#              |  o   o   o  / <-- X aligned 'set of field wires' model
+#          +---+------------/+---+
+#          | o |      :    / | o |
+#          |   |      :      |   | front (1)
+# back (0)-|-o |- - - o - - -|-o-|- - -> x
+#          |   |      :      |   |
+#          | o |      :      | o | <--- Y aligned 'set of field wires' model
+#          +---+-------------+---+
+#              |  o   o   o  |
+#              +-------------+
+#                     : left (2)
+#                     :
+#
+
+#######################
+# Geometry parameters #
+#######################
+
+surrounded.centered_x  : boolean = false
+surrounded.centered_y  : boolean = false
+surrounded.centered_z  : boolean = false
+
+surrounded.model       : string = "drift_cell_core.model"
+surrounded.label       : string = "core_cell"
+
+surrounded.back_model  : string = "y_field_wires_set.model"
+surrounded.back_label  : string = "field_wires_set_back"
+
+surrounded.front_model : string = "y_field_wires_set.model"
+surrounded.front_label : string = "field_wires_set_front"
+
+surrounded.left_model  : string = "x_field_wires_set.model"
+surrounded.left_label  : string = "field_wires_set_left"
+
+surrounded.right_model : string = "x_field_wires_set.model"
+surrounded.right_label : string = "field_wires_set_right"
+
+#######################
+# Material parameters #
+#######################
+
+#@description Name of the material (may be a material alias)
+material.ref : string = "tracking_gas"
+
+#########################
+# Visibility parameters #
+#########################
+
+# visibility.hidden           : boolean = false
+# visibility.hidden_envelope  : boolean = false
+visibility.daughters.hidden : boolean = true
+visibility.daughters.core_cell.shown : boolean = true
+visibility.color            : string = "cyan"
+
+######################
+# Mapping parameters #
+######################
+
+mapping.daughter_id.field_wires_set_back  : string = "[drift_cell_field_wires_set:set=0]"
+mapping.daughter_id.field_wires_set_front : string = "[drift_cell_field_wires_set:set=1]"
+mapping.daughter_id.field_wires_set_left  : string = "[drift_cell_field_wires_set:set=2]"
+mapping.daughter_id.field_wires_set_right : string = "[drift_cell_field_wires_set:set=3]"
+mapping.daughter_id.core_cell             : string = "[drift_cell_core]"
+
+
+######################################################################
+[name="drift_cell_node_013_miss01.model" type="geomtools::surrounded_boxed_model"]
+
+#@config A cell equipped with field wire sets on 3 sides
+#
+#                    y
+#                     ^       'core cell' model
+#           right (3) :        /
+#              +-------------+/
+#              |  o   o   o  / <-- X aligned 'set of field wires' model
+#          +---+------------/+---+
+#          | o |      :    / | o |
+#          |   |      :      |   | front (1)
+# back (0)-|-o |- - - o - - -|-o-|- - -> x
+#          |   |      :      |   |
+#          | o |      :      | o | <--- Y aligned 'set of field wires' model
+#          +---+-------------+---+
+#                     :
+#                     :
+#
+
+#######################
+# Geometry parameters #
+#######################
+
+surrounded.centered_x  : boolean = false
+surrounded.centered_y  : boolean = false
+surrounded.centered_z  : boolean = false
+
+surrounded.model       : string = "drift_cell_core.model"
+surrounded.label       : string = "core_cell"
+
+surrounded.back_model  : string = "y_field_wires_set_miss1.model"
+surrounded.back_label  : string = "field_wires_set_back"
+
+surrounded.front_model : string = "y_field_wires_set.model"
+surrounded.front_label : string = "field_wires_set_front"
+
+surrounded.right_model : string = "x_field_wires_set.model"
+surrounded.right_label : string = "field_wires_set_right"
+
+#######################
+# Material parameters #
+#######################
+
+material.ref : string = "tracking_gas"
+
+#########################
+# Visibility parameters #
+#########################
+
+# visibility.hidden           : boolean = false
+# visibility.hidden_envelope  : boolean = false
+visibility.daughters.hidden : boolean = true
+visibility.daughters.core_cell.shown : boolean = true
+visibility.color            : string = "cyan"
+
+######################
+# Mapping parameters #
+######################
+
+mapping.daughter_id.field_wires_set_back  : string = "[drift_cell_field_wires_set:set=0]"
+mapping.daughter_id.field_wires_set_front : string = "[drift_cell_field_wires_set:set=1]"
+mapping.daughter_id.field_wires_set_right : string = "[drift_cell_field_wires_set:set=3]"
+mapping.daughter_id.core_cell             : string = "[drift_cell_core]"
+
+######################################################################
+[name="drift_cell_node_13_missing_anode.model" type="geomtools::surrounded_boxed_model"]
+
+#@config A cell equipped with field wire sets on 3 sides
+#
+#                    y
+#                     ^       'core cell' model with missing anode
+#           right (3) :        /
+#              +-------------+/
+#              |  o   o   o  / <-- X aligned 'set of field wires' model
+#              +------------/+---+
+#              |      :    / | o |
+#              |      :      |   | front (1)
+#              |- - - X - - -|-o-|- - -> x
+#              |      :      |   |
+#              |      :      | o | <--- Y aligned 'set of field wires' model
+#              +-------------+---+
+#                     :
+#                     :
+#
+
+#######################
+# Geometry parameters #
+#######################
+
+surrounded.centered_x  : boolean = false
+surrounded.centered_y  : boolean = false
+surrounded.centered_z  : boolean = false
+
+surrounded.model       : string = "drift_cell_core_missing.model"
+surrounded.label       : string = "core_cell"
+
+surrounded.front_model : string = "y_field_wires_set.model"
+surrounded.front_label : string = "field_wires_set_front"
+
+surrounded.right_model : string = "x_field_wires_set.model"
+surrounded.right_label : string = "field_wires_set_right"
+
+#######################
+# Material parameters #
+#######################
+
+#@description Name of the material (may be a material alias)
+material.ref : string = "tracking_gas"
+
+#########################
+# Visibility parameters #
+#########################
+
+# visibility.hidden           : boolean = false
+# visibility.hidden_envelope  : boolean = false
+visibility.daughters.hidden : boolean = true
+visibility.daughters.core_cell.shown : boolean = true
+visibility.color            : string = "green"
+
+######################
+# Mapping parameters #
+######################
+
+mapping.daughter_id.field_wires_set_front : string = "[drift_cell_field_wires_set:set=1]"
+mapping.daughter_id.field_wires_set_right : string = "[drift_cell_field_wires_set:set=3]"
+mapping.daughter_id.core_cell             : string = "[drift_cell_core]"
+
+
+######################################################################
+[name="drift_cell_node_13_miss32.model" type="geomtools::surrounded_boxed_model"]
+
+#@config A cell equipped with field wire sets on 3 sides
+#
+#                    y
+#                     ^       'core cell' model
+#           right (3) :        /
+#              +-------------+/
+#              |  o   o   -  / <-- X aligned 'set of field wires' model -- missing 0
+#              +------------/+---+
+#              |      :    / | O |
+#              |      :      |   | front (1)
+#              |- - - o - - -|-O-|- - -> x
+#              |      :      |   |
+#              |      :      | O | <--- Y aligned 'set of field wires' model 
+#              +-------------+---+
+#                     :
+#                     :
+#
+
+#######################
+# Geometry parameters #
+#######################
+
+surrounded.centered_x  : boolean = false
+surrounded.centered_y  : boolean = false
+surrounded.centered_z  : boolean = false
+
+surrounded.model       : string = "drift_cell_core.model"
+surrounded.label       : string = "core_cell"
+
+surrounded.front_model : string = "y_field_wires_set.model"
+surrounded.front_label : string = "field_wires_set_front"
+
+surrounded.right_model : string = "x_field_wires_set_miss2.model"
+surrounded.right_label : string = "field_wires_set_right"
+
+#######################
+# Material parameters #
+#######################
+
+#@description Name of the material (may be a material alias)
+material.ref : string = "tracking_gas"
+
+#########################
+# Visibility parameters #
+#########################
+
+# visibility.hidden           : boolean = false
+# visibility.hidden_envelope  : boolean = false
+visibility.daughters.hidden : boolean = true
+visibility.daughters.core_cell.shown : boolean = true
+visibility.color            : string = "cyan"
+
+######################
+# Mapping parameters #
+######################
+
+mapping.daughter_id.field_wires_set_front : string = "[drift_cell_field_wires_set:set=1]"
+mapping.daughter_id.field_wires_set_right : string = "[drift_cell_field_wires_set:set=3]"
+mapping.daughter_id.core_cell             : string = "[drift_cell_core]"
+
+
+######################################################################
+[name="drift_cell_node_13_miss1.model" type="geomtools::surrounded_boxed_model"]
+
+#@config A cell equipped with field wire sets on 3 sides
+#
+#                    y
+#                     ^       'core cell' model
+#           right (3) :        /
+#              +-------------+/
+#              |  o   o   o  / <-- X aligned 'set of field wires' model
+#              +------------/+---+
+#              |      :    / | : |
+#              |      :      |   | front (1)
+#              |- - - o - - -|-:-|- - -> x
+#              |      :      |   |
+#              |      :      | : | <--- Y aligned 'set of field wires' model -- missing
+#              +-------------+---+
+#                     :
+#                     :
+#
+
+#######################
+# Geometry parameters #
+#######################
+
+surrounded.centered_x  : boolean = false
+surrounded.centered_y  : boolean = false
+surrounded.centered_z  : boolean = false
+
+surrounded.model       : string = "drift_cell_core.model"
+surrounded.label       : string = "core_cell"
+
+#surrounded.front_model : string = "y_field_wires_set.model"
+#surrounded.front_label : string = "field_wires_set_front"
+
+surrounded.right_model : string = "x_field_wires_set.model"
+surrounded.right_label : string = "field_wires_set_right"
+
+#######################
+# Material parameters #
+#######################
+
+#@description Name of the material (may be a material alias)
+material.ref : string = "tracking_gas"
+
+#########################
+# Visibility parameters #
+#########################
+
+# visibility.hidden           : boolean = false
+# visibility.hidden_envelope  : boolean = false
+visibility.daughters.hidden : boolean = true
+visibility.daughters.core_cell.shown : boolean = true
+visibility.color            : string = "cyan"
+
+######################
+# Mapping parameters #
+######################
+
+#mapping.daughter_id.field_wires_set_front : string = "[drift_cell_field_wires_set:set=1]"
+mapping.daughter_id.field_wires_set_right : string = "[drift_cell_field_wires_set:set=3]"
+mapping.daughter_id.core_cell             : string = "[drift_cell_core]"
+
+
+#####################################################################
+[name="drift_cell_node_123_miss.model" type="geomtools::surrounded_boxed_model"]
+
+#@config A cell equipped with field wire sets on 3 sides
+#
+#                    y
+#                     ^       'core cell' model
+#           right (3) :        /
+#              +-------------+/
+#              |  o   o   o  / <-- X aligned 'set of field wires' model
+#              +------------/+---+
+#              |      :    / | o |
+#              |      :      |   | front (1)
+#              |- - - o - - -|-o-|- - -> x
+#              |      :      |   |
+#              |      :      | o | <--- Y aligned 'set of field wires' model
+#              +-------------+---+
+#              |  o   o   o  |
+#              +-------------+
+#                     : left (2)
+#                     :
+#
+
+#######################
+# Geometry parameters #
+#######################
+
+surrounded.centered_x  : boolean = false
+surrounded.centered_y  : boolean = false
+surrounded.centered_z  : boolean = false
+
+surrounded.model       : string = "drift_cell_core.model"
+surrounded.label       : string = "core_cell"
+
+surrounded.front_model : string = "y_field_wires_set.model"
+surrounded.front_label : string = "field_wires_set_front"
+
+surrounded.left_model  : string = "x_field_wires_set.model"
+surrounded.left_label  : string = "field_wires_set_left"
+
+surrounded.right_model : string = "x_field_wires_set.model"
+surrounded.right_label : string = "field_wires_set_right"
+
+#######################
+# Material parameters #
+#######################
+
+#@description Name of the material (may be a material alias)
+material.ref : string = "tracking_gas"
+
+#########################
+# Visibility parameters #
+#########################
+
+# visibility.hidden           : boolean = false
+# visibility.hidden_envelope  : boolean = false
+visibility.daughters.hidden : boolean = true
+visibility.daughters.core_cell.shown : boolean = true
+visibility.color            : string = "cyan"
+
+######################
+# Mapping parameters #
+######################
+
+mapping.daughter_id.field_wires_set_front : string = "[drift_cell_field_wires_set:set=1]"
+mapping.daughter_id.field_wires_set_left  : string = "[drift_cell_field_wires_set:set=2]"
+mapping.daughter_id.field_wires_set_right : string = "[drift_cell_field_wires_set:set=3]"
+mapping.daughter_id.core_cell             : string = "[drift_cell_core]"
+
+
+# end of missing_wires.geom

--- a/resources/config/snemo/demonstrator/geometry/4.0/models/tracker_modules/tracker_layers_missing_wires.geom
+++ b/resources/config/snemo/demonstrator/geometry/4.0/models/tracker_modules/tracker_layers_missing_wires.geom
@@ -1,0 +1,392 @@
+# -*- mode: conf-unix; -*-
+# @falaise:config/snemo/demonstrator/geometry/4.0/models/tracker_module/tracker_layers_missing_wires.geom
+
+
+
+
+
+# Pawel Guzowski 05 May 2017: Set up the missing wire geometry for the following known missing wires:
+#
+# SNCM 050 - field (between cell 0 and 9, closest to calo)
+# SNCM 123 - anode cell 5 cut out at manchester
+# SNCM C0C1 - field (cell 0, middle, closest to calo wall) had fallen out on inspection at LSM gas seal plate removal
+# SNCM C0C1 - 3 fields between cell 3 and 4 never constructed by design
+# SNCM C2C3 - 3 fields between cell 3 and 4 never constructed by design
+#
+#
+#
+# The following cases were not diligently noted during cell insertion, and will need to be determined later:
+# SNCM 070 - field (cell 15 somewhere?)
+# SNCM 073 - field (somewhere?)
+# SNCM 075 - field (somewhere?)
+# SNCM 099 - field (cell 10 somewhere?)
+# SNCM 101 - field (cell 16 somewhere?)
+# SNCM 114 - field (cell 13 'external bottom'?)
+
+
+
+
+
+
+
+
+
+
+
+#
+# Last 108 cells (beginning at #5) of layer 3 are normal
+#
+##########################################################################
+[name="tracker_layer_back_l3_108.model" type="geomtools::replicated_boxed_model"]
+
+replicated.number_of_items : integer = 108
+replicated.model           : string = "drift_cell_node_13.model"
+replicated.axis            : string = "y"
+replicated.label           : string = "cells"
+
+material.ref               : string = "tracking_gas"
+
+visibility.hidden_envelope  : boolean = true
+# visibility.daughters.hidden : boolean = false
+visibility.color            : string = "grey"
+
+# Daughters mapping informations:
+mapping.daughter_id.cells : string = "[drift_cell:row+5]"
+
+
+#
+# Cells 1-4 of layer 3 are normal
+#
+##########################################################################
+[name="tracker_layer_back_l3_003.model" type="geomtools::replicated_boxed_model"]
+
+replicated.number_of_items : integer = 3
+replicated.model           : string = "drift_cell_node_13.model"
+replicated.axis            : string = "y"
+replicated.label           : string = "cells"
+
+material.ref               : string = "tracking_gas"
+
+visibility.hidden_envelope  : boolean = true
+# visibility.daughters.hidden : boolean = false
+visibility.color            : string = "grey"
+
+# Daughters mapping informations:
+mapping.daughter_id.cells : string = "[drift_cell:row+1]"
+
+#
+# Set up complete layer 3 (edge normal; 3 normal replicated; missing 1; 108 normal replicated)
+#
+##########################################################################
+[name="tracker_layer_back_l3.model" type="geomtools::stacked_model"]
+
+stacked.axis             : string = "y"
+stacked.number_of_items  : integer = 4
+stacked.model_0          : string = "drift_cell_node_123.model"
+stacked.label_0          : string = "first_drift_cell"
+stacked.model_1          : string = "tracker_layer_back_l3_003.model"
+stacked.label_1          : string = "other_drift_cells_below"
+stacked.model_2          : string = "drift_cell_node_13_missing_anode.model"
+stacked.label_2          : string = "missing_anode_cell"
+stacked.model_3          : string = "tracker_layer_back_l3_108.model"
+stacked.label_3          : string = "other_drift_cells_above"
+
+material.ref : string = "tracking_gas"
+
+# Daughters mapping informations:
+mapping.daughter_id.first_drift_cell : string = "[drift_cell:row=0]"
+mapping.daughter_id.missing_anode_cell : string = "[drift_cell:row=4]"
+
+visibility.hidden_envelope  : boolean = true
+# visibility.daughters.hidden : boolean = false
+visibility.color            : string = "grey"
+
+
+######################################################
+#                                                    #
+# Layers 4(front) and 5(back) look identical because #
+# these have the missing row of cathode wires in the #
+# special cassette in the middle                     #
+#                                                    #
+######################################################
+
+
+#
+# first 55 replicated cells in layer 4 are normal
+#
+##########################################################################
+[name="tracker_layer_front_l4_055.model" type="geomtools::replicated_boxed_model"]
+
+replicated.number_of_items : integer = 55
+replicated.model           : string = "drift_cell_node_13.model"
+replicated.axis            : string = "y"
+replicated.label           : string = "cells"
+
+material.ref               : string = "tracking_gas"
+
+visibility.hidden_envelope  : boolean = true
+# visibility.daughters.hidden : boolean = false
+visibility.color            : string = "grey"
+
+# Daughters mapping informations:
+mapping.daughter_id.cells : string = "[drift_cell:row+1]"
+
+#
+# last 56 replicated cells in layer 4 are normal
+#
+##########################################################################
+[name="tracker_layer_front_l4_056.model" type="geomtools::replicated_boxed_model"]
+
+replicated.number_of_items : integer = 56
+replicated.model           : string = "drift_cell_node_13.model"
+replicated.axis            : string = "y"
+replicated.label           : string = "cells"
+
+material.ref               : string = "tracking_gas"
+
+visibility.hidden_envelope  : boolean = true
+# visibility.daughters.hidden : boolean = false
+visibility.color            : string = "grey"
+
+# Daughters mapping informations:
+mapping.daughter_id.cells : string = "[drift_cell:row+57]"
+
+#
+# Set up layer 4 (edge normal, 55 normal replicated, 1 missing, 56 normal replicated)
+#
+##########################################################################
+[name="tracker_layer_front_l4.model" type="geomtools::stacked_model"]
+
+stacked.axis             : string = "y"
+stacked.number_of_items  : integer = 4
+stacked.model_0          : string = "drift_cell_node_123.model"
+stacked.label_0          : string = "first_drift_cell"
+stacked.model_1          : string = "tracker_layer_front_l4_055.model"
+stacked.label_1          : string = "other_drift_cells_below"
+stacked.model_2          : string = "drift_cell_node_13_miss1.model"
+stacked.label_2          : string = "missing_cathode_cell"
+stacked.model_3          : string = "tracker_layer_front_l4_056.model"
+stacked.label_3          : string = "other_drift_cells_above"
+
+
+material.ref : string = "tracking_gas"
+
+# Daughters mapping informations:
+mapping.daughter_id.first_drift_cell : string = "[drift_cell:row=0]"
+mapping.daughter_id.missing_cathode_cell : string = "[drift_cell:row=56]"
+
+visibility.hidden_envelope  : boolean = true
+# visibility.daughters.hidden : boolean = false
+visibility.color            : string = "grey"
+
+
+#
+# first 55 replicated cells in layer 5 are normal
+#
+##########################################################################
+[name="tracker_layer_back_l5_055.model" type="geomtools::replicated_boxed_model"]
+
+replicated.number_of_items : integer = 55
+replicated.model           : string = "drift_cell_node_13.model"
+replicated.axis            : string = "y"
+replicated.label           : string = "cells"
+
+material.ref               : string = "tracking_gas"
+
+visibility.hidden_envelope  : boolean = true
+# visibility.daughters.hidden : boolean = false
+visibility.color            : string = "grey"
+
+# Daughters mapping informations:
+mapping.daughter_id.cells : string = "[drift_cell:row+1]"
+
+#
+# last 56 replicated cells in layer 5 are normal
+#
+##########################################################################
+[name="tracker_layer_back_l5_056.model" type="geomtools::replicated_boxed_model"]
+
+replicated.number_of_items : integer = 56
+replicated.model           : string = "drift_cell_node_13.model"
+replicated.axis            : string = "y"
+replicated.label           : string = "cells"
+
+material.ref               : string = "tracking_gas"
+
+visibility.hidden_envelope  : boolean = true
+# visibility.daughters.hidden : boolean = false
+visibility.color            : string = "grey"
+
+# Daughters mapping informations:
+mapping.daughter_id.cells : string = "[drift_cell:row+57]"
+
+#
+# Set up layer 5 (edge normal, 55 normal replicated, 1 missing, 56 normal replicated
+#
+##########################################################################
+[name="tracker_layer_back_l5.model" type="geomtools::stacked_model"]
+
+stacked.axis             : string = "y"
+stacked.number_of_items  : integer = 4
+stacked.model_0          : string = "drift_cell_node_123.model"
+stacked.label_0          : string = "first_drift_cell"
+stacked.model_1          : string = "tracker_layer_back_l5_055.model"
+stacked.label_1          : string = "other_drift_cells_below"
+stacked.model_2          : string = "drift_cell_node_13_miss1.model"
+stacked.label_2          : string = "missing_cathode_cell"
+stacked.model_3          : string = "tracker_layer_back_l5_056.model"
+stacked.label_3          : string = "other_drift_cells_above"
+
+
+material.ref : string = "tracking_gas"
+
+# Daughters mapping informations:
+mapping.daughter_id.first_drift_cell : string = "[drift_cell:row=0]"
+mapping.daughter_id.missing_cathode_cell : string = "[drift_cell:row=56]"
+
+visibility.hidden_envelope  : boolean = true
+# visibility.daughters.hidden : boolean = false
+visibility.color            : string = "grey"
+
+
+#
+# First 31 replicaed cells are normal
+#
+##########################################################################
+[name="tracker_layer_front_l8_031.model" type="geomtools::replicated_boxed_model"]
+
+replicated.number_of_items : integer = 31
+replicated.model           : string = "drift_cell_node_13.model"
+replicated.axis            : string = "y"
+replicated.label           : string = "cells"
+
+material.ref               : string = "tracking_gas"
+
+visibility.hidden_envelope  : boolean = true
+# visibility.daughters.hidden : boolean = false
+visibility.color            : string = "grey"
+
+# Daughters mapping informations:
+mapping.daughter_id.cells : string = "[drift_cell:row+1]"
+
+#
+# Last 80 replicated cells are normal
+#
+##########################################################################
+[name="tracker_layer_front_l8_080.model" type="geomtools::replicated_boxed_model"]
+
+replicated.number_of_items : integer = 80
+replicated.model           : string = "drift_cell_node_13.model"
+replicated.axis            : string = "y"
+replicated.label           : string = "cells"
+
+material.ref               : string = "tracking_gas"
+
+visibility.hidden_envelope  : boolean = true
+# visibility.daughters.hidden : boolean = false
+visibility.color            : string = "grey"
+
+# Daughters mapping informations:
+mapping.daughter_id.cells : string = "[drift_cell:row+33]"
+
+#
+# Set up layer 8 (edge normal, 31 normal replicated, 1 missing, 80 normal)
+#
+############################################################
+[name="tracker_layer_front_l8.model" type="geomtools::stacked_model"]
+
+stacked.axis             : string = "y"
+stacked.number_of_items  : integer = 4
+stacked.model_0          : string = "drift_cell_node_123.model"
+stacked.label_0          : string = "first_drift_cell"
+stacked.model_1          : string = "tracker_layer_front_l8_031.model"
+stacked.label_1          : string = "other_drift_cells_below"
+stacked.model_2          : string = "drift_cell_node_13_miss32.model"
+stacked.label_2          : string = "missing_cathode_cell"
+stacked.model_3          : string = "tracker_layer_front_l8_080.model"
+stacked.label_3          : string = "other_drift_cells_above"
+
+
+material.ref : string = "tracking_gas"
+
+# Daughters mapping informations:
+mapping.daughter_id.first_drift_cell : string = "[drift_cell:row=0]"
+mapping.daughter_id.missing_cathode_cell : string = "[drift_cell:row=32]"
+
+visibility.hidden_envelope  : boolean = true
+# visibility.daughters.hidden : boolean = false
+visibility.color            : string = "grey"
+
+
+
+#
+# First 55 replicated are normal
+#
+##################################################################################
+[name="tracker_layer_front_l0_055.model" type="geomtools::replicated_boxed_model"]
+
+replicated.number_of_items : integer = 55
+replicated.model           : string = "drift_cell_node_013.model"
+replicated.axis            : string = "y"
+replicated.label           : string = "cells"
+
+material.ref               : string = "tracking_gas"
+
+visibility.hidden_envelope  : boolean = true
+# visibility.daughters.hidden : boolean = false
+visibility.color            : string = "grey"
+
+# Daughters mapping informations:
+mapping.daughter_id.cells : string = "[drift_cell:row+1]"
+
+#
+# Last 56 replicated are normal
+#
+##################################################################################
+[name="tracker_layer_front_l0_056.model" type="geomtools::replicated_boxed_model"]
+
+replicated.number_of_items : integer = 56
+replicated.model           : string = "drift_cell_node_013.model"
+replicated.axis            : string = "y"
+replicated.label           : string = "cells"
+
+material.ref               : string = "tracking_gas"
+
+visibility.hidden_envelope  : boolean = true
+# visibility.daughters.hidden : boolean = false
+visibility.color            : string = "grey"
+
+# Daughters mapping informations:
+mapping.daughter_id.cells : string = "[drift_cell:row+57]"
+
+#
+# Set up layer 0 (edge normal, 55 normal replicated, 1 missing, 56 replicated normal
+#
+####################################################################
+[name="tracker_layer_front_l0.model" type="geomtools::stacked_model"]
+
+stacked.axis             : string = "y"
+stacked.number_of_items  : integer = 4
+stacked.model_0          : string = "drift_cell_node_0123.model"
+stacked.label_0          : string = "first_drift_cell"
+stacked.model_1          : string = "tracker_layer_front_l0_055.model"
+stacked.label_1          : string = "other_drift_cells_below"
+stacked.model_2          : string = "drift_cell_node_013_miss01.model"
+stacked.label_2          : string = "missing_cathode_cell"
+stacked.model_3          : string = "tracker_layer_front_l0_056.model"
+stacked.label_3          : string = "other_drift_cells_above"
+
+material.ref             : string = "tracking_gas"
+
+visibility.hidden_envelope  : boolean = true
+# visibility.daughters.hidden : boolean = false
+visibility.color            : string = "grey"
+
+# Daughters mapping informations:
+mapping.daughter_id.first_drift_cell : string = "[drift_cell:row=0]"
+mapping.daughter_id.missing_cathode_cell : string = "[drift_cell:row=56]"
+
+
+
+
+# end of @falaise:config/snemo/demonstrator/geometry/4.0/models/tracker_module/tracker_layers_missing_wires.geom

--- a/resources/config/snemo/demonstrator/geometry/4.0/models/tracker_modules/tracker_layers_missing_wires.geom
+++ b/resources/config/snemo/demonstrator/geometry/4.0/models/tracker_modules/tracker_layers_missing_wires.geom
@@ -16,6 +16,7 @@
 #
 #
 # The following cases were not diligently noted during cell insertion, and will need to be determined later:
+# SNCM 047 - field (somewhere?)
 # SNCM 070 - field (cell 15 somewhere?)
 # SNCM 073 - field (somewhere?)
 # SNCM 075 - field (somewhere?)

--- a/resources/config/snemo/demonstrator/geometry/4.0/models/tracker_modules/tracker_volumes.geom
+++ b/resources/config/snemo/demonstrator/geometry/4.0/models/tracker_modules/tracker_volumes.geom
@@ -1,6 +1,10 @@
 # -*- mode: conf-unix; -*-
 # @falaise:config/snemo/demonstrator/geometry/4.0/models/tracker_module/tracker_volumes.geom
 
+#
+# Pawel Guzowski 05 May 2013: Converted to "missing wires" models
+#
+
 
 ###################################################################
 #
@@ -45,7 +49,8 @@ stacked.number_of_items : integer = 11
 stacked.model_0    : string  = "tracker_gap_source.model"
 stacked.label_0    : string  = "source_gap"
 
-stacked.model_1    : string  = "tracker_layer_closing.model"
+#stacked.model_1    : string  = "tracker_layer_closing.model"
+stacked.model_1    : string  = "tracker_layer_front_l0.model"
 stacked.label_1    : string  = "layer_0"
 
 stacked.model_2    : string  = "tracker_layer.model"
@@ -57,7 +62,8 @@ stacked.label_3    : string  = "layer_2"
 stacked.model_4    : string  = "tracker_layer.model"
 stacked.label_4    : string  = "layer_3"
 
-stacked.model_5    : string  = "tracker_layer.model"
+#stacked.model_5    : string  = "tracker_layer.model"
+stacked.model_5    : string  = "tracker_layer_front_l4.model"
 stacked.label_5    : string  = "layer_4"
 
 stacked.model_6    : string  = "tracker_layer.model"
@@ -69,7 +75,8 @@ stacked.label_7    : string  = "layer_6"
 stacked.model_8    : string  = "tracker_layer.model"
 stacked.label_8    : string  = "layer_7"
 
-stacked.model_9    : string  = "tracker_layer.model"
+#stacked.model_9    : string  = "tracker_layer.model"
+stacked.model_9    : string  = "tracker_layer_front_l8.model"
 stacked.label_9    : string  = "layer_8"
 
 stacked.model_10   : string  = "tracker_gap_calo.model"
@@ -145,13 +152,15 @@ stacked.label_2    : string  = "layer_7"
 stacked.model_3    : string  = "tracker_layer.model"
 stacked.label_3    : string  = "layer_6"
 
-stacked.model_4    : string  = "tracker_layer.model"
+#stacked.model_4    : string  = "tracker_layer.model"
+stacked.model_4    : string  = "tracker_layer_back_l5.model"
 stacked.label_4    : string  = "layer_5"
 
 stacked.model_5    : string  = "tracker_layer.model"
 stacked.label_5    : string  = "layer_4"
 
-stacked.model_6    : string  = "tracker_layer.model"
+#stacked.model_6    : string  = "tracker_layer.model"
+stacked.model_6    : string  = "tracker_layer_back_l3.model"
 stacked.label_6    : string  = "layer_3"
 
 stacked.model_7    : string  = "tracker_layer.model"


### PR DESCRIPTION
Added two new geometry model files (missing_wires & tracker_layer_missing_wires) that hard-code some missing anode & field wires.