### PR TITLE
Use 3.0 containers for test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,13 @@ matrix:
     - os: linux
       services: docker
       env:
-        - DOCKER_IMAGE=supernemo/falaise-ubuntu1604-base
+        - DOCKER_IMAGE=supernemo/falaise-ubuntu1604-base:latest
         - DOCKER_CONTAINER=falaise-docker
         - SCRIPT_PREFIX_CMD="docker exec $DOCKER_CONTAINER"
     - os: linux
       services: docker
       env:
-        - DOCKER_IMAGE=supernemo/falaise-centos6-base
+        - DOCKER_IMAGE=supernemo/falaise-centos6-base:latest
         - DOCKER_CONTAINER=falaise-docker
         - SCRIPT_PREFIX_CMD="docker exec $DOCKER_CONTAINER"
     - os: osx


### PR DESCRIPTION
Update to Falaise 3.1 introduced new containers. Running on Travis
showed a testing error in tests for FECOM.

To clarify origin of this error, explicitly use older 3.0 version
of containers. If builds pass, it shows that the newer system/brewed
packages in the container are responsible.

This PR is not intended for merging - it is just to trigger a Travis build using the old container explicitly.