### PR TITLE
Add event header bank in flsimulate output

### DIFF
--- a/documentation/flsimulate/FLSimulateOutput.md
+++ b/documentation/flsimulate/FLSimulateOutput.md
@@ -8,33 +8,45 @@ Introduction to the FLSimulate Output {#flsimulateoutput_introduction}
 
 The  current official  simulation application  defines an  output data
 model  to  represent  the detector  response  (SuperNEMO  demonstrator
-module...).  Each *simulated* event  record is implemented through the
-generic `datatools::things`  container object that handle  a dedicated
-data bank which is conventionaly  named `SD` (for **S** imulated **D**
-ata).
+module...).  Each simulated event  record is implemented using the
+`datatools::things`  container object to stor dedicated data banks:
 
-In  the  future, the  simulation  application  will also  support  the
-creation of  the *digitization  data* `SDD` bank  (**S**imulated **D**
-igitization **D** ata).
+- `EH`: **Event Header**, containing generic information such as
+   run number, event number and how the data was produced (Monte Carlo
+   or real detector)
+- `SD`: **Simulated Data**, containing output of the simulation such
+  as hits.
+- `SDD`: **Simulated Digitized Data**, containing simulated electronic signals (TODO)
 
-Here  we describe  the  contents of  the data  model  produced by  the
+Each bank maps to a C++ object that stores data, so the event record may be visualized as a basic mapping:
+
+~~~~
++- Event N (datatools::things)
+   +- EH (string) -> snemo::datamodel:event_header (C++ object)
+   +- SD (string) -> mctools::simulated_data (C++ object)
+~~~~
+
+Here  we describe  the C++ objects comprising the data  model  produced by  the
 SuperNEMO Monte-Carlo program.
 
-~~~~~
-+----------------------------------+
-| Event record (datatools::things) |
-+----------------------------------+
-          |
-        +----+
-        | SD |----- {this is a bank}
-        +----+
-         /
-        /
-+------+------+
-| Monte-Carlo |
-|   output    |
-+-------------+
-~~~~~
+The EH Bank {#flsimulateoutput_theehbank}
+===========
+
+The `EH` bank stores an instance of the `snemo::datamodel::event_header`
+class. This is a simple Plain-Old-Data object that holds event metadata,
+including:
+
+- Run number
+- Event number
+- How produced (Simulation or Physical Detector)
+- Timestamp
+- User defined attributes
+
+In the simulation output, both the timestamp and attributes member are empty,
+and are retained for compatibility with real data.
+
+See the `snemo::datamodel::event_header` API guide for further information
+on using this class.
 
 The geometry identifier concept {#flsimulateoutput_thegeometryidentifierconcept}
 ===============================

--- a/source/flsimulate/flsimulatemain.cc
+++ b/source/flsimulate/flsimulatemain.cc
@@ -70,6 +70,7 @@
 #include "falaise/resource.h"
 #include "falaise/snemo/processing/services.h"
 #include "falaise/snemo/datamodels/data_model.h"
+#include "falaise/snemo/datamodels/event_header.h"
 
 #include "FLSimulateArgs.h"
 // #include "FLSimulateCommandLine.h"
@@ -357,6 +358,14 @@ namespace FLSimulate {
 
       for (unsigned int i(0); i < flSimParameters.numberOfEvents; ++i) {
         workItem.clear();
+
+        // Add the event header bank
+        auto& eventHeader = workItem.add<snemo::datamodel::event_header>(
+            snemo::datamodel::data_info::default_event_header_label(),
+            "Event Header Bank");
+        eventHeader.set_generation(snemo::datamodel::event_header::GENERATION_SIMULATED);
+        datatools::event_id eventID {datatools::event_id::ANY_RUN_NUMBER, static_cast<int>(i)};
+        eventHeader.set_id(eventID);
 
         status = flSimModule.process(workItem);
         if (status != dpp::base_module::PROCESS_OK) {


### PR DESCRIPTION
Addresses issue identified in #35, where an "EH" event header bank is required to do cuts based selection of event numbers.

It simply adds the bank to each event in flsimulate for propagation downstream to flvisualize and flreconstruct.