### PR TITLE
Break case statements

### DIFF
--- a/source/falaise/resource.cc.in
+++ b/source/falaise/resource.cc.in
@@ -68,14 +68,19 @@ namespace {
     switch (err) {
     case BR_INIT_ERROR_NOMEM:
       errMsg = "Unable to open /proc/self/maps";
+      break;
     case BR_INIT_ERROR_OPEN_MAPS:
       errMsg =  "Unable to read from /proc/self/maps";
+      break;
     case BR_INIT_ERROR_READ_MAPS:
       errMsg = "The file format of /proc/self/maps";
+      break;
     case BR_INIT_ERROR_INVALID_MAPS:
       errMsg = "The file format of /proc/self/maps is invalid";
+      break;
     case BR_INIT_ERROR_DISABLED:
       errMsg = "Binary relocation disabled";
+      break;
     default:
       BOOST_ASSERT_MSG(1,"Invalid BrInitError");
     }


### PR DESCRIPTION
```g++``` version 7.X compiler complains that case instructions can continue to the next one. Fixed by adding break commands.