### PR TITLE
Clang format fixes

### DIFF
--- a/modules/EventBrowser/source/browser_tracks.cc
+++ b/modules/EventBrowser/source/browser_tracks.cc
@@ -60,623 +60,1263 @@
 
 ClassImp(snemo::visualization::view::browser_tracks);
 
-    namespace snemo {
-  namespace visualization {
+namespace snemo {
+namespace visualization {
 
-  namespace view {
+namespace view {
 
-  class TGListTreeItemStdPlus : public TGListTreeItemStd {
-   public:
-    TGListTreeItemStdPlus(const char *name_ = 0, browser_tracks *bt_ = 0,
-                          const TGPicture *open_pic_ = 0, const TGPicture *close_pic_ = 0,
-                          const bool checked_ = false);
-    virtual ~TGListTreeItemStdPlus();
+class TGListTreeItemStdPlus : public TGListTreeItemStd {
+ public:
+  TGListTreeItemStdPlus(const char *name_ = 0, browser_tracks *bt_ = 0,
+                        const TGPicture *open_pic_ = 0, const TGPicture *close_pic_ = 0,
+                        const bool checked_ = false);
+  virtual ~TGListTreeItemStdPlus();
 
-    virtual void CheckChildren(TGListTreeItem *item, Bool_t state);
+  virtual void CheckChildren(TGListTreeItem *item, Bool_t state);
 
-   private:
-    browser_tracks *fBrowser;
-  };
+ private:
+  browser_tracks *fBrowser;
+};
 
-  TGListTreeItemStdPlus::TGListTreeItemStdPlus(const char *name_, browser_tracks *bt_,
-                                               const TGPicture *open_pic_,
-                                               const TGPicture *close_pic_, const bool checked_)
-      : TGListTreeItemStd(gClient, name_, open_pic_, close_pic_, checked_), fBrowser(bt_) {
-    return;
-  }
+TGListTreeItemStdPlus::TGListTreeItemStdPlus(const char *name_, browser_tracks *bt_,
+                                             const TGPicture *open_pic_,
+                                             const TGPicture *close_pic_, const bool checked_)
+    : TGListTreeItemStd(gClient, name_, open_pic_, close_pic_, checked_), fBrowser(bt_) {
+  return;
+}
 
-  TGListTreeItemStdPlus::~TGListTreeItemStdPlus() { return; }
+TGListTreeItemStdPlus::~TGListTreeItemStdPlus() { return; }
 
-  void TGListTreeItemStdPlus::CheckChildren(TGListTreeItem *item, Bool_t state) {
-    // Code a bit hacked from default TGListTreeItemStd in order
-    // to only check 'default' trajectory and not everything
-    if (!item) return;
+void TGListTreeItemStdPlus::CheckChildren(TGListTreeItem *item, Bool_t state) {
+  // Code a bit hacked from default TGListTreeItemStd in order
+  // to only check 'default' trajectory and not everything
+  if (!item) return;
 
-    while (item) {
-      if (state) {
-        if (!item->IsChecked()) {
-          const int id = (intptr_t)item->GetUserData();
-          // Check item only if 'default' key is active
-          if (id < 0 && fBrowser) {
-            // Search in which dictionnary the item comes from:
-            datatools::properties *properties = fBrowser->get_item_properties(id);
+  while (item) {
+    if (state) {
+      if (!item->IsChecked()) {
+        const int id = (intptr_t)item->GetUserData();
+        // Check item only if 'default' key is active
+        if (id < 0 && fBrowser) {
+          // Search in which dictionnary the item comes from:
+          datatools::properties *properties = fBrowser->get_item_properties(id);
 
-            if (properties->has_flag("default"))
-              item->CheckItem(true);
-            else
-              properties->update(browser_tracks::CHECKED_FLAG, false);
-          } else {
-            item->CheckItem();
-          }
+          if (properties->has_flag("default"))
+            item->CheckItem(true);
+          else
+            properties->update(browser_tracks::CHECKED_FLAG, false);
+        } else {
+          item->CheckItem();
         }
-      } else {
-        if (item->IsChecked()) item->Toggle();
       }
-      if (item->GetFirstChild()) {
-        CheckChildren(item->GetFirstChild(), state);
-      }
-      item->UpdateState();
-      item = item->GetNextSibling();
+    } else {
+      if (item->IsChecked()) item->Toggle();
     }
-
-    return;
-  }
-
-  //______________________________________________________________________________
-
-  const std::string browser_tracks::CHECKED_FLAG = "snvisu.check_flag";
-  const std::string browser_tracks::COLOR_FLAG = "snvisu.color_flag";
-  const std::string browser_tracks::HIGHLIGHT_FLAG = "snvisu.highlight_flag";
-
-  bool browser_tracks::is_initialized() const { return _initialized_; }
-
-  // ctor:
-  browser_tracks::browser_tracks(TGCompositeFrame *main_, io::event_server *server_) {
-    _initialized_ = false;
-    _server_ = server_;
-    _browser_ = 0;
-    _main_ = 0;
-    this->_at_init_(main_);
-    return;
-  }
-
-  // dtor:
-  browser_tracks::~browser_tracks() {
-    this->reset();
-
-    for (std::map<std::string, const TGPicture *>::iterator i_pict = _icons_.begin();
-         i_pict != _icons_.end(); ++i_pict)
-      delete _icons_[i_pict->first];
-
-    delete _tracks_list_box_;
-
-    _main_->Cleanup();
-    return;
-  }
-
-  void browser_tracks::initialize(TGCompositeFrame *main_) {
-    this->_at_init_(main_);
-    _initialized_ = true;
-    return;
-  }
-
-  void browser_tracks::_at_init_(TGCompositeFrame *main_) {
-    // Keep track of main frame in order to regenerate it for
-    // different detector setup
-    _main_ = main_;
-    _main_->SetCleanup(kDeepCleanup);
-
-    // event browser frame : this sucks but this is needed to
-    // connect button with action. In order to instantiate
-    // properly the number of parent, one has to count how many
-    // frames have been instantiated until here
-    TGCompositeFrame *parent = (TGCompositeFrame *)_main_->GetParent()
-                                   ->GetParent()
-                                   ->GetParent()
-                                   ->GetParent()
-                                   ->GetParent()
-                                   ->GetParent();
-
-    _browser_ = dynamic_cast<event_browser *>(parent);
-    DT_THROW_IF(!_browser_, std::logic_error, "Event_browser can't be cast from frame!");
-
-    this->_at_construct_();
-    return;
-  }
-
-  void browser_tracks::_at_construct_() {
-    const int width = _main_->GetWidth();
-    const int height = _main_->GetHeight();
-
-    TGCanvas *canvas = new TGCanvas(_main_, width, height);
-    _tracks_list_box_ = new TGListTree(canvas, kHorizontalFrame);
-
-    _main_->AddFrame(canvas, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY | kLHintsBottom));
-
-    _tracks_list_box_->Connect("Checked(TObject *,Bool_t)",
-                               "snemo::visualization::view::browser_tracks", this,
-                               "item_checked(TObject *,bool)");
-
-    _tracks_list_box_->Connect("DoubleClicked(TGListTreeItem *,Int_t)",
-                               "snemo::visualization::view::browser_tracks", this,
-                               "item_selected(TGListTreeItem *,int)");
-
-    return;
-  }
-
-  void browser_tracks::clear() {
-    for (std::vector<TGListTreeItem *>::iterator item = _item_list_.begin();
-         item != _item_list_.end(); ++item)
-      _tracks_list_box_->DeleteItem(*item);
-
-    _item_list_.clear();
-
-    _item_id_ = 0;
-    _properties_dictionnary_.clear();
-    _base_hit_dictionnary_.clear();
-
-    return;
-  }
-
-  void browser_tracks::reset() {
-    this->clear();
-    return;
-  }
-
-  void browser_tracks::update() {
-    this->clear();
-
-    if (!_server_->is_initialized()) {
-      DT_LOG_WARNING(options_manager::get_instance().get_logging_priority(),
-                     "Event server has not been initialized !");
-      return;
+    if (item->GetFirstChild()) {
+      CheckChildren(item->GetFirstChild(), state);
     }
+    item->UpdateState();
+    item = item->GetNextSibling();
+  }
 
-    this->_update_event_header();
-    this->_update_simulated_data();
-    this->_update_calibrated_data();
-    this->_update_tracker_clustering_data();
-    this->_update_tracker_trajectory_data();
-    this->_update_particle_track_data();
+  return;
+}
 
-    _tracks_list_box_->MapSubwindows();
-    _main_->GetClient()->NeedRedraw(_tracks_list_box_);
+//______________________________________________________________________________
 
+const std::string browser_tracks::CHECKED_FLAG = "snvisu.check_flag";
+const std::string browser_tracks::COLOR_FLAG = "snvisu.color_flag";
+const std::string browser_tracks::HIGHLIGHT_FLAG = "snvisu.highlight_flag";
+
+bool browser_tracks::is_initialized() const { return _initialized_; }
+
+// ctor:
+browser_tracks::browser_tracks(TGCompositeFrame *main_, io::event_server *server_) {
+  _initialized_ = false;
+  _server_ = server_;
+  _browser_ = 0;
+  _main_ = 0;
+  this->_at_init_(main_);
+  return;
+}
+
+// dtor:
+browser_tracks::~browser_tracks() {
+  this->reset();
+
+  for (std::map<std::string, const TGPicture *>::iterator i_pict = _icons_.begin();
+       i_pict != _icons_.end(); ++i_pict)
+    delete _icons_[i_pict->first];
+
+  delete _tracks_list_box_;
+
+  _main_->Cleanup();
+  return;
+}
+
+void browser_tracks::initialize(TGCompositeFrame *main_) {
+  this->_at_init_(main_);
+  _initialized_ = true;
+  return;
+}
+
+void browser_tracks::_at_init_(TGCompositeFrame *main_) {
+  // Keep track of main frame in order to regenerate it for
+  // different detector setup
+  _main_ = main_;
+  _main_->SetCleanup(kDeepCleanup);
+
+  // event browser frame : this sucks but this is needed to
+  // connect button with action. In order to instantiate
+  // properly the number of parent, one has to count how many
+  // frames have been instantiated until here
+  TGCompositeFrame *parent = (TGCompositeFrame *)_main_->GetParent()
+                                 ->GetParent()
+                                 ->GetParent()
+                                 ->GetParent()
+                                 ->GetParent()
+                                 ->GetParent();
+
+  _browser_ = dynamic_cast<event_browser *>(parent);
+  DT_THROW_IF(!_browser_, std::logic_error, "Event_browser can't be cast from frame!");
+
+  this->_at_construct_();
+  return;
+}
+
+void browser_tracks::_at_construct_() {
+  const int width = _main_->GetWidth();
+  const int height = _main_->GetHeight();
+
+  TGCanvas *canvas = new TGCanvas(_main_, width, height);
+  _tracks_list_box_ = new TGListTree(canvas, kHorizontalFrame);
+
+  _main_->AddFrame(canvas, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY | kLHintsBottom));
+
+  _tracks_list_box_->Connect("Checked(TObject *,Bool_t)",
+                             "snemo::visualization::view::browser_tracks", this,
+                             "item_checked(TObject *,bool)");
+
+  _tracks_list_box_->Connect("DoubleClicked(TGListTreeItem *,Int_t)",
+                             "snemo::visualization::view::browser_tracks", this,
+                             "item_selected(TGListTreeItem *,int)");
+
+  return;
+}
+
+void browser_tracks::clear() {
+  for (std::vector<TGListTreeItem *>::iterator item = _item_list_.begin();
+       item != _item_list_.end(); ++item)
+    _tracks_list_box_->DeleteItem(*item);
+
+  _item_list_.clear();
+
+  _item_id_ = 0;
+  _properties_dictionnary_.clear();
+  _base_hit_dictionnary_.clear();
+
+  return;
+}
+
+void browser_tracks::reset() {
+  this->clear();
+  return;
+}
+
+void browser_tracks::update() {
+  this->clear();
+
+  if (!_server_->is_initialized()) {
+    DT_LOG_WARNING(options_manager::get_instance().get_logging_priority(),
+                   "Event server has not been initialized !");
     return;
   }
 
-  void browser_tracks::_update_event_header() {
-    // Grab event and other resources. Here nothing is constant
-    // since properties will be modified here and used later
-    // through 'checking' and 'double_clicking' actions:
-    const io::event_record &event = _server_->grab_event();
+  this->_update_event_header();
+  this->_update_simulated_data();
+  this->_update_calibrated_data();
+  this->_update_tracker_clustering_data();
+  this->_update_tracker_trajectory_data();
+  this->_update_particle_track_data();
 
-    std::ostringstream label;
+  _tracks_list_box_->MapSubwindows();
+  _main_->GetClient()->NeedRedraw(_tracks_list_box_);
+
+  return;
+}
+
+void browser_tracks::_update_event_header() {
+  // Grab event and other resources. Here nothing is constant
+  // since properties will be modified here and used later
+  // through 'checking' and 'double_clicking' actions:
+  const io::event_record &event = _server_->grab_event();
+
+  std::ostringstream label;
+  std::ostringstream tip_text;
+
+  // 'event_header' availability:
+  if (!event.has(io::EH_LABEL)) {
+    label << "Event #" << _server_->get_current_event_number();
+  } else {
+    const snemo::datamodel::event_header &eh =
+        event.get<snemo::datamodel::event_header>(io::EH_LABEL);
+
+    label << "Run #" << eh.get_id().get_run_number() << " - "
+          << "Event #" << eh.get_id().get_event_number();
+    if (options_manager::get_instance().get_option_flag(DUMP_INTO_TOOLTIP)) {
+      // Here we use the event_server dump method since it
+      // gives much more info on the event record
+      eh.tree_dump(tip_text);
+      //_server_->dump_event(tip_text);
+    }
+  }
+
+  // Add 'event_header' information as top item:
+  _top_item_ = _tracks_list_box_->AddItem(0, label.str().c_str(), _get_colored_icon_("ofolder"),
+                                          _get_colored_icon_("folder"));
+  _item_list_.push_back(_top_item_);
+  _top_item_->SetCheckBox(false);
+  _top_item_->SetUserData((void *)(intptr_t)++_item_id_);
+  if (!tip_text.str().empty()) {
+    _top_item_->SetTipText(tip_text.str().c_str());
+  } else {
+    _top_item_->SetTipText("Double click to expand event record");
+  }
+  _tracks_list_box_->OpenItem(_top_item_);
+  return;
+}
+
+void browser_tracks::_update_simulated_data() {
+  const options_manager &options_mgr = options_manager::get_instance();
+
+  // Grab event and other resources. Here nothing is constant
+  // since properties will be modified here and used later
+  // through 'checking' and 'double_clicking' actions:
+  io::event_record &event = _server_->grab_event();
+
+  // 'simulated_data' availability:
+  if (!event.has(io::SD_LABEL)) return;
+
+  mctools::simulated_data &sd = event.grab<mctools::simulated_data>(io::SD_LABEL);
+
+  if (!options_mgr.get_option_flag(SHOW_MC_VERTEX) && !options_mgr.get_option_flag(SHOW_MC_HITS))
+    return;
+
+  // Add 'simulated_data' folder as sub item:
+  const std::string data_bank_name = "Simulated data (" + io::SD_LABEL + ")";
+  TGListTreeItem *item_simulated_data =
+      _tracks_list_box_->AddItem(_top_item_, data_bank_name.c_str(), _get_colored_icon_("ofolder"),
+                                 _get_colored_icon_("folder"));
+  _tracks_list_box_->OpenItem(item_simulated_data);
+  item_simulated_data->SetCheckBox(false);
+  item_simulated_data->SetUserData((void *)(intptr_t)++_item_id_);
+
+  if (options_mgr.get_option_flag(DUMP_INTO_TOOLTIP)) {
     std::ostringstream tip_text;
-
-    // 'event_header' availability:
-    if (!event.has(io::EH_LABEL)) {
-      label << "Event #" << _server_->get_current_event_number();
-    } else {
-      const snemo::datamodel::event_header &eh =
-          event.get<snemo::datamodel::event_header>(io::EH_LABEL);
-
-      label << "Run #" << eh.get_id().get_run_number() << " - "
-            << "Event #" << eh.get_id().get_event_number();
-      if (options_manager::get_instance().get_option_flag(DUMP_INTO_TOOLTIP)) {
-        // Here we use the event_server dump method since it
-        // gives much more info on the event record
-        eh.tree_dump(tip_text);
-        //_server_->dump_event(tip_text);
-      }
-    }
-
-    // Add 'event_header' information as top item:
-    _top_item_ = _tracks_list_box_->AddItem(0, label.str().c_str(), _get_colored_icon_("ofolder"),
-                                            _get_colored_icon_("folder"));
-    _item_list_.push_back(_top_item_);
-    _top_item_->SetCheckBox(false);
-    _top_item_->SetUserData((void *)(intptr_t)++_item_id_);
-    if (!tip_text.str().empty()) {
-      _top_item_->SetTipText(tip_text.str().c_str());
-    } else {
-      _top_item_->SetTipText("Double click to expand event record");
-    }
-    _tracks_list_box_->OpenItem(_top_item_);
-    return;
+    sd.tree_dump(tip_text);
+    item_simulated_data->SetTipText(tip_text.str().c_str());
+  } else {
+    item_simulated_data->SetTipText("Double click to expand simulated data");
   }
 
-  void browser_tracks::_update_simulated_data() {
-    const options_manager &options_mgr = options_manager::get_instance();
+  // Item id for 'properties' dictionnary:
+  int &icheck_id = _item_id_;
 
-    // Grab event and other resources. Here nothing is constant
-    // since properties will be modified here and used later
-    // through 'checking' and 'double_clicking' actions:
-    io::event_record &event = _server_->grab_event();
+  // Add a folder relative to primary event info.
+  if (options_mgr.get_option_flag(SHOW_MC_VERTEX)) {
+    mctools::simulated_data::primary_event_type &pevent = sd.grab_primary_event();
+    const std::string &a_label = pevent.get_label();
+    TGListTreeItem *item_primary_event = _tracks_list_box_->AddItem(
+        item_simulated_data,
+        std::string("Primary particles" + (!a_label.empty() ? " - " + a_label : "")).c_str(),
+        _get_colored_icon_("ofolder"), _get_colored_icon_("folder"));
+    _tracks_list_box_->OpenItem(item_primary_event);
+    item_primary_event->SetCheckBox(false);
+    item_primary_event->SetUserData((void *)(intptr_t)++icheck_id);
 
-    // 'simulated_data' availability:
-    if (!event.has(io::SD_LABEL)) return;
+    genbb::primary_event::particles_col_type &particles = pevent.grab_particles();
 
-    mctools::simulated_data &sd = event.grab<mctools::simulated_data>(io::SD_LABEL);
+    for (genbb::primary_event::particles_col_type::iterator ip = particles.begin();
+         ip != particles.end(); ++ip) {
+      std::ostringstream label;
+      label.precision(3);
+      label.setf(std::ios::fixed, std::ios::floatfield);
+      label << ip->get_particle_label() << " particle: E = ";
+      utils::root_utilities::get_prettified_energy(label, ip->get_kinetic_energy());
+      label << ", t = ";
+      utils::root_utilities::get_prettified_time(label, ip->get_time());
+      label << " - (px, py, pz) = " << ip->get_momentum() / CLHEP::MeV << " MeV, "
+            << "(x, y, z) = ";
+      if (sd.has_vertex()) {
+        label << sd.get_vertex() / CLHEP::mm << " mm";
+      } else {
+        label << "no vertex position";
+      }
 
-    if (!options_mgr.get_option_flag(SHOW_MC_VERTEX) && !options_mgr.get_option_flag(SHOW_MC_HITS))
-      return;
-
-    // Add 'simulated_data' folder as sub item:
-    const std::string data_bank_name = "Simulated data (" + io::SD_LABEL + ")";
-    TGListTreeItem *item_simulated_data =
-        _tracks_list_box_->AddItem(_top_item_, data_bank_name.c_str(),
-                                   _get_colored_icon_("ofolder"), _get_colored_icon_("folder"));
-    _tracks_list_box_->OpenItem(item_simulated_data);
-    item_simulated_data->SetCheckBox(false);
-    item_simulated_data->SetUserData((void *)(intptr_t)++_item_id_);
-
-    if (options_mgr.get_option_flag(DUMP_INTO_TOOLTIP)) {
+      const std::string hex_str = utils::root_utilities::get_hex_color(kViolet);
+      TGListTreeItem *item_particle = _tracks_list_box_->AddItem(
+          item_primary_event, label.str().c_str(), _get_colored_icon_("vertex", hex_str, true),
+          _get_colored_icon_("vertex", hex_str));
+      item_particle->SetCheckBox(ip->has_generation_id());
+      item_particle->SetUserData((void *)(intptr_t) - (++icheck_id));
+      // _properties_dictionnary_[-icheck_id] = &(pevent.grab_auxiliaries());
+      _properties_dictionnary_[-icheck_id] = &(ip->grab_auxiliaries());
       std::ostringstream tip_text;
-      sd.tree_dump(tip_text);
-      item_simulated_data->SetTipText(tip_text.str().c_str());
-    } else {
-      item_simulated_data->SetTipText("Double click to expand simulated data");
-    }
-
-    // Item id for 'properties' dictionnary:
-    int &icheck_id = _item_id_;
-
-    // Add a folder relative to primary event info.
-    if (options_mgr.get_option_flag(SHOW_MC_VERTEX)) {
-      mctools::simulated_data::primary_event_type &pevent = sd.grab_primary_event();
-      const std::string &a_label = pevent.get_label();
-      TGListTreeItem *item_primary_event = _tracks_list_box_->AddItem(
-          item_simulated_data,
-          std::string("Primary particles" + (!a_label.empty() ? " - " + a_label : "")).c_str(),
-          _get_colored_icon_("ofolder"), _get_colored_icon_("folder"));
-      _tracks_list_box_->OpenItem(item_primary_event);
-      item_primary_event->SetCheckBox(false);
-      item_primary_event->SetUserData((void *)(intptr_t)++icheck_id);
-
-      genbb::primary_event::particles_col_type &particles = pevent.grab_particles();
-
-      for (genbb::primary_event::particles_col_type::iterator ip = particles.begin();
-           ip != particles.end(); ++ip) {
-        std::ostringstream label;
-        label.precision(3);
-        label.setf(std::ios::fixed, std::ios::floatfield);
-        label << ip->get_particle_label() << " particle: E = ";
-        utils::root_utilities::get_prettified_energy(label, ip->get_kinetic_energy());
-        label << ", t = ";
-        utils::root_utilities::get_prettified_time(label, ip->get_time());
-        label << " - (px, py, pz) = " << ip->get_momentum() / CLHEP::MeV << " MeV, "
-              << "(x, y, z) = ";
-        if (sd.has_vertex()) {
-          label << sd.get_vertex() / CLHEP::mm << " mm";
-        } else {
-          label << "no vertex position";
-        }
-
-        const std::string hex_str = utils::root_utilities::get_hex_color(kViolet);
-        TGListTreeItem *item_particle = _tracks_list_box_->AddItem(
-            item_primary_event, label.str().c_str(), _get_colored_icon_("vertex", hex_str, true),
-            _get_colored_icon_("vertex", hex_str));
-        item_particle->SetCheckBox(ip->has_generation_id());
-        item_particle->SetUserData((void *)(intptr_t) - (++icheck_id));
-        // _properties_dictionnary_[-icheck_id] = &(pevent.grab_auxiliaries());
-        _properties_dictionnary_[-icheck_id] = &(ip->grab_auxiliaries());
-        std::ostringstream tip_text;
-        if (options_mgr.get_option_flag(DUMP_INTO_TOOLTIP)) {
-          ip->tree_dump(tip_text);
-        } else {
-          tip_text << "Double click to highlight track "
-                   << "and to dump info on terminal";
-        }
-        item_particle->SetTipText(tip_text.str().c_str());
+      if (options_mgr.get_option_flag(DUMP_INTO_TOOLTIP)) {
+        ip->tree_dump(tip_text);
+      } else {
+        tip_text << "Double click to highlight track "
+                 << "and to dump info on terminal";
       }
+      item_particle->SetTipText(tip_text.str().c_str());
     }
+  }
 
-    // Add MC step hits information:
-    if (options_mgr.get_option_flag(SHOW_MC_TRACKS)) {
-      // Get hit categories related to visual track
-      std::vector<std::string> visual_categories;
-      sd.get_step_hits_categories(
-          visual_categories, mctools::simulated_data::HIT_CATEGORY_TYPE_PREFIX, "__visu.tracks");
-      typedef std::pair<size_t, TGListTreeItem *> entry_type;
-      std::map<int, entry_type> item_tracks;
-      if (!visual_categories.empty()) {
-        TGListTreeItem *item_mc_tracks =
-            _tracks_list_box_->AddItem(item_simulated_data, "Simulated tracks",
-                                       _get_colored_icon_("ofolder"), _get_colored_icon_("folder"));
-        item_mc_tracks->SetCheckBox(false);
-        item_mc_tracks->SetUserData((void *)(intptr_t)++icheck_id);
+  // Add MC step hits information:
+  if (options_mgr.get_option_flag(SHOW_MC_TRACKS)) {
+    // Get hit categories related to visual track
+    std::vector<std::string> visual_categories;
+    sd.get_step_hits_categories(visual_categories,
+                                mctools::simulated_data::HIT_CATEGORY_TYPE_PREFIX, "__visu.tracks");
+    typedef std::pair<size_t, TGListTreeItem *> entry_type;
+    std::map<int, entry_type> item_tracks;
+    if (!visual_categories.empty()) {
+      TGListTreeItem *item_mc_tracks =
+          _tracks_list_box_->AddItem(item_simulated_data, "Simulated tracks",
+                                     _get_colored_icon_("ofolder"), _get_colored_icon_("folder"));
+      item_mc_tracks->SetCheckBox(false);
+      item_mc_tracks->SetUserData((void *)(intptr_t)++icheck_id);
 
-        TGListTreeItem *item_mc_highlight_step_hits =
-            _tracks_list_box_->AddItem(item_simulated_data, "Highlighted simulated step hits",
-                                       _get_colored_icon_("ofolder"), _get_colored_icon_("folder"));
-        item_mc_highlight_step_hits->SetCheckBox(false);
-        item_mc_highlight_step_hits->SetUserData((void *)(intptr_t)++icheck_id);
-        for (size_t icat = 0; icat < visual_categories.size(); ++icat) {
-          const std::string &category = visual_categories[icat];
-          if (sd.has_step_hits(category)) {
-            mctools::simulated_data::hit_handle_collection_type &hit_collection =
-                sd.grab_step_hits(category);
-            for (mctools::simulated_data::hit_handle_collection_type::iterator it_hit =
-                     hit_collection.begin();
-                 it_hit != hit_collection.end(); ++it_hit) {
-              mctools::base_step_hit &a_step = it_hit->grab();
-              datatools::properties &a_auxiliaries = a_step.grab_auxiliaries();
-
-              std::string name = a_step.get_particle_name();
-              if (name == "e-") name = "electron";
-              if (name == "e+") name = "positron";
-              const size_t color = style_manager::get_instance().get_particle_color(name);
-              const std::string hex_str = utils::root_utilities::get_hex_color(color);
-              TGListTreeItem *item = 0;
-              if (a_auxiliaries.has_flag(mctools::hit_utils::HIT_VISU_HIGHLIGHTED_KEY)) {
-                item = item_mc_highlight_step_hits;
-              } else {
-                const int a_track_id = a_step.get_track_id();
-                if (!item_tracks.count(a_track_id)) {
-                  std::ostringstream track_label;
-                  track_label.precision(3);
-                  track_label.setf(std::ios::fixed, std::ios::floatfield);
-                  track_label << a_step.get_particle_name() << " track";
-                  if (a_step.is_primary_particle()) track_label << " (primary)";
-                  item = _tracks_list_box_->AddItem(item_mc_tracks, track_label.str().c_str(),
-                                                    _get_colored_icon_("track", hex_str),
-                                                    _get_colored_icon_("track", hex_str));
-                  entry_type a_pair = std::make_pair(1, item);
-                  item_tracks.insert(std::make_pair(a_track_id, a_pair));
-                  item->SetUserData((void *)(intptr_t) - (++icheck_id));
-                  _base_hit_dictionnary_[-icheck_id] = &(a_step);
-                  _properties_dictionnary_[-icheck_id] = &(a_auxiliaries);
-                } else {
-                  entry_type &a_entry = item_tracks[a_track_id];
-                  item = a_entry.second;
-                  a_entry.first++;
-                }
-                item->SetCheckBox(true);
-              }
-
-              // Add subsubitem:
-              std::ostringstream label_hit;
-              label_hit.precision(3);
-              label_hit.setf(std::ios::fixed, std::ios::floatfield);
-              label_hit << "Step #" << a_step.get_hit_id() << " - "
-                        << "particle " << a_step.get_particle_name();
-              if (a_step.get_energy_deposit() > 0.0) {
-                label_hit << " / energy deposit = ";
-                utils::root_utilities::get_prettified_energy(label_hit,
-                                                             a_step.get_energy_deposit());
-              }
-              TGListTreeItem *item_hit = _tracks_list_box_->AddItem(item, label_hit.str().c_str());
-              item_hit->SetUserData((void *)(intptr_t) - (++icheck_id));
-              _base_hit_dictionnary_[-icheck_id] = &(a_step);
-              item_hit->SetPictures(_get_colored_icon_("step", hex_str, true),
-                                    _get_colored_icon_("step", hex_str));
-
-              std::ostringstream tip_text;
-              if (options_mgr.get_option_flag(DUMP_INTO_TOOLTIP)) {
-                a_step.tree_dump(tip_text);
-              } else {
-                tip_text << "Double click to highlight step hit "
-                         << "and to dump info on terminal";
-              }
-              item_hit->SetTipText(tip_text.str().c_str());
-            }
-          }
-        }
-        // Update item text following the number of hits found
-        for (std::map<int, entry_type>::iterator i = item_tracks.begin(); i != item_tracks.end();
-             ++i) {
-          entry_type a_entry = i->second;
-          const size_t count = a_entry.first;
-          TGListTreeItem *item = a_entry.second;
-          std::ostringstream oss;
-          oss << item->GetText();
-          if (count == 0) {
-            oss << " - no hits";
-          } else {
-            oss << " - " << count << " hit";
-            if (count > 1) oss << "s";
-          }
-          item->SetText(oss.str().c_str());
-        }
-        // Update number of tracks
-        std::ostringstream oss;
-        oss << item_mc_tracks->GetText();
-        const size_t count = item_tracks.size();
-        if (count == 0) {
-          oss << " - no tracks";
-        } else {
-          oss << " - " << count << " track";
-          if (count > 1) oss << "s";
-        }
-        item_mc_tracks->SetText(oss.str().c_str());
-      }
-    }
-
-    // Add MC hits information:
-    if (options_mgr.get_option_flag(SHOW_MC_HITS)) {
-      if (options_mgr.get_option_flag(SHOW_MC_CALORIMETER_HITS)) {
-        TGListTreeItem *item_mc_calorimeter =
-            _tracks_list_box_->AddItem(item_simulated_data, "Simulated calorimeter hits",
-                                       _get_colored_icon_("ofolder"), _get_colored_icon_("folder"));
-        item_mc_calorimeter->SetCheckBox(false);
-        item_mc_calorimeter->SetUserData((void *)(intptr_t)++icheck_id);
-
-        // Retrieve all category names except private category such as '__visual.tracks'
-        std::vector<std::string> calo_categories;
-        sd.get_step_hits_categories(calo_categories,
-                                    mctools::simulated_data::HIT_CATEGORY_TYPE_PUBLIC);
-
-        size_t ihit = 0;
-        for (std::vector<std::string>::const_iterator iname = calo_categories.begin();
-             iname != calo_categories.end(); ++iname) {
-          const std::string &a_calo_name = *iname;
-
-          // 2015/07/07 XG: Remove Geiger energy deposit since it is treated
-          // in a particular way
-          if (a_calo_name == "gg") continue;
-
-          if (!sd.has_step_hits(a_calo_name)) continue;
-
+      TGListTreeItem *item_mc_highlight_step_hits =
+          _tracks_list_box_->AddItem(item_simulated_data, "Highlighted simulated step hits",
+                                     _get_colored_icon_("ofolder"), _get_colored_icon_("folder"));
+      item_mc_highlight_step_hits->SetCheckBox(false);
+      item_mc_highlight_step_hits->SetUserData((void *)(intptr_t)++icheck_id);
+      for (size_t icat = 0; icat < visual_categories.size(); ++icat) {
+        const std::string &category = visual_categories[icat];
+        if (sd.has_step_hits(category)) {
           mctools::simulated_data::hit_handle_collection_type &hit_collection =
-              sd.grab_step_hits(a_calo_name);
-          ihit += hit_collection.size();
-
+              sd.grab_step_hits(category);
           for (mctools::simulated_data::hit_handle_collection_type::iterator it_hit =
                    hit_collection.begin();
                it_hit != hit_collection.end(); ++it_hit) {
             mctools::base_step_hit &a_step = it_hit->grab();
+            datatools::properties &a_auxiliaries = a_step.grab_auxiliaries();
 
-            std::string hex_str;
-            if (a_step.get_auxiliaries().has_key(COLOR_FLAG)) {
-              a_step.get_auxiliaries().fetch(COLOR_FLAG, hex_str);
-              // TColor::GetColor (hex_str.c_str());
+            std::string name = a_step.get_particle_name();
+            if (name == "e-") name = "electron";
+            if (name == "e+") name = "positron";
+            const size_t color = style_manager::get_instance().get_particle_color(name);
+            const std::string hex_str = utils::root_utilities::get_hex_color(color);
+            TGListTreeItem *item = 0;
+            if (a_auxiliaries.has_flag(mctools::hit_utils::HIT_VISU_HIGHLIGHTED_KEY)) {
+              item = item_mc_highlight_step_hits;
+            } else {
+              const int a_track_id = a_step.get_track_id();
+              if (!item_tracks.count(a_track_id)) {
+                std::ostringstream track_label;
+                track_label.precision(3);
+                track_label.setf(std::ios::fixed, std::ios::floatfield);
+                track_label << a_step.get_particle_name() << " track";
+                if (a_step.is_primary_particle()) track_label << " (primary)";
+                item = _tracks_list_box_->AddItem(item_mc_tracks, track_label.str().c_str(),
+                                                  _get_colored_icon_("track", hex_str),
+                                                  _get_colored_icon_("track", hex_str));
+                entry_type a_pair = std::make_pair(1, item);
+                item_tracks.insert(std::make_pair(a_track_id, a_pair));
+                item->SetUserData((void *)(intptr_t) - (++icheck_id));
+                _base_hit_dictionnary_[-icheck_id] = &(a_step);
+                _properties_dictionnary_[-icheck_id] = &(a_auxiliaries);
+              } else {
+                entry_type &a_entry = item_tracks[a_track_id];
+                item = a_entry.second;
+                a_entry.first++;
+              }
+              item->SetCheckBox(true);
             }
+
             // Add subsubitem:
             std::ostringstream label_hit;
             label_hit.precision(3);
             label_hit.setf(std::ios::fixed, std::ios::floatfield);
-            label_hit << a_calo_name << " hit #" << a_step.get_hit_id() << " - "
-                      << "Energy deposit = ";
-            utils::root_utilities::get_prettified_energy(label_hit, a_step.get_energy_deposit());
-            label_hit << " - geom_id = " << a_step.get_geom_id();
-
-            TGListTreeItem *item_hit =
-                _tracks_list_box_->AddItem(item_mc_calorimeter, label_hit.str().c_str());
+            label_hit << "Step #" << a_step.get_hit_id() << " - "
+                      << "particle " << a_step.get_particle_name();
+            if (a_step.get_energy_deposit() > 0.0) {
+              label_hit << " / energy deposit = ";
+              utils::root_utilities::get_prettified_energy(label_hit, a_step.get_energy_deposit());
+            }
+            TGListTreeItem *item_hit = _tracks_list_box_->AddItem(item, label_hit.str().c_str());
             item_hit->SetUserData((void *)(intptr_t) - (++icheck_id));
             _base_hit_dictionnary_[-icheck_id] = &(a_step);
-            item_hit->SetPictures(_get_colored_icon_("calorimeter", "", true),
-                                  _get_colored_icon_("calorimeter"));
+            item_hit->SetPictures(_get_colored_icon_("step", hex_str, true),
+                                  _get_colored_icon_("step", hex_str));
 
             std::ostringstream tip_text;
             if (options_mgr.get_option_flag(DUMP_INTO_TOOLTIP)) {
               a_step.tree_dump(tip_text);
             } else {
-              tip_text << "Double click to highlight calorimeter hit "
+              tip_text << "Double click to highlight step hit "
                        << "and to dump info on terminal";
             }
             item_hit->SetTipText(tip_text.str().c_str());
           }
         }
-        // Update item text following the number of hits found
+      }
+      // Update item text following the number of hits found
+      for (std::map<int, entry_type>::iterator i = item_tracks.begin(); i != item_tracks.end();
+           ++i) {
+        entry_type a_entry = i->second;
+        const size_t count = a_entry.first;
+        TGListTreeItem *item = a_entry.second;
         std::ostringstream oss;
-        oss << item_mc_calorimeter->GetText();
-        ihit == 0 ? oss << " - no hits" : oss << " - " << ihit << " hits";
-        item_mc_calorimeter->SetText(oss.str().c_str());
-      }  // end of SHOW_MC_CALORIMETER_HITS
-
-      if (options_mgr.get_option_flag(SHOW_MC_TRACKER_HITS)) {
-        if (sd.has_step_hits("gg")) {
-          TGListTreeItem *item_mc_tracker = _tracks_list_box_->AddItem(
-              item_simulated_data, "Simulated tracker hits", _get_colored_icon_("ofolder"),
-              _get_colored_icon_("folder"));
-          item_mc_tracker->SetCheckBox(false);
-          item_mc_tracker->SetUserData((void *)(intptr_t)++icheck_id);
-
-          mctools::simulated_data::hit_handle_collection_type &hit_collection =
-              sd.grab_step_hits("gg");
-
-          for (mctools::simulated_data::hit_handle_collection_type::iterator it_hit =
-                   hit_collection.begin();
-               it_hit != hit_collection.end(); ++it_hit) {
-            mctools::base_step_hit &a_step = it_hit->grab();
-
-            // If color is available, add a color box close to the item:
-            std::string hex_str;
-            if (a_step.get_auxiliaries().has_key(COLOR_FLAG)) {
-              a_step.get_auxiliaries().fetch(COLOR_FLAG, hex_str);
-              // TColor::GetColor(hex_str.c_str());
-            }
-            // Add subsubitem:
-            std::ostringstream label_hit;
-            label_hit << "Geiger hit #" << std::setw(2) << std::setfill('0') << a_step.get_hit_id()
-                      << " - "
-                      << "geom_id = " << a_step.get_geom_id();
-
-            TGListTreeItem *item_hit =
-                _tracks_list_box_->AddItem(item_mc_tracker, label_hit.str().c_str());
-            item_hit->SetUserData((void *)(intptr_t) - (++icheck_id));
-            _base_hit_dictionnary_[-icheck_id] = &(a_step);
-            item_hit->SetPictures(_get_colored_icon_("geiger", hex_str, true),
-                                  _get_colored_icon_("geiger", hex_str));
-
-            std::ostringstream tip_text;
-            if (options_mgr.get_option_flag(DUMP_INTO_TOOLTIP)) {
-              a_step.tree_dump(tip_text);
-            } else {
-              tip_text << "Double click to highlight Geiger hit "
-                       << "and to dump info on terminal";
-            }
-            item_hit->SetTipText(tip_text.str().c_str());
-          }
-          // Update item text following the number of hits found
-          const size_t ihit = hit_collection.size();
-          std::ostringstream oss;
-          oss << item_mc_tracker->GetText();
-          ihit == 0 ? oss << " - no hits" : oss << " - " << ihit << " hits";
-          item_mc_tracker->SetText(oss.str().c_str());
+        oss << item->GetText();
+        if (count == 0) {
+          oss << " - no hits";
+        } else {
+          oss << " - " << count << " hit";
+          if (count > 1) oss << "s";
         }
-      }  // end of SHOW_MC_TRACKER_HITS
-    }    // end of SHOW_MC_HITS
-
-    return;
+        item->SetText(oss.str().c_str());
+      }
+      // Update number of tracks
+      std::ostringstream oss;
+      oss << item_mc_tracks->GetText();
+      const size_t count = item_tracks.size();
+      if (count == 0) {
+        oss << " - no tracks";
+      } else {
+        oss << " - " << count << " track";
+        if (count > 1) oss << "s";
+      }
+      item_mc_tracks->SetText(oss.str().c_str());
+    }
   }
 
-  void browser_tracks::_update_calibrated_data() {
-    // Grab event and other resources. Here nothing is constant
-    // since properties will be modified here and used later
-    // through 'checking' and 'double_clicking' actions:
-    io::event_record &event = _server_->grab_event();
+  // Add MC hits information:
+  if (options_mgr.get_option_flag(SHOW_MC_HITS)) {
+    if (options_mgr.get_option_flag(SHOW_MC_CALORIMETER_HITS)) {
+      TGListTreeItem *item_mc_calorimeter =
+          _tracks_list_box_->AddItem(item_simulated_data, "Simulated calorimeter hits",
+                                     _get_colored_icon_("ofolder"), _get_colored_icon_("folder"));
+      item_mc_calorimeter->SetCheckBox(false);
+      item_mc_calorimeter->SetUserData((void *)(intptr_t)++icheck_id);
 
-    // 'calibrated_data' availability:
-    if (!event.has(io::CD_LABEL)) return;
+      // Retrieve all category names except private category such as '__visual.tracks'
+      std::vector<std::string> calo_categories;
+      sd.get_step_hits_categories(calo_categories,
+                                  mctools::simulated_data::HIT_CATEGORY_TYPE_PUBLIC);
 
-    snemo::datamodel::calibrated_data &cd =
-        event.grab<snemo::datamodel::calibrated_data>(io::CD_LABEL);
+      size_t ihit = 0;
+      for (std::vector<std::string>::const_iterator iname = calo_categories.begin();
+           iname != calo_categories.end(); ++iname) {
+        const std::string &a_calo_name = *iname;
 
-    const options_manager &options_mgr = options_manager::get_instance();
-    if (!options_mgr.get_option_flag(SHOW_CALIBRATED_HITS)) return;
+        // 2015/07/07 XG: Remove Geiger energy deposit since it is treated
+        // in a particular way
+        if (a_calo_name == "gg") continue;
 
-    // Add 'calibrated_data' folder as sub item:
-    const std::string data_bank_name = "Calibrated data (" + io::CD_LABEL + ")";
-    TGListTreeItem *item_calibrated_data =
-        _tracks_list_box_->AddItem(_top_item_, data_bank_name.c_str(),
+        if (!sd.has_step_hits(a_calo_name)) continue;
+
+        mctools::simulated_data::hit_handle_collection_type &hit_collection =
+            sd.grab_step_hits(a_calo_name);
+        ihit += hit_collection.size();
+
+        for (mctools::simulated_data::hit_handle_collection_type::iterator it_hit =
+                 hit_collection.begin();
+             it_hit != hit_collection.end(); ++it_hit) {
+          mctools::base_step_hit &a_step = it_hit->grab();
+
+          std::string hex_str;
+          if (a_step.get_auxiliaries().has_key(COLOR_FLAG)) {
+            a_step.get_auxiliaries().fetch(COLOR_FLAG, hex_str);
+            // TColor::GetColor (hex_str.c_str());
+          }
+          // Add subsubitem:
+          std::ostringstream label_hit;
+          label_hit.precision(3);
+          label_hit.setf(std::ios::fixed, std::ios::floatfield);
+          label_hit << a_calo_name << " hit #" << a_step.get_hit_id() << " - "
+                    << "Energy deposit = ";
+          utils::root_utilities::get_prettified_energy(label_hit, a_step.get_energy_deposit());
+          label_hit << " - geom_id = " << a_step.get_geom_id();
+
+          TGListTreeItem *item_hit =
+              _tracks_list_box_->AddItem(item_mc_calorimeter, label_hit.str().c_str());
+          item_hit->SetUserData((void *)(intptr_t) - (++icheck_id));
+          _base_hit_dictionnary_[-icheck_id] = &(a_step);
+          item_hit->SetPictures(_get_colored_icon_("calorimeter", "", true),
+                                _get_colored_icon_("calorimeter"));
+
+          std::ostringstream tip_text;
+          if (options_mgr.get_option_flag(DUMP_INTO_TOOLTIP)) {
+            a_step.tree_dump(tip_text);
+          } else {
+            tip_text << "Double click to highlight calorimeter hit "
+                     << "and to dump info on terminal";
+          }
+          item_hit->SetTipText(tip_text.str().c_str());
+        }
+      }
+      // Update item text following the number of hits found
+      std::ostringstream oss;
+      oss << item_mc_calorimeter->GetText();
+      ihit == 0 ? oss << " - no hits" : oss << " - " << ihit << " hits";
+      item_mc_calorimeter->SetText(oss.str().c_str());
+    }  // end of SHOW_MC_CALORIMETER_HITS
+
+    if (options_mgr.get_option_flag(SHOW_MC_TRACKER_HITS)) {
+      if (sd.has_step_hits("gg")) {
+        TGListTreeItem *item_mc_tracker =
+            _tracks_list_box_->AddItem(item_simulated_data, "Simulated tracker hits",
+                                       _get_colored_icon_("ofolder"), _get_colored_icon_("folder"));
+        item_mc_tracker->SetCheckBox(false);
+        item_mc_tracker->SetUserData((void *)(intptr_t)++icheck_id);
+
+        mctools::simulated_data::hit_handle_collection_type &hit_collection =
+            sd.grab_step_hits("gg");
+
+        for (mctools::simulated_data::hit_handle_collection_type::iterator it_hit =
+                 hit_collection.begin();
+             it_hit != hit_collection.end(); ++it_hit) {
+          mctools::base_step_hit &a_step = it_hit->grab();
+
+          // If color is available, add a color box close to the item:
+          std::string hex_str;
+          if (a_step.get_auxiliaries().has_key(COLOR_FLAG)) {
+            a_step.get_auxiliaries().fetch(COLOR_FLAG, hex_str);
+            // TColor::GetColor(hex_str.c_str());
+          }
+          // Add subsubitem:
+          std::ostringstream label_hit;
+          label_hit << "Geiger hit #" << std::setw(2) << std::setfill('0') << a_step.get_hit_id()
+                    << " - "
+                    << "geom_id = " << a_step.get_geom_id();
+
+          TGListTreeItem *item_hit =
+              _tracks_list_box_->AddItem(item_mc_tracker, label_hit.str().c_str());
+          item_hit->SetUserData((void *)(intptr_t) - (++icheck_id));
+          _base_hit_dictionnary_[-icheck_id] = &(a_step);
+          item_hit->SetPictures(_get_colored_icon_("geiger", hex_str, true),
+                                _get_colored_icon_("geiger", hex_str));
+
+          std::ostringstream tip_text;
+          if (options_mgr.get_option_flag(DUMP_INTO_TOOLTIP)) {
+            a_step.tree_dump(tip_text);
+          } else {
+            tip_text << "Double click to highlight Geiger hit "
+                     << "and to dump info on terminal";
+          }
+          item_hit->SetTipText(tip_text.str().c_str());
+        }
+        // Update item text following the number of hits found
+        const size_t ihit = hit_collection.size();
+        std::ostringstream oss;
+        oss << item_mc_tracker->GetText();
+        ihit == 0 ? oss << " - no hits" : oss << " - " << ihit << " hits";
+        item_mc_tracker->SetText(oss.str().c_str());
+      }
+    }  // end of SHOW_MC_TRACKER_HITS
+  }    // end of SHOW_MC_HITS
+
+  return;
+}
+
+void browser_tracks::_update_calibrated_data() {
+  // Grab event and other resources. Here nothing is constant
+  // since properties will be modified here and used later
+  // through 'checking' and 'double_clicking' actions:
+  io::event_record &event = _server_->grab_event();
+
+  // 'calibrated_data' availability:
+  if (!event.has(io::CD_LABEL)) return;
+
+  snemo::datamodel::calibrated_data &cd =
+      event.grab<snemo::datamodel::calibrated_data>(io::CD_LABEL);
+
+  const options_manager &options_mgr = options_manager::get_instance();
+  if (!options_mgr.get_option_flag(SHOW_CALIBRATED_HITS)) return;
+
+  // Add 'calibrated_data' folder as sub item:
+  const std::string data_bank_name = "Calibrated data (" + io::CD_LABEL + ")";
+  TGListTreeItem *item_calibrated_data =
+      _tracks_list_box_->AddItem(_top_item_, data_bank_name.c_str(), _get_colored_icon_("ofolder"),
+                                 _get_colored_icon_("folder"));
+  _tracks_list_box_->OpenItem(item_calibrated_data);
+  item_calibrated_data->SetCheckBox(false);
+  item_calibrated_data->SetUserData((void *)(intptr_t)++_item_id_);
+  if (options_manager::get_instance().get_option_flag(DUMP_INTO_TOOLTIP)) {
+    std::ostringstream tip_text;
+    cd.tree_dump(tip_text);
+    item_calibrated_data->SetTipText(tip_text.str().c_str());
+  } else {
+    item_calibrated_data->SetTipText("Double click to expand calibrated data");
+  }
+
+  int &icheck_id = _item_id_;
+
+  // Add calibrated hits information:
+  // Start with calorimeter info:
+  {
+    TGListTreeItem *item_calorimeter =
+        _tracks_list_box_->AddItem(item_calibrated_data, "Calibrated calorimeter hits",
                                    _get_colored_icon_("ofolder"), _get_colored_icon_("folder"));
-    _tracks_list_box_->OpenItem(item_calibrated_data);
-    item_calibrated_data->SetCheckBox(false);
-    item_calibrated_data->SetUserData((void *)(intptr_t)++_item_id_);
-    if (options_manager::get_instance().get_option_flag(DUMP_INTO_TOOLTIP)) {
+    item_calorimeter->SetCheckBox(false);
+    item_calorimeter->SetUserData((void *)(intptr_t)++icheck_id);
+
+    snemo::datamodel::calibrated_data::calorimeter_hit_collection_type &cc_collection =
+        cd.calibrated_calorimeter_hits();
+
+    for (snemo::datamodel::calibrated_data::calorimeter_hit_collection_type::iterator it_hit =
+             cc_collection.begin();
+         it_hit != cc_collection.end(); ++it_hit) {
+      snemo::datamodel::calibrated_calorimeter_hit &a_hit = it_hit->grab();
+
+      std::string hex_str;
+      if (a_hit.get_auxiliaries().has_key(COLOR_FLAG)) {
+        a_hit.get_auxiliaries().fetch(COLOR_FLAG, hex_str);
+        // TColor::GetColor(hex_str.c_str());
+      }
+
+      // Add subsubitem:
+      std::ostringstream label_hit;
+      label_hit.precision(3);
+      label_hit.setf(std::ios::fixed, std::ios::floatfield);
+      if (a_hit.get_auxiliaries().has_key("category"))
+        label_hit << a_hit.get_auxiliaries().fetch_string("category") << " ";
+      label_hit << "hit #" << a_hit.get_hit_id() << " - E = ";
+      utils::root_utilities::get_prettified_energy(label_hit, a_hit.get_energy(),
+                                                   a_hit.get_sigma_energy());
+      label_hit << " - t = ";
+      utils::root_utilities::get_prettified_time(label_hit, a_hit.get_time(),
+                                                 a_hit.get_sigma_time());
+
+      TGListTreeItem *item_hit =
+          _tracks_list_box_->AddItem(item_calorimeter, label_hit.str().c_str());
+      item_hit->SetUserData((void *)(intptr_t) - (++icheck_id));
+      _base_hit_dictionnary_[-icheck_id] = &(a_hit);
+      item_hit->SetPictures(_get_colored_icon_("calorimeter", "", true),
+                            _get_colored_icon_("calorimeter"));
+
       std::ostringstream tip_text;
-      cd.tree_dump(tip_text);
-      item_calibrated_data->SetTipText(tip_text.str().c_str());
+      if (options_mgr.get_option_flag(DUMP_INTO_TOOLTIP)) {
+        a_hit.tree_dump(tip_text);
+      } else {
+        tip_text << "Double click to highlight calorimeter hit "
+                 << "and to dump info on terminal";
+      }
+      item_hit->SetTipText(tip_text.str().c_str());
+    }
+    // Update item text following the number of hits found
+    const size_t ihit = cc_collection.size();
+    std::ostringstream oss;
+    oss << item_calorimeter->GetText();
+    ihit == 0 ? oss << " - no hits" : oss << " - " << ihit << " hits";
+    item_calorimeter->SetText(oss.str().c_str());
+  }  // end of calorimeter info
+
+  // Continue with tracker info:
+  {
+    TGListTreeItem *item_tracker =
+        _tracks_list_box_->AddItem(item_calibrated_data, "Calibrated tracker hits",
+                                   _get_colored_icon_("ofolder"), _get_colored_icon_("folder"));
+    item_tracker->SetCheckBox(false);
+    item_tracker->SetUserData((void *)(intptr_t)++icheck_id);
+
+    snemo::datamodel::calibrated_data::tracker_hit_collection_type &ct_collection =
+        cd.calibrated_tracker_hits();
+
+    for (snemo::datamodel::calibrated_data::tracker_hit_collection_type::iterator it_hit =
+             ct_collection.begin();
+         it_hit != ct_collection.end(); ++it_hit) {
+      snemo::datamodel::calibrated_tracker_hit &a_hit = it_hit->grab();
+
+      // Add subsubitem:
+      std::ostringstream label_hit;
+      label_hit.precision(3);
+      label_hit.setf(std::ios::fixed, std::ios::floatfield);
+      label_hit << "Geiger hit #" << std::setw(2) << std::setfill('0') << a_hit.get_id()
+                << " (r, z) = (" << a_hit.get_r() / CLHEP::cm << ", " << a_hit.get_z() / CLHEP::cm
+                << ") cm";
+
+      TGListTreeItem *item_hit = _tracks_list_box_->AddItem(item_tracker, label_hit.str().c_str(),
+                                                            _get_colored_icon_("geiger", "", true),
+                                                            _get_colored_icon_("geiger"));
+      item_hit->SetUserData((void *)(intptr_t) - (++icheck_id));
+      _base_hit_dictionnary_[-icheck_id] = &(a_hit);
+
+      std::ostringstream tip_text;
+      if (options_mgr.get_option_flag(DUMP_INTO_TOOLTIP)) {
+        a_hit.tree_dump(tip_text);
+      } else {
+        tip_text << "Double click to highlight Geiger hit "
+                 << "and to dump info on terminal";
+      }
+      item_hit->SetTipText(tip_text.str().c_str());
+    }
+    // Update item text following the number of hits found
+    const size_t ihit = ct_collection.size();
+    std::ostringstream oss;
+    oss << item_tracker->GetText();
+    ihit == 0 ? oss << " - no hits" : oss << " - " << ihit << " hits";
+    item_tracker->SetText(oss.str().c_str());
+  }  // end of tracker info
+
+  return;
+}
+
+void browser_tracks::_update_tracker_clustering_data() {
+  // Grab event and other resources. Here nothing is constant
+  // since properties will be modified here and used later
+  // through 'checking' and 'double_clicking' actions:
+  io::event_record &event = _server_->grab_event();
+
+  // 'tracker_clustering_data' availability:
+  if (!event.has(io::TCD_LABEL)) return;
+
+  snemo::datamodel::tracker_clustering_data &tcd =
+      event.grab<snemo::datamodel::tracker_clustering_data>(io::TCD_LABEL);
+
+  const options_manager &options_mgr = options_manager::get_instance();
+  if (!options_mgr.get_option_flag(SHOW_TRACKER_CLUSTERED_HITS)) return;
+
+  // Identifiant for item dictionnary:
+  int &icheck_id = _item_id_;
+
+  // Add 'tracker_clustering_data' item:
+  const std::string data_bank_name = "Tracker clustering data (" + io::TCD_LABEL + ")";
+  TGListTreeItem *item_tracker_cluster =
+      _tracks_list_box_->AddItem(_top_item_, data_bank_name.c_str(), _get_colored_icon_("ofolder"),
+                                 _get_colored_icon_("folder"));
+  item_tracker_cluster->SetCheckBox(false);
+  item_tracker_cluster->SetUserData((void *)(intptr_t)++icheck_id);
+
+  _tracks_list_box_->SetCheckMode(TGListTree::kRecursive);
+  //        _tracks_list_box_->SetCheckBox(item_tracker_cluster);
+  _tracks_list_box_->OpenItem(item_tracker_cluster);
+
+  {
+    std::ostringstream tip_text;
+    if (options_mgr.get_option_flag(DUMP_INTO_TOOLTIP)) {
+      tcd.tree_dump(tip_text);
     } else {
-      item_calibrated_data->SetTipText("Double click to expand calibrated data");
+      tip_text << "Double click to expand tracker clustering data";
+    }
+    item_tracker_cluster->SetTipText(tip_text.str().c_str());
+  }
+
+  snemo::datamodel::tracker_clustering_data::solution_col_type &cluster_solutions =
+      tcd.grab_solutions();
+  for (snemo::datamodel::tracker_clustering_data::solution_col_type::iterator isolution =
+           cluster_solutions.begin();
+       isolution != cluster_solutions.end(); ++isolution) {
+    // Get current tracker solution:
+    snemo::datamodel::tracker_clustering_solution &a_solution = isolution->grab();
+
+    // Add item:
+    std::ostringstream label_solution;
+    label_solution << "Solution #" << a_solution.get_solution_id() << " - "
+                   << a_solution.get_unclustered_hits().size() << " unclustered hit"
+                   << (a_solution.get_unclustered_hits().size() > 1 ? "s" : "");
+    if (tcd.has_default_solution()) {
+      if (&a_solution == &(tcd.get_default_solution())) {
+        label_solution << " - default";
+      }
     }
 
-    int &icheck_id = _item_id_;
-
-    // Add calibrated hits information:
-    // Start with calorimeter info:
+    TGListTreeItem *item_solution =
+        _tracks_list_box_->AddItem(item_tracker_cluster, label_solution.str().c_str(),
+                                   _get_colored_icon_("ofolder"), _get_colored_icon_("folder"));
+    _tracks_list_box_->OpenItem(item_solution);
+    item_solution->SetUserData((void *)(intptr_t)++icheck_id);
+    item_solution->SetCheckBox(true);
     {
-      TGListTreeItem *item_calorimeter =
-          _tracks_list_box_->AddItem(item_calibrated_data, "Calibrated calorimeter hits",
-                                     _get_colored_icon_("ofolder"), _get_colored_icon_("folder"));
-      item_calorimeter->SetCheckBox(false);
-      item_calorimeter->SetUserData((void *)(intptr_t)++icheck_id);
+      // Set tooltip text
+      std::ostringstream tip_text;
+      a_solution.tree_dump(tip_text);
+      item_solution->SetTipText(tip_text.str().c_str());
+    }
+    // Get solution auxiliaries:
+    datatools::properties &a_auxiliaries = a_solution.grab_auxiliaries();
 
+    if (a_auxiliaries.has_key(browser_tracks::CHECKED_FLAG))
+      item_solution->CheckItem(a_auxiliaries.has_flag(browser_tracks::CHECKED_FLAG));
+
+    // Update properties dictionnary:
+    _properties_dictionnary_[icheck_id] = &(a_auxiliaries);
+
+    // Get clusters stored in the current tracker solution:
+    snemo::datamodel::tracker_clustering_solution::cluster_col_type &clusters =
+        a_solution.grab_clusters();
+    for (snemo::datamodel::tracker_clustering_solution::cluster_col_type::iterator icluster =
+             clusters.begin();
+         icluster != clusters.end(); ++icluster) {
+      // Get current tracker cluster:
+      snemo::datamodel::tracker_cluster &a_cluster = icluster->grab();
+
+      // Add subitem:
+      std::ostringstream label_cluster;
+      label_cluster << "Cluster #" << a_cluster.get_cluster_id() << " "
+                    << "(" << a_cluster.get_hits().size() << " hits) ";
+      if (a_cluster.is_prompt()) {
+        label_cluster << "- prompt";
+      } else {
+        label_cluster << "- delayed";
+      }
+
+      TGListTreeItem *item_cluster =
+          _tracks_list_box_->AddItem(item_solution, label_cluster.str().c_str());
+      item_cluster->SetUserData((void *)(intptr_t)++icheck_id);
+      item_cluster->SetCheckBox(true);
+      {
+        // Set tooltip text
+        std::ostringstream tip_text;
+        a_cluster.tree_dump(tip_text);
+        item_cluster->SetTipText(tip_text.str().c_str());
+      }
+      // Get cluster auxiliaries:
+      datatools::properties &aa_auxiliaries = a_cluster.grab_auxiliaries();
+
+      if (aa_auxiliaries.has_key(browser_tracks::CHECKED_FLAG))
+        item_cluster->CheckItem(aa_auxiliaries.has_flag(browser_tracks::CHECKED_FLAG));
+
+      // Update base hit dictionnary:
+      _base_hit_dictionnary_[icheck_id] = &(a_cluster);
+
+      // If color is available, add a color box close to the
+      // item (obsolete since xpm icon can be colorized):
+      std::string hex_str;
+      if (aa_auxiliaries.has_key(browser_tracks::COLOR_FLAG)) {
+        aa_auxiliaries.fetch(browser_tracks::COLOR_FLAG, hex_str);
+        // const size_t color = TColor::GetColor(hex_str.c_str());
+        // item_cluster->SetColor(color);
+      }
+      item_cluster->SetPictures(_get_colored_icon_("cluster", hex_str),
+                                _get_colored_icon_("cluster", hex_str));
+
+      // Get tracker hits stored in the current tracker cluster:
+      snemo::datamodel::calibrated_tracker_hit::collection_type &hits = a_cluster.grab_hits();
+      for (snemo::datamodel::calibrated_tracker_hit::collection_type::iterator igg = hits.begin();
+           igg != hits.end(); ++igg) {
+        snemo::datamodel::calibrated_tracker_hit &a_gg_hit = igg->grab();
+        // Add subsubitem:
+        std::ostringstream label_hit;
+        label_hit.precision(3);
+        label_hit.setf(std::ios::fixed, std::ios::floatfield);
+        label_hit << "Geiger hit #" << std::setw(2) << std::setfill('0') << a_gg_hit.get_id()
+                  << " (r, z) = (" << a_gg_hit.get_r() / CLHEP::cm << ", "
+                  << a_gg_hit.get_z() / CLHEP::cm << ") cm";
+
+        TGListTreeItem *item_hit = _tracks_list_box_->AddItem(
+            item_cluster, label_hit.str().c_str(), _get_colored_icon_("geiger", hex_str, true),
+            _get_colored_icon_("geiger", hex_str));
+        item_hit->SetUserData((void *)(intptr_t) - (++icheck_id));
+        _base_hit_dictionnary_[-icheck_id] = &(a_gg_hit);
+
+        std::ostringstream tip_text;
+        if (options_mgr.get_option_flag(DUMP_INTO_TOOLTIP)) {
+          a_gg_hit.tree_dump(tip_text);
+        } else {
+          tip_text << "Double click to highlight Geiger hit "
+                   << "and to dump info on terminal";
+        }
+        item_hit->SetTipText(tip_text.str().c_str());
+      }
+    }  // end of cluster loop
+  }    // end of solution loop
+
+  return;
+}
+
+void browser_tracks::_update_tracker_trajectory_data() {
+  // Grab event and other resources. Here nothing is constant
+  // since properties will be modified here and used later
+  // through 'checking' and 'double_clicking' actions:
+  io::event_record &event = _server_->grab_event();
+
+  // 'tracker_trajectory_data' availability:
+  if (!event.has(io::TTD_LABEL)) return;
+
+  snemo::datamodel::tracker_trajectory_data &ttd =
+      event.grab<snemo::datamodel::tracker_trajectory_data>(io::TTD_LABEL);
+
+  const options_manager &options_mgr = options_manager::get_instance();
+  if (!options_mgr.get_option_flag(SHOW_TRACKER_TRAJECTORIES)) return;
+
+  // Identifiant for item dictionnary:
+  int &icheck_id = _item_id_;
+
+  // Add 'tracker_clustering_data' item:
+  const std::string data_bank_name = "Tracker trajectory data (" + io::TTD_LABEL + ")";
+  TGListTreeItem *item_tracker_trajectory =
+      _tracks_list_box_->AddItem(_top_item_, data_bank_name.c_str(), _get_colored_icon_("ofolder"),
+                                 _get_colored_icon_("folder"));
+  item_tracker_trajectory->SetCheckBox(false);
+  item_tracker_trajectory->SetUserData((void *)(intptr_t)++icheck_id);
+
+  //        _tracks_list_box_->SetCheckBox(item_tracker_cluster);
+  _tracks_list_box_->OpenItem(item_tracker_trajectory);
+
+  std::ostringstream tip_text;
+  if (options_mgr.get_option_flag(DUMP_INTO_TOOLTIP)) {
+    ttd.tree_dump(tip_text);
+  } else {
+    tip_text << "Double click to expand tracker trajectory data";
+  }
+  item_tracker_trajectory->SetTipText(tip_text.str().c_str());
+
+  if (!ttd.has_solutions()) return;
+
+  snemo::datamodel::tracker_trajectory_data::solution_col_type &trajectory_solutions =
+      ttd.grab_solutions();
+  for (snemo::datamodel::tracker_trajectory_data::solution_col_type::iterator isolution =
+           trajectory_solutions.begin();
+       isolution != trajectory_solutions.end(); ++isolution) {
+    // Get current tracker solution:
+    snemo::datamodel::tracker_trajectory_solution &a_solution = isolution->grab();
+
+    // Add item:
+    std::ostringstream label_solution;
+    label_solution << "Solution #" << a_solution.get_solution_id() << " - "
+                   << a_solution.get_trajectories().size() << " trajector"
+                   << (a_solution.get_trajectories().size() > 1 ? "ies" : "y") << ", "
+                   << a_solution.get_unfitted_clusters().size() << " unfitted cluster"
+                   << (a_solution.get_unfitted_clusters().size() > 1 ? "s" : "");
+    if (ttd.has_default_solution()) {
+      if (&a_solution == &(ttd.get_default_solution())) {
+        label_solution << " - default";
+      }
+    }
+
+    TGListTreeItemStdPlus *item_solution =
+        new TGListTreeItemStdPlus(label_solution.str().c_str(), this, _get_colored_icon_("ofolder"),
+                                  _get_colored_icon_("folder"),
+                                  /*check=*/true);
+    _tracks_list_box_->AddItem(item_tracker_trajectory, item_solution);
+    // TGListTreeItem * item_solution
+    //   = _tracks_list_box_->AddItem(item_tracker_trajectory,
+    //                                 label_solution.str().c_str());
+    _tracks_list_box_->OpenItem(item_solution);
+    item_solution->SetUserData((void *)(intptr_t)++icheck_id);
+
+    // Get solution auxiliaries:
+    datatools::properties &a_auxiliaries = a_solution.grab_auxiliaries();
+
+    if (a_auxiliaries.has_key(browser_tracks::CHECKED_FLAG))
+      item_solution->CheckItem(a_auxiliaries.has_flag(browser_tracks::CHECKED_FLAG));
+
+    // Update properties dictionnary:
+    _properties_dictionnary_[icheck_id] = &(a_auxiliaries);
+
+    // Prepare folder for helix pattern:
+    TGListTreeItem *item_helix_solution = 0;
+
+    // Prepare folder for line pattern:
+    TGListTreeItem *item_line_solution = 0;
+
+    // Get trajectories stored in the current tracker trajectory solution:
+    snemo::datamodel::tracker_trajectory_solution::trajectory_col_type &trajectories =
+        a_solution.grab_trajectories();
+    for (snemo::datamodel::tracker_trajectory_solution::trajectory_col_type::iterator itrajectory =
+             trajectories.begin();
+         itrajectory != trajectories.end(); ++itrajectory) {
+      // Get current tracker trajectory:
+      snemo::datamodel::tracker_trajectory &a_trajectory = itrajectory->grab();
+
+      // Determine trajectory color by getting cluster color:
+      std::string hex_str;
+      if (a_trajectory.has_cluster()) {
+        const snemo::datamodel::tracker_cluster &a_cluster = a_trajectory.get_cluster();
+        const datatools::properties &prop = a_cluster.get_auxiliaries();
+        if (prop.has_key(browser_tracks::COLOR_FLAG)) {
+          prop.fetch(browser_tracks::COLOR_FLAG, hex_str);
+        }
+      }
+
+      // Add subitem:
+      std::ostringstream label_trajectory;
+      //                label_trajectory.setf(ios::fixed, ios::floatfield);
+      datatools::properties &properties = a_trajectory.grab_auxiliaries();
+      if (properties.has_key("chi2") && properties.has_key("ndof")) {
+        const double chi2 = properties.fetch_real("chi2");
+        const size_t ndof = properties.fetch_integer("ndof");
+        label_trajectory << " - chi2/ndf = " << std::setprecision(2) << std::fixed << chi2 << "/"
+                         << std::setprecision(0) << ndof << std::setprecision(2) << std::fixed
+                         << ", p = " << TMath::Prob(chi2, ndof);
+      }
+      if (properties.has_key("t0")) {
+        const double t0 = properties.fetch_real("t0");
+        label_trajectory << std::setprecision(0) << std::fixed << ", t0 = ";
+        utils::root_utilities::get_prettified_time(label_trajectory, t0);
+      }
+      if (properties.has_key("guess")) {
+        label_trajectory << " (" << properties.fetch_string("guess") << " guess)";
+      }
+      bool is_default = false;
+      if (properties.has_flag("default")) {
+        label_trajectory << " - default";
+        is_default = true;
+      }
+
+      TGListTreeItem *item_trajectory = 0;
+      if (a_trajectory.get_pattern().get_pattern_id() ==
+          snemo::datamodel::helix_trajectory_pattern::pattern_id()) {
+        // First time instantiate it
+        if (!item_helix_solution) {
+          item_helix_solution =
+              new TGListTreeItemStdPlus("Helix trajectories", this, _get_colored_icon_("ofolder"),
+                                        _get_colored_icon_("folder"),
+                                        /*check=*/true);
+          _tracks_list_box_->AddItem(item_solution, item_helix_solution);
+          // _tracks_list_box_->OpenItem(item_helix_solution);
+          item_helix_solution->SetUserData((void *)(intptr_t)++icheck_id);
+          if (a_auxiliaries.has_key(browser_tracks::CHECKED_FLAG))
+            item_helix_solution->CheckItem(a_auxiliaries.has_flag(browser_tracks::CHECKED_FLAG));
+          _properties_dictionnary_[icheck_id] = &(a_auxiliaries);
+        }
+
+        item_trajectory = _tracks_list_box_->AddItem(
+            item_helix_solution, std::string("helix" + label_trajectory.str()).c_str(),
+            _get_colored_icon_("helix", hex_str, true), _get_colored_icon_("helix", hex_str));
+      } else if (a_trajectory.get_pattern().get_pattern_id() ==
+                 snemo::datamodel::line_trajectory_pattern::pattern_id()) {
+        // First time instantiate it
+        if (!item_line_solution) {
+          const bool checked = true;
+          item_line_solution =
+              new TGListTreeItemStdPlus("Line trajectories", this, _get_colored_icon_("ofolder"),
+                                        _get_colored_icon_("folder"), checked);
+          _tracks_list_box_->AddItem(item_solution, item_line_solution);
+          // _tracks_list_box_->OpenItem(item_line_solution);
+          item_line_solution->SetUserData((void *)(intptr_t)++icheck_id);
+          if (a_auxiliaries.has_key(browser_tracks::CHECKED_FLAG))
+            item_line_solution->CheckItem(a_auxiliaries.has_flag(browser_tracks::CHECKED_FLAG));
+          _properties_dictionnary_[icheck_id] = &(a_auxiliaries);
+        }
+
+        item_trajectory = _tracks_list_box_->AddItem(
+            item_line_solution, std::string("line" + label_trajectory.str()).c_str(),
+            _get_colored_icon_("line", hex_str, true), _get_colored_icon_("line", hex_str));
+      }
+
+      if (!item_trajectory) continue;
+
+      item_trajectory->SetCheckBox(true);
+      if (is_default) {
+        a_trajectory.grab_auxiliaries().update(CHECKED_FLAG, true);
+        _tracks_list_box_->CheckItem(item_trajectory, true);
+      } else {
+        a_trajectory.grab_auxiliaries().update(CHECKED_FLAG, false);
+        _tracks_list_box_->CheckItem(item_trajectory, false);
+      }
+      item_trajectory->SetUserData((void *)(intptr_t) - (++icheck_id));
+      _base_hit_dictionnary_[-icheck_id] = &(a_trajectory);
+
+      if (options_mgr.get_option_flag(DUMP_INTO_TOOLTIP)) {
+        std::ostringstream oss;
+        a_trajectory.tree_dump(oss);
+        item_trajectory->SetTipText(oss.str().c_str());
+      } else {
+        std::ostringstream message;
+        message << "Double click to highlight trajectory "
+                << "and to dump info on terminal";
+        item_trajectory->SetTipText(message.str().c_str());
+      }
+    }  // end of trajectory loop
+  }    // end of solution loop
+
+  return;
+}
+
+void browser_tracks::_update_particle_track_data() {
+  // Grab event and other resources. Here nothing is constant
+  // since properties will be modified here and used later
+  // through 'checking' and 'double_clicking' actions:
+  io::event_record &event = _server_->grab_event();
+
+  // 'tracker_trajectory_data' availability:
+  if (!event.has(io::PTD_LABEL)) return;
+
+  snemo::datamodel::particle_track_data &ptd =
+      event.grab<snemo::datamodel::particle_track_data>(io::PTD_LABEL);
+
+  const options_manager &options_mgr = options_manager::get_instance();
+  if (!options_mgr.get_option_flag(SHOW_PARTICLE_TRACKS)) return;
+
+  // Identifiant for item dictionnary:
+  int &icheck_id = _item_id_;
+
+  // Add 'tracker_clustering_data' item:
+  const std::string data_bank_name = "Particle track data (" + io::PTD_LABEL + ")";
+  TGListTreeItem *item_particle_track_data =
+      _tracks_list_box_->AddItem(_top_item_, data_bank_name.c_str(), _get_colored_icon_("ofolder"),
+                                 _get_colored_icon_("folder"));
+  item_particle_track_data->SetCheckBox(false);
+  item_particle_track_data->SetUserData((void *)(intptr_t)++icheck_id);
+  _tracks_list_box_->OpenItem(item_particle_track_data);
+  {
+    std::ostringstream tip_text;
+    if (options_mgr.get_option_flag(DUMP_INTO_TOOLTIP)) {
+      ptd.tree_dump(tip_text);
+    } else {
+      tip_text << "Double click to expand particle track data";
+    }
+    item_particle_track_data->SetTipText(tip_text.str().c_str());
+  }
+  // Add unassociated calorimeter hits info
+  if (ptd.has_non_associated_calorimeters()) {
+    snemo::datamodel::calibrated_data::calorimeter_hit_collection_type &cc_collection =
+        ptd.grab_non_associated_calorimeters();
+
+    for (snemo::datamodel::calibrated_data::calorimeter_hit_collection_type::iterator it_hit =
+             cc_collection.begin();
+         it_hit != cc_collection.end(); ++it_hit) {
+      snemo::datamodel::calibrated_calorimeter_hit &a_hit = it_hit->grab();
+
+      // Add subsubitem:
+      std::ostringstream label_hit;
+      label_hit.precision(3);
+      label_hit.setf(std::ios::fixed, std::ios::floatfield);
+      label_hit << "Unassociated ";
+      if (a_hit.get_auxiliaries().has_key("category"))
+        label_hit << a_hit.get_auxiliaries().fetch_string("category") << " block ";
+      label_hit << "hit #" << a_hit.get_hit_id() << " - E = ";
+      utils::root_utilities::get_prettified_energy(label_hit, a_hit.get_energy(),
+                                                   a_hit.get_sigma_energy());
+      label_hit << " - t = ";
+      utils::root_utilities::get_prettified_time(label_hit, a_hit.get_time(),
+                                                 a_hit.get_sigma_time());
+
+      TGListTreeItem *item_hit =
+          _tracks_list_box_->AddItem(item_particle_track_data, label_hit.str().c_str());
+      item_hit->SetUserData((void *)(intptr_t) - (++icheck_id));
+      _base_hit_dictionnary_[-icheck_id] = &(a_hit);
+      item_hit->SetPictures(_get_colored_icon_("calorimeter", "", true),
+                            _get_colored_icon_("calorimeter"));
+
+      {
+        std::ostringstream tip_text;
+        if (options_mgr.get_option_flag(DUMP_INTO_TOOLTIP)) {
+          a_hit.tree_dump(tip_text);
+        } else {
+          tip_text << "Double click to highlight calorimeter hit "
+                   << "and to dump info on terminal";
+        }
+        item_hit->SetTipText(tip_text.str().c_str());
+      }
+    }
+  }
+
+  if (!ptd.has_particles()) return;
+
+  snemo::datamodel::particle_track_data::particle_collection_type &particles = ptd.grab_particles();
+  for (snemo::datamodel::particle_track_data::particle_collection_type::iterator iparticle =
+           particles.begin();
+       iparticle != particles.end(); ++iparticle) {
+    // Get current particle track:
+    snemo::datamodel::particle_track &a_particle = iparticle->grab();
+
+    // Add item:
+    size_t item_color = 0;
+    std::ostringstream label_particle;
+    label_particle << "Particle #" << a_particle.get_track_id();
+    if (a_particle.get_charge() == snemo::datamodel::particle_track::neutral) {
+      label_particle << " - neutral charged particle";
+      item_color = style_manager::get_instance().get_particle_color("gamma");
+    } else if (a_particle.get_charge() == snemo::datamodel::particle_track::negative) {
+      label_particle << " - negative charged particle";
+      item_color = style_manager::get_instance().get_particle_color("electron");
+    } else if (a_particle.get_charge() == snemo::datamodel::particle_track::positive) {
+      label_particle << " - positive charged particle";
+      item_color = style_manager::get_instance().get_particle_color("positron");
+    } else if (a_particle.get_charge() == snemo::datamodel::particle_track::undefined) {
+      label_particle << " - undefined charged particle";
+      item_color = style_manager::get_instance().get_particle_color("alpha");
+    }
+    // Get particle auxiliaries:
+    datatools::properties &a_auxiliaries = a_particle.grab_auxiliaries();
+    // item_color = utils::root_utilities::get_fade_color_from(item_color, 0.5);
+    std::string hex_str = utils::root_utilities::get_hex_color(item_color);
+    if (a_auxiliaries.has_key(browser_tracks::COLOR_FLAG)) {
+      a_auxiliaries.fetch(browser_tracks::COLOR_FLAG, hex_str);
+    }
+
+    TGListTreeItem *item_particle =
+        _tracks_list_box_->AddItem(item_particle_track_data, label_particle.str().c_str());
+    item_particle->SetPictures(_get_colored_icon_("track", hex_str),
+                               _get_colored_icon_("track", hex_str));
+    item_particle->SetUserData((void *)(intptr_t) - (++icheck_id));
+    item_particle->SetCheckBox(true);
+    item_particle->SetOpen(true);
+    {
+      // Set tooltip text
+      std::ostringstream tip_text;
+      a_particle.tree_dump(tip_text);
+      item_particle->SetTipText(tip_text.str().c_str());
+    }
+    if (a_auxiliaries.has_key(browser_tracks::CHECKED_FLAG))
+      item_particle->CheckItem(a_auxiliaries.has_flag(browser_tracks::CHECKED_FLAG));
+
+    // Update base hit dictionnary:
+    _base_hit_dictionnary_[-icheck_id] = &(a_particle);
+
+    // Update property dictionnary:
+    _properties_dictionnary_[-icheck_id] = &(a_auxiliaries);
+
+    // Get associated vertices
+    if (a_particle.has_vertices()) {
+      snemo::datamodel::particle_track::vertex_collection_type &vts = a_particle.grab_vertices();
+      for (snemo::datamodel::particle_track::vertex_collection_type::iterator ivtx = vts.begin();
+           ivtx != vts.end(); ++ivtx) {
+        geomtools::blur_spot &a_vertex = ivtx->grab();
+
+        std::ostringstream label;
+        label << "Vertex on ";
+        if (snemo::datamodel::particle_track::vertex_is_on_source_foil(a_vertex)) {
+          label << "source foil - ";
+        } else if (snemo::datamodel::particle_track::vertex_is_on_main_calorimeter(a_vertex)) {
+          label << "main calorimeter wall - ";
+        } else if (snemo::datamodel::particle_track::vertex_is_on_x_calorimeter(a_vertex)) {
+          label << "X-calorimeter wall - ";
+        } else if (snemo::datamodel::particle_track::vertex_is_on_gamma_veto(a_vertex)) {
+          label << "gamma veto - ";
+        } else if (snemo::datamodel::particle_track::vertex_is_on_wire(a_vertex)) {
+          label << "wire - ";
+        } else {
+          label << "unkown part of the detector -";
+        }
+        label << "(x, y, z) = ";
+        label.precision(3);
+        label.setf(std::ios::fixed, std::ios::floatfield);
+        label << a_vertex.get_position() / CLHEP::mm << " mm";
+        TGListTreeItem *item_vertex = _tracks_list_box_->AddItem(
+            item_particle, label.str().c_str(), _get_colored_icon_("vertex", hex_str, true),
+            _get_colored_icon_("vertex", hex_str));
+        item_vertex->SetCheckBox(false);
+        item_vertex->SetUserData((void *)(intptr_t) - (++icheck_id));
+        // Update properties dictionnary:
+        _properties_dictionnary_[-icheck_id] = &(a_vertex.grab_auxiliaries());
+        {
+          std::ostringstream tip_text;
+          if (options_mgr.get_option_flag(DUMP_INTO_TOOLTIP)) {
+            a_vertex.tree_dump(tip_text);
+          } else {
+            tip_text << "Double click to highlight vertex position "
+                     << "and to dump info on terminal";
+          }
+          item_vertex->SetTipText(tip_text.str().c_str());
+        }
+      }  // end of vertex list
+    }    // end of vertex check
+
+    // Get associated calorimeter
+    if (a_particle.has_associated_calorimeter_hits()) {
       snemo::datamodel::calibrated_data::calorimeter_hit_collection_type &cc_collection =
-          cd.calibrated_calorimeter_hits();
+          a_particle.grab_associated_calorimeter_hits();
 
       for (snemo::datamodel::calibrated_data::calorimeter_hit_collection_type::iterator it_hit =
                cc_collection.begin();
            it_hit != cc_collection.end(); ++it_hit) {
         snemo::datamodel::calibrated_calorimeter_hit &a_hit = it_hit->grab();
-
-        std::string hex_str;
-        if (a_hit.get_auxiliaries().has_key(COLOR_FLAG)) {
-          a_hit.get_auxiliaries().fetch(COLOR_FLAG, hex_str);
-          // TColor::GetColor(hex_str.c_str());
-        }
 
         // Add subsubitem:
         std::ostringstream label_hit;
@@ -692,11 +1332,11 @@ ClassImp(snemo::visualization::view::browser_tracks);
                                                    a_hit.get_sigma_time());
 
         TGListTreeItem *item_hit =
-            _tracks_list_box_->AddItem(item_calorimeter, label_hit.str().c_str());
+            _tracks_list_box_->AddItem(item_particle, label_hit.str().c_str(),
+                                       _get_colored_icon_("calorimeter", hex_str, true),
+                                       _get_colored_icon_("calorimeter", hex_str));
         item_hit->SetUserData((void *)(intptr_t) - (++icheck_id));
         _base_hit_dictionnary_[-icheck_id] = &(a_hit);
-        item_hit->SetPictures(_get_colored_icon_("calorimeter", "", true),
-                              _get_colored_icon_("calorimeter"));
 
         std::ostringstream tip_text;
         if (options_mgr.get_option_flag(DUMP_INTO_TOOLTIP)) {
@@ -706,794 +1346,152 @@ ClassImp(snemo::visualization::view::browser_tracks);
                    << "and to dump info on terminal";
         }
         item_hit->SetTipText(tip_text.str().c_str());
-      }
-      // Update item text following the number of hits found
-      const size_t ihit = cc_collection.size();
-      std::ostringstream oss;
-      oss << item_calorimeter->GetText();
-      ihit == 0 ? oss << " - no hits" : oss << " - " << ihit << " hits";
-      item_calorimeter->SetText(oss.str().c_str());
-    }  // end of calorimeter info
-
-    // Continue with tracker info:
-    {
-      TGListTreeItem *item_tracker =
-          _tracks_list_box_->AddItem(item_calibrated_data, "Calibrated tracker hits",
-                                     _get_colored_icon_("ofolder"), _get_colored_icon_("folder"));
-      item_tracker->SetCheckBox(false);
-      item_tracker->SetUserData((void *)(intptr_t)++icheck_id);
-
-      snemo::datamodel::calibrated_data::tracker_hit_collection_type &ct_collection =
-          cd.calibrated_tracker_hits();
-
-      for (snemo::datamodel::calibrated_data::tracker_hit_collection_type::iterator it_hit =
-               ct_collection.begin();
-           it_hit != ct_collection.end(); ++it_hit) {
-        snemo::datamodel::calibrated_tracker_hit &a_hit = it_hit->grab();
-
-        // Add subsubitem:
-        std::ostringstream label_hit;
-        label_hit.precision(3);
-        label_hit.setf(std::ios::fixed, std::ios::floatfield);
-        label_hit << "Geiger hit #" << std::setw(2) << std::setfill('0') << a_hit.get_id()
-                  << " (r, z) = (" << a_hit.get_r() / CLHEP::cm << ", " << a_hit.get_z() / CLHEP::cm
-                  << ") cm";
-
-        TGListTreeItem *item_hit = _tracks_list_box_->AddItem(
-            item_tracker, label_hit.str().c_str(), _get_colored_icon_("geiger", "", true),
-            _get_colored_icon_("geiger"));
-        item_hit->SetUserData((void *)(intptr_t) - (++icheck_id));
-        _base_hit_dictionnary_[-icheck_id] = &(a_hit);
-
-        std::ostringstream tip_text;
-        if (options_mgr.get_option_flag(DUMP_INTO_TOOLTIP)) {
-          a_hit.tree_dump(tip_text);
-        } else {
-          tip_text << "Double click to highlight Geiger hit "
-                   << "and to dump info on terminal";
-        }
-        item_hit->SetTipText(tip_text.str().c_str());
-      }
-      // Update item text following the number of hits found
-      const size_t ihit = ct_collection.size();
-      std::ostringstream oss;
-      oss << item_tracker->GetText();
-      ihit == 0 ? oss << " - no hits" : oss << " - " << ihit << " hits";
-      item_tracker->SetText(oss.str().c_str());
-    }  // end of tracker info
-
-    return;
-  }
-
-  void browser_tracks::_update_tracker_clustering_data() {
-    // Grab event and other resources. Here nothing is constant
-    // since properties will be modified here and used later
-    // through 'checking' and 'double_clicking' actions:
-    io::event_record &event = _server_->grab_event();
-
-    // 'tracker_clustering_data' availability:
-    if (!event.has(io::TCD_LABEL)) return;
-
-    snemo::datamodel::tracker_clustering_data &tcd =
-        event.grab<snemo::datamodel::tracker_clustering_data>(io::TCD_LABEL);
-
-    const options_manager &options_mgr = options_manager::get_instance();
-    if (!options_mgr.get_option_flag(SHOW_TRACKER_CLUSTERED_HITS)) return;
-
-    // Identifiant for item dictionnary:
-    int &icheck_id = _item_id_;
-
-    // Add 'tracker_clustering_data' item:
-    const std::string data_bank_name = "Tracker clustering data (" + io::TCD_LABEL + ")";
-    TGListTreeItem *item_tracker_cluster =
-        _tracks_list_box_->AddItem(_top_item_, data_bank_name.c_str(),
-                                   _get_colored_icon_("ofolder"), _get_colored_icon_("folder"));
-    item_tracker_cluster->SetCheckBox(false);
-    item_tracker_cluster->SetUserData((void *)(intptr_t)++icheck_id);
-
-    _tracks_list_box_->SetCheckMode(TGListTree::kRecursive);
-    //        _tracks_list_box_->SetCheckBox(item_tracker_cluster);
-    _tracks_list_box_->OpenItem(item_tracker_cluster);
-
-    {
-      std::ostringstream tip_text;
-      if (options_mgr.get_option_flag(DUMP_INTO_TOOLTIP)) {
-        tcd.tree_dump(tip_text);
-      } else {
-        tip_text << "Double click to expand tracker clustering data";
-      }
-      item_tracker_cluster->SetTipText(tip_text.str().c_str());
-    }
-
-    snemo::datamodel::tracker_clustering_data::solution_col_type &cluster_solutions =
-        tcd.grab_solutions();
-    for (snemo::datamodel::tracker_clustering_data::solution_col_type::iterator isolution =
-             cluster_solutions.begin();
-         isolution != cluster_solutions.end(); ++isolution) {
-      // Get current tracker solution:
-      snemo::datamodel::tracker_clustering_solution &a_solution = isolution->grab();
-
-      // Add item:
-      std::ostringstream label_solution;
-      label_solution << "Solution #" << a_solution.get_solution_id() << " - "
-                     << a_solution.get_unclustered_hits().size() << " unclustered hit"
-                     << (a_solution.get_unclustered_hits().size() > 1 ? "s" : "");
-      if (tcd.has_default_solution()) {
-        if (&a_solution == &(tcd.get_default_solution())) {
-          label_solution << " - default";
-        }
-      }
-
-      TGListTreeItem *item_solution =
-          _tracks_list_box_->AddItem(item_tracker_cluster, label_solution.str().c_str(),
-                                     _get_colored_icon_("ofolder"), _get_colored_icon_("folder"));
-      _tracks_list_box_->OpenItem(item_solution);
-      item_solution->SetUserData((void *)(intptr_t)++icheck_id);
-      item_solution->SetCheckBox(true);
-      {
-        // Set tooltip text
-        std::ostringstream tip_text;
-        a_solution.tree_dump(tip_text);
-        item_solution->SetTipText(tip_text.str().c_str());
-      }
-      // Get solution auxiliaries:
-      datatools::properties &a_auxiliaries = a_solution.grab_auxiliaries();
-
-      if (a_auxiliaries.has_key(browser_tracks::CHECKED_FLAG))
-        item_solution->CheckItem(a_auxiliaries.has_flag(browser_tracks::CHECKED_FLAG));
-
-      // Update properties dictionnary:
-      _properties_dictionnary_[icheck_id] = &(a_auxiliaries);
-
-      // Get clusters stored in the current tracker solution:
-      snemo::datamodel::tracker_clustering_solution::cluster_col_type &clusters =
-          a_solution.grab_clusters();
-      for (snemo::datamodel::tracker_clustering_solution::cluster_col_type::iterator icluster =
-               clusters.begin();
-           icluster != clusters.end(); ++icluster) {
-        // Get current tracker cluster:
-        snemo::datamodel::tracker_cluster &a_cluster = icluster->grab();
-
-        // Add subitem:
-        std::ostringstream label_cluster;
-        label_cluster << "Cluster #" << a_cluster.get_cluster_id() << " "
-                      << "(" << a_cluster.get_hits().size() << " hits) ";
-        if (a_cluster.is_prompt()) {
-          label_cluster << "- prompt";
-        } else {
-          label_cluster << "- delayed";
-        }
-
-        TGListTreeItem *item_cluster =
-            _tracks_list_box_->AddItem(item_solution, label_cluster.str().c_str());
-        item_cluster->SetUserData((void *)(intptr_t)++icheck_id);
-        item_cluster->SetCheckBox(true);
-        {
-          // Set tooltip text
-          std::ostringstream tip_text;
-          a_cluster.tree_dump(tip_text);
-          item_cluster->SetTipText(tip_text.str().c_str());
-        }
-        // Get cluster auxiliaries:
-        datatools::properties &aa_auxiliaries = a_cluster.grab_auxiliaries();
-
-        if (aa_auxiliaries.has_key(browser_tracks::CHECKED_FLAG))
-          item_cluster->CheckItem(aa_auxiliaries.has_flag(browser_tracks::CHECKED_FLAG));
-
-        // Update base hit dictionnary:
-        _base_hit_dictionnary_[icheck_id] = &(a_cluster);
-
-        // If color is available, add a color box close to the
-        // item (obsolete since xpm icon can be colorized):
-        std::string hex_str;
-        if (aa_auxiliaries.has_key(browser_tracks::COLOR_FLAG)) {
-          aa_auxiliaries.fetch(browser_tracks::COLOR_FLAG, hex_str);
-          // const size_t color = TColor::GetColor(hex_str.c_str());
-          // item_cluster->SetColor(color);
-        }
-        item_cluster->SetPictures(_get_colored_icon_("cluster", hex_str),
-                                  _get_colored_icon_("cluster", hex_str));
-
-        // Get tracker hits stored in the current tracker cluster:
-        snemo::datamodel::calibrated_tracker_hit::collection_type &hits = a_cluster.grab_hits();
-        for (snemo::datamodel::calibrated_tracker_hit::collection_type::iterator igg = hits.begin();
-             igg != hits.end(); ++igg) {
-          snemo::datamodel::calibrated_tracker_hit &a_gg_hit = igg->grab();
-          // Add subsubitem:
-          std::ostringstream label_hit;
-          label_hit.precision(3);
-          label_hit.setf(std::ios::fixed, std::ios::floatfield);
-          label_hit << "Geiger hit #" << std::setw(2) << std::setfill('0') << a_gg_hit.get_id()
-                    << " (r, z) = (" << a_gg_hit.get_r() / CLHEP::cm << ", "
-                    << a_gg_hit.get_z() / CLHEP::cm << ") cm";
-
-          TGListTreeItem *item_hit = _tracks_list_box_->AddItem(
-              item_cluster, label_hit.str().c_str(), _get_colored_icon_("geiger", hex_str, true),
-              _get_colored_icon_("geiger", hex_str));
-          item_hit->SetUserData((void *)(intptr_t) - (++icheck_id));
-          _base_hit_dictionnary_[-icheck_id] = &(a_gg_hit);
-
-          std::ostringstream tip_text;
-          if (options_mgr.get_option_flag(DUMP_INTO_TOOLTIP)) {
-            a_gg_hit.tree_dump(tip_text);
-          } else {
-            tip_text << "Double click to highlight Geiger hit "
-                     << "and to dump info on terminal";
-          }
-          item_hit->SetTipText(tip_text.str().c_str());
-        }
-      }  // end of cluster loop
-    }    // end of solution loop
-
-    return;
-  }
-
-  void browser_tracks::_update_tracker_trajectory_data() {
-    // Grab event and other resources. Here nothing is constant
-    // since properties will be modified here and used later
-    // through 'checking' and 'double_clicking' actions:
-    io::event_record &event = _server_->grab_event();
-
-    // 'tracker_trajectory_data' availability:
-    if (!event.has(io::TTD_LABEL)) return;
-
-    snemo::datamodel::tracker_trajectory_data &ttd =
-        event.grab<snemo::datamodel::tracker_trajectory_data>(io::TTD_LABEL);
-
-    const options_manager &options_mgr = options_manager::get_instance();
-    if (!options_mgr.get_option_flag(SHOW_TRACKER_TRAJECTORIES)) return;
-
-    // Identifiant for item dictionnary:
-    int &icheck_id = _item_id_;
-
-    // Add 'tracker_clustering_data' item:
-    const std::string data_bank_name = "Tracker trajectory data (" + io::TTD_LABEL + ")";
-    TGListTreeItem *item_tracker_trajectory =
-        _tracks_list_box_->AddItem(_top_item_, data_bank_name.c_str(),
-                                   _get_colored_icon_("ofolder"), _get_colored_icon_("folder"));
-    item_tracker_trajectory->SetCheckBox(false);
-    item_tracker_trajectory->SetUserData((void *)(intptr_t)++icheck_id);
-
-    //        _tracks_list_box_->SetCheckBox(item_tracker_cluster);
-    _tracks_list_box_->OpenItem(item_tracker_trajectory);
-
-    std::ostringstream tip_text;
-    if (options_mgr.get_option_flag(DUMP_INTO_TOOLTIP)) {
-      ttd.tree_dump(tip_text);
-    } else {
-      tip_text << "Double click to expand tracker trajectory data";
-    }
-    item_tracker_trajectory->SetTipText(tip_text.str().c_str());
-
-    if (!ttd.has_solutions()) return;
-
-    snemo::datamodel::tracker_trajectory_data::solution_col_type &trajectory_solutions =
-        ttd.grab_solutions();
-    for (snemo::datamodel::tracker_trajectory_data::solution_col_type::iterator isolution =
-             trajectory_solutions.begin();
-         isolution != trajectory_solutions.end(); ++isolution) {
-      // Get current tracker solution:
-      snemo::datamodel::tracker_trajectory_solution &a_solution = isolution->grab();
-
-      // Add item:
-      std::ostringstream label_solution;
-      label_solution << "Solution #" << a_solution.get_solution_id() << " - "
-                     << a_solution.get_trajectories().size() << " trajector"
-                     << (a_solution.get_trajectories().size() > 1 ? "ies" : "y") << ", "
-                     << a_solution.get_unfitted_clusters().size() << " unfitted cluster"
-                     << (a_solution.get_unfitted_clusters().size() > 1 ? "s" : "");
-      if (ttd.has_default_solution()) {
-        if (&a_solution == &(ttd.get_default_solution())) {
-          label_solution << " - default";
-        }
-      }
-
-      TGListTreeItemStdPlus *item_solution =
-          new TGListTreeItemStdPlus(label_solution.str().c_str(), this,
-                                    _get_colored_icon_("ofolder"), _get_colored_icon_("folder"),
-                                    /*check=*/true);
-      _tracks_list_box_->AddItem(item_tracker_trajectory, item_solution);
-      // TGListTreeItem * item_solution
-      //   = _tracks_list_box_->AddItem(item_tracker_trajectory,
-      //                                 label_solution.str().c_str());
-      _tracks_list_box_->OpenItem(item_solution);
-      item_solution->SetUserData((void *)(intptr_t)++icheck_id);
-
-      // Get solution auxiliaries:
-      datatools::properties &a_auxiliaries = a_solution.grab_auxiliaries();
-
-      if (a_auxiliaries.has_key(browser_tracks::CHECKED_FLAG))
-        item_solution->CheckItem(a_auxiliaries.has_flag(browser_tracks::CHECKED_FLAG));
-
-      // Update properties dictionnary:
-      _properties_dictionnary_[icheck_id] = &(a_auxiliaries);
-
-      // Prepare folder for helix pattern:
-      TGListTreeItem *item_helix_solution = 0;
-
-      // Prepare folder for line pattern:
-      TGListTreeItem *item_line_solution = 0;
-
-      // Get trajectories stored in the current tracker trajectory solution:
-      snemo::datamodel::tracker_trajectory_solution::trajectory_col_type &trajectories =
-          a_solution.grab_trajectories();
-      for (snemo::datamodel::tracker_trajectory_solution::trajectory_col_type::iterator
-               itrajectory = trajectories.begin();
-           itrajectory != trajectories.end(); ++itrajectory) {
-        // Get current tracker trajectory:
-        snemo::datamodel::tracker_trajectory &a_trajectory = itrajectory->grab();
-
-        // Determine trajectory color by getting cluster color:
-        std::string hex_str;
-        if (a_trajectory.has_cluster()) {
-          const snemo::datamodel::tracker_cluster &a_cluster = a_trajectory.get_cluster();
-          const datatools::properties &prop = a_cluster.get_auxiliaries();
-          if (prop.has_key(browser_tracks::COLOR_FLAG)) {
-            prop.fetch(browser_tracks::COLOR_FLAG, hex_str);
-          }
-        }
-
-        // Add subitem:
-        std::ostringstream label_trajectory;
-        //                label_trajectory.setf(ios::fixed, ios::floatfield);
-        datatools::properties &properties = a_trajectory.grab_auxiliaries();
-        if (properties.has_key("chi2") && properties.has_key("ndof")) {
-          const double chi2 = properties.fetch_real("chi2");
-          const size_t ndof = properties.fetch_integer("ndof");
-          label_trajectory << " - chi2/ndf = " << std::setprecision(2) << std::fixed << chi2 << "/"
-                           << std::setprecision(0) << ndof << std::setprecision(2) << std::fixed
-                           << ", p = " << TMath::Prob(chi2, ndof);
-        }
-        if (properties.has_key("t0")) {
-          const double t0 = properties.fetch_real("t0");
-          label_trajectory << std::setprecision(0) << std::fixed << ", t0 = ";
-          utils::root_utilities::get_prettified_time(label_trajectory, t0);
-        }
-        if (properties.has_key("guess")) {
-          label_trajectory << " (" << properties.fetch_string("guess") << " guess)";
-        }
-        bool is_default = false;
-        if (properties.has_flag("default")) {
-          label_trajectory << " - default";
-          is_default = true;
-        }
-
-        TGListTreeItem *item_trajectory = 0;
-        if (a_trajectory.get_pattern().get_pattern_id() ==
-            snemo::datamodel::helix_trajectory_pattern::pattern_id()) {
-          // First time instantiate it
-          if (!item_helix_solution) {
-            item_helix_solution =
-                new TGListTreeItemStdPlus("Helix trajectories", this, _get_colored_icon_("ofolder"),
-                                          _get_colored_icon_("folder"),
-                                          /*check=*/true);
-            _tracks_list_box_->AddItem(item_solution, item_helix_solution);
-            // _tracks_list_box_->OpenItem(item_helix_solution);
-            item_helix_solution->SetUserData((void *)(intptr_t)++icheck_id);
-            if (a_auxiliaries.has_key(browser_tracks::CHECKED_FLAG))
-              item_helix_solution->CheckItem(a_auxiliaries.has_flag(browser_tracks::CHECKED_FLAG));
-            _properties_dictionnary_[icheck_id] = &(a_auxiliaries);
-          }
-
-          item_trajectory = _tracks_list_box_->AddItem(
-              item_helix_solution, std::string("helix" + label_trajectory.str()).c_str(),
-              _get_colored_icon_("helix", hex_str, true), _get_colored_icon_("helix", hex_str));
-        } else if (a_trajectory.get_pattern().get_pattern_id() ==
-                   snemo::datamodel::line_trajectory_pattern::pattern_id()) {
-          // First time instantiate it
-          if (!item_line_solution) {
-            const bool checked = true;
-            item_line_solution =
-                new TGListTreeItemStdPlus("Line trajectories", this, _get_colored_icon_("ofolder"),
-                                          _get_colored_icon_("folder"), checked);
-            _tracks_list_box_->AddItem(item_solution, item_line_solution);
-            // _tracks_list_box_->OpenItem(item_line_solution);
-            item_line_solution->SetUserData((void *)(intptr_t)++icheck_id);
-            if (a_auxiliaries.has_key(browser_tracks::CHECKED_FLAG))
-              item_line_solution->CheckItem(a_auxiliaries.has_flag(browser_tracks::CHECKED_FLAG));
-            _properties_dictionnary_[icheck_id] = &(a_auxiliaries);
-          }
-
-          item_trajectory = _tracks_list_box_->AddItem(
-              item_line_solution, std::string("line" + label_trajectory.str()).c_str(),
-              _get_colored_icon_("line", hex_str, true), _get_colored_icon_("line", hex_str));
-        }
-
-        if (!item_trajectory) continue;
-
-        item_trajectory->SetCheckBox(true);
-        if (is_default) {
-          a_trajectory.grab_auxiliaries().update(CHECKED_FLAG, true);
-          _tracks_list_box_->CheckItem(item_trajectory, true);
-        } else {
-          a_trajectory.grab_auxiliaries().update(CHECKED_FLAG, false);
-          _tracks_list_box_->CheckItem(item_trajectory, false);
-        }
-        item_trajectory->SetUserData((void *)(intptr_t) - (++icheck_id));
-        _base_hit_dictionnary_[-icheck_id] = &(a_trajectory);
-
-        if (options_mgr.get_option_flag(DUMP_INTO_TOOLTIP)) {
-          std::ostringstream oss;
-          a_trajectory.tree_dump(oss);
-          item_trajectory->SetTipText(oss.str().c_str());
-        } else {
-          std::ostringstream message;
-          message << "Double click to highlight trajectory "
-                  << "and to dump info on terminal";
-          item_trajectory->SetTipText(message.str().c_str());
-        }
-      }  // end of trajectory loop
-    }    // end of solution loop
-
-    return;
-  }
-
-  void browser_tracks::_update_particle_track_data() {
-    // Grab event and other resources. Here nothing is constant
-    // since properties will be modified here and used later
-    // through 'checking' and 'double_clicking' actions:
-    io::event_record &event = _server_->grab_event();
-
-    // 'tracker_trajectory_data' availability:
-    if (!event.has(io::PTD_LABEL)) return;
-
-    snemo::datamodel::particle_track_data &ptd =
-        event.grab<snemo::datamodel::particle_track_data>(io::PTD_LABEL);
-
-    const options_manager &options_mgr = options_manager::get_instance();
-    if (!options_mgr.get_option_flag(SHOW_PARTICLE_TRACKS)) return;
-
-    // Identifiant for item dictionnary:
-    int &icheck_id = _item_id_;
-
-    // Add 'tracker_clustering_data' item:
-    const std::string data_bank_name = "Particle track data (" + io::PTD_LABEL + ")";
-    TGListTreeItem *item_particle_track_data =
-        _tracks_list_box_->AddItem(_top_item_, data_bank_name.c_str(),
-                                   _get_colored_icon_("ofolder"), _get_colored_icon_("folder"));
-    item_particle_track_data->SetCheckBox(false);
-    item_particle_track_data->SetUserData((void *)(intptr_t)++icheck_id);
-    _tracks_list_box_->OpenItem(item_particle_track_data);
-    {
-      std::ostringstream tip_text;
-      if (options_mgr.get_option_flag(DUMP_INTO_TOOLTIP)) {
-        ptd.tree_dump(tip_text);
-      } else {
-        tip_text << "Double click to expand particle track data";
-      }
-      item_particle_track_data->SetTipText(tip_text.str().c_str());
-    }
-    // Add unassociated calorimeter hits info
-    if (ptd.has_non_associated_calorimeters()) {
-      snemo::datamodel::calibrated_data::calorimeter_hit_collection_type &cc_collection =
-          ptd.grab_non_associated_calorimeters();
-
-      for (snemo::datamodel::calibrated_data::calorimeter_hit_collection_type::iterator it_hit =
-               cc_collection.begin();
-           it_hit != cc_collection.end(); ++it_hit) {
-        snemo::datamodel::calibrated_calorimeter_hit &a_hit = it_hit->grab();
-
-        // Add subsubitem:
-        std::ostringstream label_hit;
-        label_hit.precision(3);
-        label_hit.setf(std::ios::fixed, std::ios::floatfield);
-        label_hit << "Unassociated ";
-        if (a_hit.get_auxiliaries().has_key("category"))
-          label_hit << a_hit.get_auxiliaries().fetch_string("category") << " block ";
-        label_hit << "hit #" << a_hit.get_hit_id() << " - E = ";
-        utils::root_utilities::get_prettified_energy(label_hit, a_hit.get_energy(),
-                                                     a_hit.get_sigma_energy());
-        label_hit << " - t = ";
-        utils::root_utilities::get_prettified_time(label_hit, a_hit.get_time(),
-                                                   a_hit.get_sigma_time());
-
-        TGListTreeItem *item_hit =
-            _tracks_list_box_->AddItem(item_particle_track_data, label_hit.str().c_str());
-        item_hit->SetUserData((void *)(intptr_t) - (++icheck_id));
-        _base_hit_dictionnary_[-icheck_id] = &(a_hit);
-        item_hit->SetPictures(_get_colored_icon_("calorimeter", "", true),
-                              _get_colored_icon_("calorimeter"));
-
-        {
-          std::ostringstream tip_text;
-          if (options_mgr.get_option_flag(DUMP_INTO_TOOLTIP)) {
-            a_hit.tree_dump(tip_text);
-          } else {
-            tip_text << "Double click to highlight calorimeter hit "
-                     << "and to dump info on terminal";
-          }
-          item_hit->SetTipText(tip_text.str().c_str());
-        }
-      }
-    }
-
-    if (!ptd.has_particles()) return;
-
-    snemo::datamodel::particle_track_data::particle_collection_type &particles =
-        ptd.grab_particles();
-    for (snemo::datamodel::particle_track_data::particle_collection_type::iterator iparticle =
-             particles.begin();
-         iparticle != particles.end(); ++iparticle) {
-      // Get current particle track:
-      snemo::datamodel::particle_track &a_particle = iparticle->grab();
-
-      // Add item:
-      size_t item_color = 0;
-      std::ostringstream label_particle;
-      label_particle << "Particle #" << a_particle.get_track_id();
-      if (a_particle.get_charge() == snemo::datamodel::particle_track::neutral) {
-        label_particle << " - neutral charged particle";
-        item_color = style_manager::get_instance().get_particle_color("gamma");
-      } else if (a_particle.get_charge() == snemo::datamodel::particle_track::negative) {
-        label_particle << " - negative charged particle";
-        item_color = style_manager::get_instance().get_particle_color("electron");
-      } else if (a_particle.get_charge() == snemo::datamodel::particle_track::positive) {
-        label_particle << " - positive charged particle";
-        item_color = style_manager::get_instance().get_particle_color("positron");
-      } else if (a_particle.get_charge() == snemo::datamodel::particle_track::undefined) {
-        label_particle << " - undefined charged particle";
-        item_color = style_manager::get_instance().get_particle_color("alpha");
-      }
-      // Get particle auxiliaries:
-      datatools::properties &a_auxiliaries = a_particle.grab_auxiliaries();
-      // item_color = utils::root_utilities::get_fade_color_from(item_color, 0.5);
-      std::string hex_str = utils::root_utilities::get_hex_color(item_color);
-      if (a_auxiliaries.has_key(browser_tracks::COLOR_FLAG)) {
-        a_auxiliaries.fetch(browser_tracks::COLOR_FLAG, hex_str);
-      }
-
-      TGListTreeItem *item_particle =
-          _tracks_list_box_->AddItem(item_particle_track_data, label_particle.str().c_str());
-      item_particle->SetPictures(_get_colored_icon_("track", hex_str),
-                                 _get_colored_icon_("track", hex_str));
-      item_particle->SetUserData((void *)(intptr_t) - (++icheck_id));
-      item_particle->SetCheckBox(true);
-      item_particle->SetOpen(true);
-      {
-        // Set tooltip text
-        std::ostringstream tip_text;
-        a_particle.tree_dump(tip_text);
-        item_particle->SetTipText(tip_text.str().c_str());
-      }
-      if (a_auxiliaries.has_key(browser_tracks::CHECKED_FLAG))
-        item_particle->CheckItem(a_auxiliaries.has_flag(browser_tracks::CHECKED_FLAG));
-
-      // Update base hit dictionnary:
-      _base_hit_dictionnary_[-icheck_id] = &(a_particle);
-
-      // Update property dictionnary:
-      _properties_dictionnary_[-icheck_id] = &(a_auxiliaries);
-
-      // Get associated vertices
-      if (a_particle.has_vertices()) {
-        snemo::datamodel::particle_track::vertex_collection_type &vts = a_particle.grab_vertices();
-        for (snemo::datamodel::particle_track::vertex_collection_type::iterator ivtx = vts.begin();
-             ivtx != vts.end(); ++ivtx) {
-          geomtools::blur_spot &a_vertex = ivtx->grab();
-
-          std::ostringstream label;
-          label << "Vertex on ";
-          if (snemo::datamodel::particle_track::vertex_is_on_source_foil(a_vertex)) {
-            label << "source foil - ";
-          } else if (snemo::datamodel::particle_track::vertex_is_on_main_calorimeter(a_vertex)) {
-            label << "main calorimeter wall - ";
-          } else if (snemo::datamodel::particle_track::vertex_is_on_x_calorimeter(a_vertex)) {
-            label << "X-calorimeter wall - ";
-          } else if (snemo::datamodel::particle_track::vertex_is_on_gamma_veto(a_vertex)) {
-            label << "gamma veto - ";
-          } else if (snemo::datamodel::particle_track::vertex_is_on_wire(a_vertex)) {
-            label << "wire - ";
-          } else {
-            label << "unkown part of the detector -";
-          }
-          label << "(x, y, z) = ";
-          label.precision(3);
-          label.setf(std::ios::fixed, std::ios::floatfield);
-          label << a_vertex.get_position() / CLHEP::mm << " mm";
-          TGListTreeItem *item_vertex = _tracks_list_box_->AddItem(
-              item_particle, label.str().c_str(), _get_colored_icon_("vertex", hex_str, true),
-              _get_colored_icon_("vertex", hex_str));
-          item_vertex->SetCheckBox(false);
-          item_vertex->SetUserData((void *)(intptr_t) - (++icheck_id));
-          // Update properties dictionnary:
-          _properties_dictionnary_[-icheck_id] = &(a_vertex.grab_auxiliaries());
-          {
-            std::ostringstream tip_text;
-            if (options_mgr.get_option_flag(DUMP_INTO_TOOLTIP)) {
-              a_vertex.tree_dump(tip_text);
-            } else {
-              tip_text << "Double click to highlight vertex position "
-                       << "and to dump info on terminal";
-            }
-            item_vertex->SetTipText(tip_text.str().c_str());
-          }
-        }  // end of vertex list
-      }    // end of vertex check
-
-      // Get associated calorimeter
-      if (a_particle.has_associated_calorimeter_hits()) {
-        snemo::datamodel::calibrated_data::calorimeter_hit_collection_type &cc_collection =
-            a_particle.grab_associated_calorimeter_hits();
-
-        for (snemo::datamodel::calibrated_data::calorimeter_hit_collection_type::iterator it_hit =
-                 cc_collection.begin();
-             it_hit != cc_collection.end(); ++it_hit) {
-          snemo::datamodel::calibrated_calorimeter_hit &a_hit = it_hit->grab();
-
-          // Add subsubitem:
-          std::ostringstream label_hit;
-          label_hit.precision(3);
-          label_hit.setf(std::ios::fixed, std::ios::floatfield);
-          if (a_hit.get_auxiliaries().has_key("category"))
-            label_hit << a_hit.get_auxiliaries().fetch_string("category") << " ";
-          label_hit << "hit #" << a_hit.get_hit_id() << " - E = ";
-          utils::root_utilities::get_prettified_energy(label_hit, a_hit.get_energy(),
-                                                       a_hit.get_sigma_energy());
-          label_hit << " - t = ";
-          utils::root_utilities::get_prettified_time(label_hit, a_hit.get_time(),
-                                                     a_hit.get_sigma_time());
-
-          TGListTreeItem *item_hit =
-              _tracks_list_box_->AddItem(item_particle, label_hit.str().c_str(),
-                                         _get_colored_icon_("calorimeter", hex_str, true),
-                                         _get_colored_icon_("calorimeter", hex_str));
-          item_hit->SetUserData((void *)(intptr_t) - (++icheck_id));
-          _base_hit_dictionnary_[-icheck_id] = &(a_hit);
-
-          std::ostringstream tip_text;
-          if (options_mgr.get_option_flag(DUMP_INTO_TOOLTIP)) {
-            a_hit.tree_dump(tip_text);
-          } else {
-            tip_text << "Double click to highlight calorimeter hit "
-                     << "and to dump info on terminal";
-          }
-          item_hit->SetTipText(tip_text.str().c_str());
-        }  // end of associated calorimeter hits
-      }    // end of calorimeter hits check
-    }      // end of particle loop
-    return;
-  }
-
-  datatools::properties *browser_tracks::get_item_properties(const int id_) {
-    // Search in which dictionnary the item comes from:
-    datatools::properties *properties = 0;
-    {
-      // First looking in 'properties' dictionnary:
-      std::map<int, datatools::properties *>::iterator found = _properties_dictionnary_.find(id_);
-
-      if (found != _properties_dictionnary_.end()) {
-        properties = found->second;
-      }
-    }
-
-    {
-      // Then looking in 'base_hit' dictionnary:
-      std::map<int, geomtools::base_hit *>::iterator found = _base_hit_dictionnary_.find(id_);
-
-      if (found != _base_hit_dictionnary_.end()) {
-        properties = &(found->second->grab_auxiliaries());
-      }
-    }
-    return properties;
-  }
-
-  geomtools::base_hit *browser_tracks::get_base_hit(const int id_) {
+      }  // end of associated calorimeter hits
+    }    // end of calorimeter hits check
+  }      // end of particle loop
+  return;
+}
+
+datatools::properties *browser_tracks::get_item_properties(const int id_) {
+  // Search in which dictionnary the item comes from:
+  datatools::properties *properties = 0;
+  {
     // First looking in 'properties' dictionnary:
+    std::map<int, datatools::properties *>::iterator found = _properties_dictionnary_.find(id_);
+
+    if (found != _properties_dictionnary_.end()) {
+      properties = found->second;
+    }
+  }
+
+  {
+    // Then looking in 'base_hit' dictionnary:
     std::map<int, geomtools::base_hit *>::iterator found = _base_hit_dictionnary_.find(id_);
 
     if (found != _base_hit_dictionnary_.end()) {
-      return found->second;
+      properties = &(found->second->grab_auxiliaries());
     }
+  }
+  return properties;
+}
 
+geomtools::base_hit *browser_tracks::get_base_hit(const int id_) {
+  // First looking in 'properties' dictionnary:
+  std::map<int, geomtools::base_hit *>::iterator found = _base_hit_dictionnary_.find(id_);
+
+  if (found != _base_hit_dictionnary_.end()) {
+    return found->second;
+  }
+
+  return 0;
+}
+
+void browser_tracks::item_checked(TObject *object_, bool is_checked_) {
+  const int i = (intptr_t)object_;
+
+  // Search in which dictionnary the item comes from:
+  datatools::properties *properties = get_item_properties(i);
+
+  // Non referenced item id:
+  if (!properties) return;
+
+  properties->update(CHECKED_FLAG, is_checked_);
+
+  _browser_->track_select();
+  return;
+}
+
+void browser_tracks::item_selected(TGListTreeItem *item_, int /*button_*/) {
+  const int i = (intptr_t)item_->GetUserData();
+
+  // Positive id means nothing to do:
+  if (i > 0) return;
+
+  // Search in which dictionnary the item comes from:
+  datatools::properties *properties = get_item_properties(i);
+  // Non referenced item id:
+  if (!properties) return;
+
+  properties->update(HIGHLIGHT_FLAG, !properties->has_flag(HIGHLIGHT_FLAG));
+
+  if (options_manager::get_instance().get_option_flag(DUMP_INTO_TERMINAL)) {
+    // Dump info on terminal
+    geomtools::base_hit *bh = get_base_hit(i);
+
+    if (bh) bh->dump();
+  }
+
+  _browser_->track_select();
+  return;
+}
+
+const TGPicture *browser_tracks::_get_colored_icon_(const std::string &icon_type_,
+                                                    const std::string &hex_color_,
+                                                    const bool reverse_color_) {
+  // xpm image are defined in browser_icons.h file
+  //
+  // Build icon name and look inside icon dictionnary:
+  const std::string icon_name = icon_type_ + hex_color_ + (reverse_color_ ? "reverse" : "");
+
+  std::map<std::string, const TGPicture *>::const_iterator found = _icons_.find(icon_name);
+
+  if (found != _icons_.end()) return found->second;
+
+  // Otherwise create new entry:
+  const char **xpm = 0;
+  if (icon_type_ == "vertex")
+    xpm = xpm_vertex;
+  else if (icon_type_ == "calorimeter")
+    xpm = xpm_calorimeter;
+  else if (icon_type_ == "geiger")
+    xpm = xpm_geiger;
+  else if (icon_type_ == "cluster")
+    xpm = xpm_cluster;
+  else if (icon_type_ == "helix")
+    xpm = xpm_helix;
+  else if (icon_type_ == "line")
+    xpm = xpm_line;
+  else if (icon_type_ == "step")
+    xpm = xpm_step;
+  else if (icon_type_ == "track")
+    xpm = xpm_track;
+  else if (icon_type_ == "flag")
+    xpm = xpm_flag;
+  else if (icon_type_ == "folder")
+    xpm = xpm_folder;
+  else if (icon_type_ == "ofolder")
+    xpm = xpm_ofolder;
+  else
     return 0;
-  }
 
-  void browser_tracks::item_checked(TObject *object_, bool is_checked_) {
-    const int i = (intptr_t)object_;
-
-    // Search in which dictionnary the item comes from:
-    datatools::properties *properties = get_item_properties(i);
-
-    // Non referenced item id:
-    if (!properties) return;
-
-    properties->update(CHECKED_FLAG, is_checked_);
-
-    _browser_->track_select();
-    return;
-  }
-
-  void browser_tracks::item_selected(TGListTreeItem *item_, int /*button_*/) {
-    const int i = (intptr_t)item_->GetUserData();
-
-    // Positive id means nothing to do:
-    if (i > 0) return;
-
-    // Search in which dictionnary the item comes from:
-    datatools::properties *properties = get_item_properties(i);
-    // Non referenced item id:
-    if (!properties) return;
-
-    properties->update(HIGHLIGHT_FLAG, !properties->has_flag(HIGHLIGHT_FLAG));
-
-    if (options_manager::get_instance().get_option_flag(DUMP_INTO_TERMINAL)) {
-      // Dump info on terminal
-      geomtools::base_hit *bh = get_base_hit(i);
-
-      if (bh) bh->dump();
+  // Change color:
+  if (icon_type_ != "folder" && icon_type_ != "ofolder") {
+    std::string color = "#303030";
+    if (!hex_color_.empty()) color = hex_color_;
+    if (reverse_color_) {
+      const std::string bg = ". c " + color;
+      xpm[1] = bg.c_str();
+      xpm[2] = "# c None";
+    } else {
+      const std::string fg = "# c " + color;
+      xpm[1] = ". c None";
+      xpm[2] = fg.c_str();
     }
-
-    _browser_->track_select();
-    return;
   }
 
-  const TGPicture *browser_tracks::_get_colored_icon_(const std::string &icon_type_,
-                                                      const std::string &hex_color_,
-                                                      const bool reverse_color_) {
-    // xpm image are defined in browser_icons.h file
-    //
-    // Build icon name and look inside icon dictionnary:
-    const std::string icon_name = icon_type_ + hex_color_ + (reverse_color_ ? "reverse" : "");
+  // Create a picture from the XPM data:
+  TGPicturePool *picpool = gClient->GetResourcePool()->GetPicturePool();
+  const TGPicture *iconpic = picpool->GetPicture(icon_name.c_str(), const_cast<char **>(xpm));
 
-    std::map<std::string, const TGPicture *>::const_iterator found = _icons_.find(icon_name);
+  // Add new picture to dictionnary:
+  _icons_[icon_name] = iconpic;
 
-    if (found != _icons_.end()) return found->second;
+  return iconpic;
+}
 
-    // Otherwise create new entry:
-    const char **xpm = 0;
-    if (icon_type_ == "vertex")
-      xpm = xpm_vertex;
-    else if (icon_type_ == "calorimeter")
-      xpm = xpm_calorimeter;
-    else if (icon_type_ == "geiger")
-      xpm = xpm_geiger;
-    else if (icon_type_ == "cluster")
-      xpm = xpm_cluster;
-    else if (icon_type_ == "helix")
-      xpm = xpm_helix;
-    else if (icon_type_ == "line")
-      xpm = xpm_line;
-    else if (icon_type_ == "step")
-      xpm = xpm_step;
-    else if (icon_type_ == "track")
-      xpm = xpm_track;
-    else if (icon_type_ == "flag")
-      xpm = xpm_flag;
-    else if (icon_type_ == "folder")
-      xpm = xpm_folder;
-    else if (icon_type_ == "ofolder")
-      xpm = xpm_ofolder;
-    else
-      return 0;
+}  // end of namespace view
 
-    // Change color:
-    if (icon_type_ != "folder" && icon_type_ != "ofolder") {
-      std::string color = "#303030";
-      if (!hex_color_.empty()) color = hex_color_;
-      if (reverse_color_) {
-        const std::string bg = ". c " + color;
-        xpm[1] = bg.c_str();
-        xpm[2] = "# c None";
-      } else {
-        const std::string fg = "# c " + color;
-        xpm[1] = ". c None";
-        xpm[2] = fg.c_str();
-      }
-    }
-
-    // Create a picture from the XPM data:
-    TGPicturePool *picpool = gClient->GetResourcePool()->GetPicturePool();
-    const TGPicture *iconpic = picpool->GetPicture(icon_name.c_str(), const_cast<char **>(xpm));
-
-    // Add new picture to dictionnary:
-    _icons_[icon_name] = iconpic;
-
-    return iconpic;
-  }
-
-  }  // end of namespace view
-
-  }  // end of namespace visualization
+}  // end of namespace visualization
 
 }  // end of namespace snemo
 

--- a/modules/EventBrowser/source/browser_tracks.cc
+++ b/modules/EventBrowser/source/browser_tracks.cc
@@ -58,7 +58,7 @@
 #include <falaise/snemo/datamodels/helix_trajectory_pattern.h>
 #include <falaise/snemo/datamodels/line_trajectory_pattern.h>
 
-ClassImp(snemo::visualization::view::browser_tracks)
+ClassImp(snemo::visualization::view::browser_tracks);
 
     namespace snemo {
   namespace visualization {

--- a/modules/EventBrowser/source/browser_tracks.cc
+++ b/modules/EventBrowser/source/browser_tracks.cc
@@ -58,7 +58,11 @@
 #include <falaise/snemo/datamodels/helix_trajectory_pattern.h>
 #include <falaise/snemo/datamodels/line_trajectory_pattern.h>
 
+// Need trailing ; to satisfy clang-format, but leads to -pedantic error, ignore
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 ClassImp(snemo::visualization::view::browser_tracks);
+#pragma GCC diagnostic pop
 
 namespace snemo {
 namespace visualization {

--- a/modules/EventBrowser/source/display_2d.cc
+++ b/modules/EventBrowser/source/display_2d.cc
@@ -39,157 +39,157 @@
 
 ClassImp(snemo::visualization::view::display_2d);
 
-    namespace snemo {
-  namespace visualization {
+namespace snemo {
+namespace visualization {
 
-  namespace view {
+namespace view {
 
-  void display_2d::set_view_type(const view_type vtype_) {
-    _2d_viewer_->set_view_type(vtype_);
-    return;
-  }
+void display_2d::set_view_type(const view_type vtype_) {
+  _2d_viewer_->set_view_type(vtype_);
+  return;
+}
 
-  // ctor:
-  display_2d::display_2d(TGCompositeFrame* main_, io::event_server* server_, const bool switch_mode)
-      : _server_(server_), _2d_drawer_(0), _2d_viewer_(0) {
-    const int width = main_->GetWidth();
-    const int height = main_->GetHeight();
+// ctor:
+display_2d::display_2d(TGCompositeFrame* main_, io::event_server* server_, const bool switch_mode)
+    : _server_(server_), _2d_drawer_(0), _2d_viewer_(0) {
+  const int width = main_->GetWidth();
+  const int height = main_->GetHeight();
 
 #ifdef SNVISUALIZATION_USE_OPENGL
-    // One can compile snvsiualization using ROOT implementation
-    // of OpenGL but then decide not to use it.
-    if (style_manager::get_instance().use_opengl()) {
-      _2d_viewer_ =
-          new opengl_embedded_viewer("2DPlot", main_, width, height, i_embedded_viewer::VIEW_2D);
-    } else
+  // One can compile snvsiualization using ROOT implementation
+  // of OpenGL but then decide not to use it.
+  if (style_manager::get_instance().use_opengl()) {
+    _2d_viewer_ =
+        new opengl_embedded_viewer("2DPlot", main_, width, height, i_embedded_viewer::VIEW_2D);
+  } else
 #endif
 
-      _2d_viewer_ =
-          new pad_embedded_viewer("2DPlot", main_, width, height, i_embedded_viewer::VIEW_2D);
+    _2d_viewer_ =
+        new pad_embedded_viewer("2DPlot", main_, width, height, i_embedded_viewer::VIEW_2D);
 
-    main_->AddFrame(_2d_viewer_->get_frame(), new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
+  main_->AddFrame(_2d_viewer_->get_frame(), new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
 
-    if (switch_mode) {
-      // 2D different views
-      TGHButtonGroup* views = new TGHButtonGroup(main_);
+  if (switch_mode) {
+    // 2D different views
+    TGHButtonGroup* views = new TGHButtonGroup(main_);
 
-      // 2012-06-08 XG: Reminder (see Trac/Ticket #10)
-      // front_view == YZ view
-      // side_view  == XZ view
-      // top view   == XY view
-      const unsigned int n_view = 3;
-      const std::string view_str[n_view] = {" top view ", " side view ", " front view "};
+    // 2012-06-08 XG: Reminder (see Trac/Ticket #10)
+    // front_view == YZ view
+    // side_view  == XZ view
+    // top view   == XY view
+    const unsigned int n_view = 3;
+    const std::string view_str[n_view] = {" top view ", " side view ", " front view "};
 
-      for (unsigned int i_view = 0; i_view < n_view; ++i_view) {
-        const view_type view_id = static_cast<view_type>(i_view);
+    for (unsigned int i_view = 0; i_view < n_view; ++i_view) {
+      const view_type view_id = static_cast<view_type>(i_view);
 
-        TGRadioButton* view = new TGRadioButton(views, view_str[i_view].c_str(), view_id);
+      TGRadioButton* view = new TGRadioButton(views, view_str[i_view].c_str(), view_id);
 
-        if (view_id == _2d_viewer_->get_view_type())
-          view->SetState(kButtonDown);
-        else
-          view->SetState(kButtonUp);
+      if (view_id == _2d_viewer_->get_view_type())
+        view->SetState(kButtonDown);
+      else
+        view->SetState(kButtonUp);
 
-        view->Connect("Clicked()", "snemo::visualization::view::display_2d", this,
-                      "process_option_buttons()");
-      }
-
-      main_->AddFrame(views, new TGLayoutHints(kLHintsCenterX));
+      view->Connect("Clicked()", "snemo::visualization::view::display_2d", this,
+                    "process_option_buttons()");
     }
 
-    return;
+    main_->AddFrame(views, new TGLayoutHints(kLHintsCenterX));
   }
 
-  // dtor:
-  display_2d::~display_2d() {
-    this->clear();
+  return;
+}
 
-    if (_2d_viewer_) {
-      delete _2d_viewer_;
-      _2d_viewer_ = 0;
-    }
-    return;
+// dtor:
+display_2d::~display_2d() {
+  this->clear();
+
+  if (_2d_viewer_) {
+    delete _2d_viewer_;
+    _2d_viewer_ = 0;
   }
+  return;
+}
 
-  void display_2d::set_drawer(i_draw_manager* draw_manager_) {
-    _2d_drawer_ = draw_manager_;
-    return;
-  }
+void display_2d::set_drawer(i_draw_manager* draw_manager_) {
+  _2d_drawer_ = draw_manager_;
+  return;
+}
 
-  void display_2d::clear() {
-    _2d_viewer_->clear();
-    return;
-  }
+void display_2d::clear() {
+  _2d_viewer_->clear();
+  return;
+}
 
-  void display_2d::reset() {
-    _2d_viewer_->reset();
-    return;
-  }
+void display_2d::reset() {
+  _2d_viewer_->reset();
+  return;
+}
 
-  void display_2d::update_detector() {
-    _2d_viewer_->update_detector();
-    return;
-  }
+void display_2d::update_detector() {
+  _2d_viewer_->update_detector();
+  return;
+}
 
-  void display_2d::update_scene() {
-    _2d_viewer_->update_scene(_2d_drawer_);
-    return;
-  }
+void display_2d::update_scene() {
+  _2d_viewer_->update_scene(_2d_drawer_);
+  return;
+}
 
-  void display_2d::process_option_buttons() {
-    TGButton* button = (TGButton*)gTQSender;
-    const view_type view_id = static_cast<view_type>(button->WidgetId());
+void display_2d::process_option_buttons() {
+  TGButton* button = (TGButton*)gTQSender;
+  const view_type view_id = static_cast<view_type>(button->WidgetId());
 
-    set_view_type(view_id);
-    return;
-  }
+  set_view_type(view_id);
+  return;
+}
 
-  void display_2d::handle_button_signals(const button_signals_type signal_) {
-    TCanvas* canvas = (TCanvas*)_2d_viewer_->get_canvas();
+void display_2d::handle_button_signals(const button_signals_type signal_) {
+  TCanvas* canvas = (TCanvas*)_2d_viewer_->get_canvas();
 
-    switch (signal_) {
-      case PRINT_2D_AS_EPS: {
-        std::ostringstream filename;
-        filename << style_manager::get_instance().get_save_prefix()
-                 << _server_->get_current_event_number();
-        switch (_2d_viewer_->get_view_type()) {
-          case TOP_VIEW:
-            filename << "_top";
-            break;
-          case SIDE_VIEW:
-            filename << "_side";
-            break;
-          case FRONT_VIEW:
-            filename << "_front";
-            break;
-          default:
-            break;
-        }
-        filename << ".eps";
-
-        if (!utils::root_utilities::save_view_as(canvas, filename.str())) {
-          DT_LOG_ERROR(view::options_manager::get_instance().get_logging_priority(),
-                       "Can not save 2D view!");
-        }
-      } break;
-
-      case PRINT_2D: {
-        if (!utils::root_utilities::save_view_as(canvas)) {
-          DT_LOG_ERROR(view::options_manager::get_instance().get_logging_priority(),
-                       "Can not save 2D view!");
-        }
-        break;
+  switch (signal_) {
+    case PRINT_2D_AS_EPS: {
+      std::ostringstream filename;
+      filename << style_manager::get_instance().get_save_prefix()
+               << _server_->get_current_event_number();
+      switch (_2d_viewer_->get_view_type()) {
+        case TOP_VIEW:
+          filename << "_top";
+          break;
+        case SIDE_VIEW:
+          filename << "_side";
+          break;
+        case FRONT_VIEW:
+          filename << "_front";
+          break;
+        default:
+          break;
       }
-      default:
+      filename << ".eps";
+
+      if (!utils::root_utilities::save_view_as(canvas, filename.str())) {
         DT_LOG_ERROR(view::options_manager::get_instance().get_logging_priority(),
-                     "Unknown id button");
-        break;
+                     "Can not save 2D view!");
+      }
+    } break;
+
+    case PRINT_2D: {
+      if (!utils::root_utilities::save_view_as(canvas)) {
+        DT_LOG_ERROR(view::options_manager::get_instance().get_logging_priority(),
+                     "Can not save 2D view!");
+      }
+      break;
     }
+    default:
+      DT_LOG_ERROR(view::options_manager::get_instance().get_logging_priority(),
+                   "Unknown id button");
+      break;
   }
+}
 
-  }  // end of namespace view
+}  // end of namespace view
 
-  }  // end of namespace visualization
+}  // end of namespace visualization
 
 }  // end of namespace snemo
 

--- a/modules/EventBrowser/source/display_2d.cc
+++ b/modules/EventBrowser/source/display_2d.cc
@@ -37,7 +37,11 @@
 #include <TGButtonGroup.h>
 #include <TGFrame.h>
 
+// Need trailing ; to satisfy clang-format, but leads to -pedantic error, ignore
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 ClassImp(snemo::visualization::view::display_2d);
+#pragma GCC diagnostic pop
 
 namespace snemo {
 namespace visualization {

--- a/modules/EventBrowser/source/display_2d.cc
+++ b/modules/EventBrowser/source/display_2d.cc
@@ -37,7 +37,7 @@
 #include <TGButtonGroup.h>
 #include <TGFrame.h>
 
-ClassImp(snemo::visualization::view::display_2d)
+ClassImp(snemo::visualization::view::display_2d);
 
     namespace snemo {
   namespace visualization {

--- a/modules/EventBrowser/source/display_3d.cc
+++ b/modules/EventBrowser/source/display_3d.cc
@@ -44,7 +44,7 @@
 #include <iostream>
 #include <stdexcept>
 
-ClassImp(snemo::visualization::view::display_3d)
+ClassImp(snemo::visualization::view::display_3d);
 
     namespace snemo {
   namespace visualization {

--- a/modules/EventBrowser/source/display_3d.cc
+++ b/modules/EventBrowser/source/display_3d.cc
@@ -46,118 +46,118 @@
 
 ClassImp(snemo::visualization::view::display_3d);
 
-    namespace snemo {
-  namespace visualization {
+namespace snemo {
+namespace visualization {
 
-  namespace view {
+namespace view {
 
-  // ctor:
-  display_3d::display_3d(TGCompositeFrame *main_, io::event_server *server_)
-      : _server_(server_), _3d_drawer_(0), _3d_viewer_(0) {
-    const int width = main_->GetWidth();
-    const int height = main_->GetHeight();
+// ctor:
+display_3d::display_3d(TGCompositeFrame *main_, io::event_server *server_)
+    : _server_(server_), _3d_drawer_(0), _3d_viewer_(0) {
+  const int width = main_->GetWidth();
+  const int height = main_->GetHeight();
 
 #ifdef SNVISUALIZATION_USE_OPENGL
-    // One can compile snvsiualization using ROOT implementation
-    // of OpenGL but then decide not to use it.
-    if (style_manager::get_instance().use_opengl()) {
-      _3d_viewer_ =
-          new opengl_embedded_viewer("3DPlot", main_, width, height, i_embedded_viewer::VIEW_3D);
-    } else
+  // One can compile snvsiualization using ROOT implementation
+  // of OpenGL but then decide not to use it.
+  if (style_manager::get_instance().use_opengl()) {
+    _3d_viewer_ =
+        new opengl_embedded_viewer("3DPlot", main_, width, height, i_embedded_viewer::VIEW_3D);
+  } else
 #endif
-      _3d_viewer_ =
-          new pad_embedded_viewer("3DPlot", main_, width, height, i_embedded_viewer::VIEW_3D);
+    _3d_viewer_ =
+        new pad_embedded_viewer("3DPlot", main_, width, height, i_embedded_viewer::VIEW_3D);
 
-    main_->AddFrame(_3d_viewer_->get_frame(), new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
+  main_->AddFrame(_3d_viewer_->get_frame(), new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
 
-    // TGHorizontalFrame* hzoom = new TGHorizontalFrame (main_,
-    //                                                   static_cast<int> (0.99*width),
-    //                                                   static_cast<int> (0.38*height));
+  // TGHorizontalFrame* hzoom = new TGHorizontalFrame (main_,
+  //                                                   static_cast<int> (0.99*width),
+  //                                                   static_cast<int> (0.38*height));
 
-    // main_->AddFrame (hzoom, new TGLayoutHints (kLHintsExpandX, 3, 3, 3, 3));
+  // main_->AddFrame (hzoom, new TGLayoutHints (kLHintsExpandX, 3, 3, 3, 3));
 
-    // hzoom->AddFrame (new TGLabel (hzoom, "Zoom to: "),
-    //                  new TGLayoutHints (kLHintsCenterY, 1, 1, 1, 1));
+  // hzoom->AddFrame (new TGLabel (hzoom, "Zoom to: "),
+  //                  new TGLayoutHints (kLHintsCenterY, 1, 1, 1, 1));
 
-    // TGComboBox* area_list = new TGComboBox (hzoom, AREA_ZOOM_LIST);
-    // hzoom->AddFrame (area_list,
-    //                  new TGLayoutHints (kLHintsCenterY|kLHintsLeft, 1, 1, 1, 1));
-    // area_list->Resize (static_cast<int> (0.2*width), 20);
-    // detList->Associate(theBrowser);
+  // TGComboBox* area_list = new TGComboBox (hzoom, AREA_ZOOM_LIST);
+  // hzoom->AddFrame (area_list,
+  //                  new TGLayoutHints (kLHintsCenterY|kLHintsLeft, 1, 1, 1, 1));
+  // area_list->Resize (static_cast<int> (0.2*width), 20);
+  // detList->Associate(theBrowser);
 
-    return;
-  }
+  return;
+}
 
-  // dtor:
-  display_3d::~display_3d() {
-    this->clear();
+// dtor:
+display_3d::~display_3d() {
+  this->clear();
 
-    delete _3d_viewer_;
-    return;
-  }
+  delete _3d_viewer_;
+  return;
+}
 
-  void display_3d::set_drawer(i_draw_manager *draw_manager_) {
-    _3d_drawer_ = draw_manager_;
-    return;
-  }
+void display_3d::set_drawer(i_draw_manager *draw_manager_) {
+  _3d_drawer_ = draw_manager_;
+  return;
+}
 
-  void display_3d::clear() {
-    _3d_viewer_->clear();
-    return;
-  }
+void display_3d::clear() {
+  _3d_viewer_->clear();
+  return;
+}
 
-  void display_3d::reset() {
-    _3d_viewer_->reset();
-    return;
-  }
+void display_3d::reset() {
+  _3d_viewer_->reset();
+  return;
+}
 
-  void display_3d::update_detector() {
-    _3d_viewer_->update_detector();
-    return;
-  }
+void display_3d::update_detector() {
+  _3d_viewer_->update_detector();
+  return;
+}
 
-  void display_3d::update_scene() {
-    _3d_viewer_->update_scene(_3d_drawer_);
-    return;
-  }
+void display_3d::update_scene() {
+  _3d_viewer_->update_scene(_3d_drawer_);
+  return;
+}
 
-  void display_3d::handle_button_signals(const button_signals_type signal_) {
-    TCanvas *canvas = (TCanvas *)_3d_viewer_->get_canvas();
+void display_3d::handle_button_signals(const button_signals_type signal_) {
+  TCanvas *canvas = (TCanvas *)_3d_viewer_->get_canvas();
 
-    switch (signal_) {
-      case VIEW_X3D:
-        ((TPad *)(canvas->GetPad(0)))->GetViewer3D("x3d");
-        break;
+  switch (signal_) {
+    case VIEW_X3D:
+      ((TPad *)(canvas->GetPad(0)))->GetViewer3D("x3d");
+      break;
 
-      case VIEW_OGL:
-        ((TPad *)(canvas->GetPad(0)))->GetViewer3D("ogl");
-        break;
+    case VIEW_OGL:
+      ((TPad *)(canvas->GetPad(0)))->GetViewer3D("ogl");
+      break;
 
-      case PRINT_3D_AS_EPS: {
-        std::ostringstream filename;
-        filename << style_manager::get_instance().get_save_prefix()
-                 << _server_->get_current_event_number() << ".eps";
+    case PRINT_3D_AS_EPS: {
+      std::ostringstream filename;
+      filename << style_manager::get_instance().get_save_prefix()
+               << _server_->get_current_event_number() << ".eps";
 
-        if (!utils::root_utilities::save_view_as(canvas, filename.str())) {
-          DT_LOG_ERROR(datatools::logger::PRIO_ERROR, "Can't save 3D view!");
-        }
-      } break;
-
-      case PRINT_3D: {
-        if (!utils::root_utilities::save_view_as(canvas)) {
-          DT_LOG_ERROR(datatools::logger::PRIO_ERROR, "Can't save 3D view!");
-        }
-        break;
+      if (!utils::root_utilities::save_view_as(canvas, filename.str())) {
+        DT_LOG_ERROR(datatools::logger::PRIO_ERROR, "Can't save 3D view!");
       }
-      default:
-        DT_LOG_ERROR(datatools::logger::PRIO_ERROR, "Unknown id button");
-        break;
+    } break;
+
+    case PRINT_3D: {
+      if (!utils::root_utilities::save_view_as(canvas)) {
+        DT_LOG_ERROR(datatools::logger::PRIO_ERROR, "Can't save 3D view!");
+      }
+      break;
     }
+    default:
+      DT_LOG_ERROR(datatools::logger::PRIO_ERROR, "Unknown id button");
+      break;
   }
+}
 
-  }  // end of namespace view
+}  // end of namespace view
 
-  }  // end of namespace visualization
+}  // end of namespace visualization
 
 }  // end of namespace snemo
 

--- a/modules/EventBrowser/source/display_3d.cc
+++ b/modules/EventBrowser/source/display_3d.cc
@@ -44,7 +44,11 @@
 #include <iostream>
 #include <stdexcept>
 
+// Need trailing ; to satisfy clang-format, but leads to -pedantic error, ignore
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 ClassImp(snemo::visualization::view::display_3d);
+#pragma GCC diagnostic pop
 
 namespace snemo {
 namespace visualization {

--- a/modules/EventBrowser/source/display_options.cc
+++ b/modules/EventBrowser/source/display_options.cc
@@ -54,7 +54,7 @@
 // - Falaise
 #include <falaise/resource.h>
 
-ClassImp(snemo::visualization::view::display_options)
+ClassImp(snemo::visualization::view::display_options);
 
     namespace snemo {
   namespace visualization {

--- a/modules/EventBrowser/source/display_options.cc
+++ b/modules/EventBrowser/source/display_options.cc
@@ -56,635 +56,631 @@
 
 ClassImp(snemo::visualization::view::display_options);
 
-    namespace snemo {
-  namespace visualization {
+namespace snemo {
+namespace visualization {
 
-  namespace view {
+namespace view {
 
-  bool display_options::is_initialized() const { return _initialized_; }
+bool display_options::is_initialized() const { return _initialized_; }
 
-  // ctor:
-  display_options::display_options() {
-    _initialized_ = false;
-    _browser_ = 0;
-    _main_ = 0;
-    return;
-  }
+// ctor:
+display_options::display_options() {
+  _initialized_ = false;
+  _browser_ = 0;
+  _main_ = 0;
+  return;
+}
 
-  // dtor:
-  display_options::~display_options() {
-    this->reset();
-    return;
-  }
+// dtor:
+display_options::~display_options() {
+  this->reset();
+  return;
+}
 
-  void display_options::initialize(TGCompositeFrame* main_) {
-    DT_THROW_IF(is_initialized(), std::logic_error, "Already initialized !");
-    this->_at_init_(main_);
-    _initialized_ = true;
-    return;
-  }
+void display_options::initialize(TGCompositeFrame* main_) {
+  DT_THROW_IF(is_initialized(), std::logic_error, "Already initialized !");
+  this->_at_init_(main_);
+  _initialized_ = true;
+  return;
+}
 
-  void display_options::_at_init_(TGCompositeFrame* main_) {
-    // Keep track of main frame in order to regenerate it for
-    // different detector setup
-    _main_ = main_;
-    _main_->SetCleanup(kDeepCleanup);
+void display_options::_at_init_(TGCompositeFrame* main_) {
+  // Keep track of main frame in order to regenerate it for
+  // different detector setup
+  _main_ = main_;
+  _main_->SetCleanup(kDeepCleanup);
 
-    // event browser frame : this sucks but this is needed to
-    // connect button with action. In order to instantiate
-    // properly the number of parent, one has to count how many
-    // frames have been instantiated until here
-    TGCompositeFrame* parent = (TGCompositeFrame*)_main_->GetParent()
-                                   ->GetParent()
-                                   ->GetParent()
-                                   ->GetParent()
-                                   ->GetParent()
-                                   ->GetParent();
+  // event browser frame : this sucks but this is needed to
+  // connect button with action. In order to instantiate
+  // properly the number of parent, one has to count how many
+  // frames have been instantiated until here
+  TGCompositeFrame* parent = (TGCompositeFrame*)_main_->GetParent()
+                                 ->GetParent()
+                                 ->GetParent()
+                                 ->GetParent()
+                                 ->GetParent()
+                                 ->GetParent();
 
-    _browser_ = dynamic_cast<event_browser*>(parent);
-    DT_THROW_IF(!_browser_, std::logic_error, "Event_browser can't be cast from frame!");
+  _browser_ = dynamic_cast<event_browser*>(parent);
+  DT_THROW_IF(!_browser_, std::logic_error, "Event_browser can't be cast from frame!");
 
-    this->_at_construct_();
-    return;
-  }
+  this->_at_construct_();
+  return;
+}
 
-  void display_options::_at_construct_() {
-    // Volume and particles properties
-    this->_build_volume_buttons_();
-    this->_build_particle_buttons_();
-    this->_build_misc_buttons_();
-    this->_set_button_values_();
+void display_options::_at_construct_() {
+  // Volume and particles properties
+  this->_build_volume_buttons_();
+  this->_build_particle_buttons_();
+  this->_build_misc_buttons_();
+  this->_set_button_values_();
 
-    // Add automatic event reading
-    TGGroupFrame* group = new TGGroupFrame(_main_, "Automatic event reading", kHorizontalFrame);
-    _main_->AddFrame(group, new TGLayoutHints(kLHintsTop | kLHintsLeft, 3, 3, 3, 3));
+  // Add automatic event reading
+  TGGroupFrame* group = new TGGroupFrame(_main_, "Automatic event reading", kHorizontalFrame);
+  _main_->AddFrame(group, new TGLayoutHints(kLHintsTop | kLHintsLeft, 3, 3, 3, 3));
 
-    TGCheckButton* auto_read = new TGCheckButton(group, "Enable..", AUTO_READ_ENABLE);
-    group->AddFrame(auto_read, new TGLayoutHints(kLHintsLeft, 1, 25, 2, 2));
+  TGCheckButton* auto_read = new TGCheckButton(group, "Enable..", AUTO_READ_ENABLE);
+  group->AddFrame(auto_read, new TGLayoutHints(kLHintsLeft, 1, 25, 2, 2));
 
-    const options_manager& options_mgr = options_manager::get_instance();
-    options_mgr.is_automatic_event_reading_mode() ? auto_read->SetState(kButtonDown)
-                                                  : auto_read->SetState(kButtonUp);
-    auto_read->Connect("Clicked ()", "snemo::visualization::view::display_options", this,
-                       "process_auto_reading ()");
+  const options_manager& options_mgr = options_manager::get_instance();
+  options_mgr.is_automatic_event_reading_mode() ? auto_read->SetState(kButtonDown)
+                                                : auto_read->SetState(kButtonUp);
+  auto_read->Connect("Clicked ()", "snemo::visualization::view::display_options", this,
+                     "process_auto_reading ()");
 
-    group->AddFrame(new TGLabel(group, "Interval [sec]:"),
-                    new TGLayoutHints(kLHintsLeft, 5, 1, 2, 2));
+  group->AddFrame(new TGLabel(group, "Interval [sec]:"),
+                  new TGLayoutHints(kLHintsLeft, 5, 1, 2, 2));
 
-    TGHSlider* slider = new TGHSlider(group, 200, kSlider1 | kScaleBoth, AUTO_READ_DELAY);
-    slider->Connect("PositionChanged (Int_t)", "snemo::visualization::view::display_options", this,
-                    "do_slider (const int)");
-    slider->SetRange(1, 10);
-    slider->SetPosition(static_cast<int>(options_mgr.get_automatic_event_reading_delay()));
-    group->AddFrame(slider, new TGLayoutHints(kLHintsLeft, 5, 1, 2, 2));
+  TGHSlider* slider = new TGHSlider(group, 200, kSlider1 | kScaleBoth, AUTO_READ_DELAY);
+  slider->Connect("PositionChanged (Int_t)", "snemo::visualization::view::display_options", this,
+                  "do_slider (const int)");
+  slider->SetRange(1, 10);
+  slider->SetPosition(static_cast<int>(options_mgr.get_automatic_event_reading_delay()));
+  group->AddFrame(slider, new TGLayoutHints(kLHintsLeft, 5, 1, 2, 2));
 
-    std::ostringstream oss;
-    oss << options_mgr.get_automatic_event_reading_delay();
-    _show_delay_ = new TGTextEntry(group, oss.str().c_str());
-    _show_delay_->Resize(50, _show_delay_->GetDefaultHeight());
-    _show_delay_->SetState(false);
-    _show_delay_->SetFrameDrawn(true);
-    _show_delay_->SetAlignment(kTextCenterX);
-    group->AddFrame(_show_delay_, new TGLayoutHints(kFixedWidth, 2, 1, 2, 2));
+  std::ostringstream oss;
+  oss << options_mgr.get_automatic_event_reading_delay();
+  _show_delay_ = new TGTextEntry(group, oss.str().c_str());
+  _show_delay_->Resize(50, _show_delay_->GetDefaultHeight());
+  _show_delay_->SetState(false);
+  _show_delay_->SetFrameDrawn(true);
+  _show_delay_->SetAlignment(kTextCenterX);
+  group->AddFrame(_show_delay_, new TGLayoutHints(kFixedWidth, 2, 1, 2, 2));
 
-    // Add 2 buttons to save and reload style file: there will be
-    // always here, so no clearing will be required
-    TGHorizontalFrame* process_style_buttons = new TGHorizontalFrame(_main_);
-    _main_->AddFrame(process_style_buttons,
-                     new TGLayoutHints(kLHintsBottom | kLHintsRight, 10, 10, 10, 10));
-    TGTextButton* reload_style_file =
-        new TGTextButton(process_style_buttons, "Reload style file", RELOAD_STYLE_FILE);
-    reload_style_file->SetToolTipText("reload current version of style file");
-    reload_style_file->Connect("Clicked ()", "snemo::visualization::view::display_options", this,
-                               "reload_style_settings ()");
-    process_style_buttons->AddFrame(reload_style_file,
-                                    new TGLayoutHints(kLHintsNoHints, 2, 2, 2, 2));
+  // Add 2 buttons to save and reload style file: there will be
+  // always here, so no clearing will be required
+  TGHorizontalFrame* process_style_buttons = new TGHorizontalFrame(_main_);
+  _main_->AddFrame(process_style_buttons,
+                   new TGLayoutHints(kLHintsBottom | kLHintsRight, 10, 10, 10, 10));
+  TGTextButton* reload_style_file =
+      new TGTextButton(process_style_buttons, "Reload style file", RELOAD_STYLE_FILE);
+  reload_style_file->SetToolTipText("reload current version of style file");
+  reload_style_file->Connect("Clicked ()", "snemo::visualization::view::display_options", this,
+                             "reload_style_settings ()");
+  process_style_buttons->AddFrame(reload_style_file, new TGLayoutHints(kLHintsNoHints, 2, 2, 2, 2));
 
-    TGTextButton* save_style_into_file =
-        new TGTextButton(process_style_buttons, "Save style file as...", SAVE_STYLE_FILE);
-    save_style_into_file->SetToolTipText("save current settings into style file");
-    save_style_into_file->Connect("Clicked ()", "snemo::visualization::view::display_options", this,
-                                  "save_style_settings ()");
-    process_style_buttons->AddFrame(save_style_into_file,
-                                    new TGLayoutHints(kLHintsNoHints, 2, 2, 2, 2));
-    return;
-  }
+  TGTextButton* save_style_into_file =
+      new TGTextButton(process_style_buttons, "Save style file as...", SAVE_STYLE_FILE);
+  save_style_into_file->SetToolTipText("save current settings into style file");
+  save_style_into_file->Connect("Clicked ()", "snemo::visualization::view::display_options", this,
+                                "save_style_settings ()");
+  process_style_buttons->AddFrame(save_style_into_file,
+                                  new TGLayoutHints(kLHintsNoHints, 2, 2, 2, 2));
+  return;
+}
 
-  void display_options::_build_volume_buttons_() {
-    // Retrieve volume properties
-    const style_manager& style_mgr = style_manager::get_instance();
-    const std::map<std::string, style_manager::volume_properties>& volumes =
-        style_mgr.get_volumes_properties();
+void display_options::_build_volume_buttons_() {
+  // Retrieve volume properties
+  const style_manager& style_mgr = style_manager::get_instance();
+  const std::map<std::string, style_manager::volume_properties>& volumes =
+      style_mgr.get_volumes_properties();
 
-    // Layout for positionning frame
-    TGLayoutHints* layout = new TGLayoutHints(kLHintsTop | kLHintsLeft, 3, 3, 3, 3);
-    TGGroupFrame* volume_group = new TGGroupFrame(_main_, "Volume Settings", kVerticalFrame);
-    volume_group->SetTitlePos(TGGroupFrame::kLeft);
-    _main_->AddFrame(volume_group, layout);
+  // Layout for positionning frame
+  TGLayoutHints* layout = new TGLayoutHints(kLHintsTop | kLHintsLeft, 3, 3, 3, 3);
+  TGGroupFrame* volume_group = new TGGroupFrame(_main_, "Volume Settings", kVerticalFrame);
+  volume_group->SetTitlePos(TGGroupFrame::kLeft);
+  _main_->AddFrame(volume_group, layout);
 
-    unsigned int id_button = _button_dictionnary_.size();
-    for (std::map<std::string, style_manager::volume_properties>::const_iterator it_volume =
-             volumes.begin();
-         it_volume != volumes.end(); ++it_volume) {
-      const std::string& volume_name = it_volume->first;
+  unsigned int id_button = _button_dictionnary_.size();
+  for (std::map<std::string, style_manager::volume_properties>::const_iterator it_volume =
+           volumes.begin();
+       it_volume != volumes.end(); ++it_volume) {
+    const std::string& volume_name = it_volume->first;
 
-      // Volume name without _
-      std::string volume_group_name = volume_name;
-      std::replace(volume_group_name.begin(), volume_group_name.end(), '_', ' ');
-      if (volume_group_name.find(".category") != std::string::npos) {
-        volume_group_name.replace(volume_group_name.find(".category"), volume_group_name.length(),
-                                  "");
-      }
+    // Volume name without _
+    std::string volume_group_name = volume_name;
+    std::replace(volume_group_name.begin(), volume_group_name.end(), '_', ' ');
+    if (volume_group_name.find(".category") != std::string::npos) {
+      volume_group_name.replace(volume_group_name.find(".category"), volume_group_name.length(),
+                                "");
+    }
 
-      // Define group frame
-      TGCompositeFrame* cframe =
-          new TGCompositeFrame(volume_group, 200, 1, kHorizontalFrame | kFixedWidth);
-      volume_group->AddFrame(cframe);
-      // _volumes_widgets_[volume_name]._tg_frame_ = volume_group;
+    // Define group frame
+    TGCompositeFrame* cframe =
+        new TGCompositeFrame(volume_group, 200, 1, kHorizontalFrame | kFixedWidth);
+    volume_group->AddFrame(cframe);
+    // _volumes_widgets_[volume_name]._tg_frame_ = volume_group;
 
-      // Add visibility widget and check visibility state
-      TGCheckButton* visibility_check =
-          new TGCheckButton(cframe, volume_group_name.c_str(), id_button);
-      visibility_check->Connect("Clicked()", "snemo::visualization::view::display_options", this,
-                                "process_volume_settings ()");
-      cframe->AddFrame(visibility_check,
-                       new TGLayoutHints(kLHintsTop | kLHintsExpandX, 2, 2, 2, 2));
-      _volumes_widgets_[volume_name]._tg_visibility_ = visibility_check;
-      _button_dictionnary_[id_button++] = volume_name;
-
-      // Add color selector
-      TGColorSelect* color_selector = new TGColorSelect(
-          cframe, TColor::Number2Pixel(style_mgr.get_volume_color(volume_name)), id_button);
-      color_selector->Connect("ColorSelected (Pixel_t)",
-                              "snemo::visualization::view::display_options", this,
+    // Add visibility widget and check visibility state
+    TGCheckButton* visibility_check =
+        new TGCheckButton(cframe, volume_group_name.c_str(), id_button);
+    visibility_check->Connect("Clicked()", "snemo::visualization::view::display_options", this,
                               "process_volume_settings ()");
-      cframe->AddFrame(color_selector);
-      // , new TGLayoutHints (kLHintsTop | kLHintsExpandX,
-      //                      2, 2, 2, 2));
+    cframe->AddFrame(visibility_check, new TGLayoutHints(kLHintsTop | kLHintsExpandX, 2, 2, 2, 2));
+    _volumes_widgets_[volume_name]._tg_visibility_ = visibility_check;
+    _button_dictionnary_[id_button++] = volume_name;
 
-      _volumes_widgets_[volume_name]._tg_color_ = color_selector;
-      _button_dictionnary_[id_button++] = volume_name;
+    // Add color selector
+    TGColorSelect* color_selector = new TGColorSelect(
+        cframe, TColor::Number2Pixel(style_mgr.get_volume_color(volume_name)), id_button);
+    color_selector->Connect("ColorSelected (Pixel_t)",
+                            "snemo::visualization::view::display_options", this,
+                            "process_volume_settings ()");
+    cframe->AddFrame(color_selector);
+    // , new TGLayoutHints (kLHintsTop | kLHintsExpandX,
+    //                      2, 2, 2, 2));
 
-      // // Add transparency slider
-      // TGNumberEntryField* transparency_entry
-      //   = new TGNumberEntryField (cframe, id_button,
-      //                             style_mgr.get_volume_transparency (volume_name),
-      //                             TGNumberFormat::kNESInteger,
-      //                             TGNumberFormat::kNEANonNegative);
-      // transparency_entry->SetLimits (TGNumberFormat::kNELLimitMinMax, 0, 100);
-      // transparency_entry->Connect ("TextChanged (char*)",
-      //                              "snemo::visualization::view::display_options",
-      //                              this, "process_volume_settings ()");
-      // cframe->AddFrame (transparency_entry);
-      // // , new TGLayoutHints (kLHintsTop |
-      // //                      kLHintsLeft, 2, 2, 2, 2));
-      // _volumes_widgets_[volume_name]._tg_transparency_ = transparency_entry;
-      // _button_dictionnary_[id_button++] = volume_name;
-    }
+    _volumes_widgets_[volume_name]._tg_color_ = color_selector;
+    _button_dictionnary_[id_button++] = volume_name;
 
-    return;
+    // // Add transparency slider
+    // TGNumberEntryField* transparency_entry
+    //   = new TGNumberEntryField (cframe, id_button,
+    //                             style_mgr.get_volume_transparency (volume_name),
+    //                             TGNumberFormat::kNESInteger,
+    //                             TGNumberFormat::kNEANonNegative);
+    // transparency_entry->SetLimits (TGNumberFormat::kNELLimitMinMax, 0, 100);
+    // transparency_entry->Connect ("TextChanged (char*)",
+    //                              "snemo::visualization::view::display_options",
+    //                              this, "process_volume_settings ()");
+    // cframe->AddFrame (transparency_entry);
+    // // , new TGLayoutHints (kLHintsTop |
+    // //                      kLHintsLeft, 2, 2, 2, 2));
+    // _volumes_widgets_[volume_name]._tg_transparency_ = transparency_entry;
+    // _button_dictionnary_[id_button++] = volume_name;
   }
 
-  void display_options::_build_particle_buttons_() {
-    // Retrieve volume properties
-    const style_manager& style_mgr = style_manager::get_instance();
-    const std::map<std::string, style_manager::particle_properties>& particles =
-        style_mgr.get_particles_properties();
+  return;
+}
 
-    // Layout for positionning frame
-    TGLayoutHints* layout = new TGLayoutHints(kLHintsTop | kLHintsLeft, 3, 3, 3, 3);
-    TGGroupFrame* particle_group = new TGGroupFrame(_main_, "Simulation Settings", kVerticalFrame);
-    particle_group->SetTitlePos(TGGroupFrame::kLeft);
-    _main_->AddFrame(particle_group, layout);
+void display_options::_build_particle_buttons_() {
+  // Retrieve volume properties
+  const style_manager& style_mgr = style_manager::get_instance();
+  const std::map<std::string, style_manager::particle_properties>& particles =
+      style_mgr.get_particles_properties();
 
-    unsigned int id_button = _button_dictionnary_.size();
-    for (std::map<std::string, style_manager::particle_properties>::const_iterator it_particle =
-             particles.begin();
-         it_particle != particles.end(); ++it_particle) {
-      const std::string& particle_name = it_particle->first;
+  // Layout for positionning frame
+  TGLayoutHints* layout = new TGLayoutHints(kLHintsTop | kLHintsLeft, 3, 3, 3, 3);
+  TGGroupFrame* particle_group = new TGGroupFrame(_main_, "Simulation Settings", kVerticalFrame);
+  particle_group->SetTitlePos(TGGroupFrame::kLeft);
+  _main_->AddFrame(particle_group, layout);
 
-      // Define group frame
-      TGCompositeFrame* cframe =
-          new TGCompositeFrame(particle_group, 200, 1, kHorizontalFrame | kFixedWidth);
-      particle_group->AddFrame(cframe);
-      //_particles_widgets_[volume_name]._tg_frame_ = particle_group;
+  unsigned int id_button = _button_dictionnary_.size();
+  for (std::map<std::string, style_manager::particle_properties>::const_iterator it_particle =
+           particles.begin();
+       it_particle != particles.end(); ++it_particle) {
+    const std::string& particle_name = it_particle->first;
 
-      // Add visibility widget and check visibility state
-      TGCheckButton* visibility_check = new TGCheckButton(cframe, particle_name.c_str(), id_button);
-      visibility_check->Connect("Clicked()", "snemo::visualization::view::display_options", this,
-                                "process_particle_settings ()");
-      cframe->AddFrame(visibility_check,
-                       new TGLayoutHints(kLHintsTop | kLHintsExpandX, 2, 2, 2, 2));
-      _particles_widgets_[particle_name]._tg_visibility_ = visibility_check;
-      _button_dictionnary_[id_button++] = particle_name;
+    // Define group frame
+    TGCompositeFrame* cframe =
+        new TGCompositeFrame(particle_group, 200, 1, kHorizontalFrame | kFixedWidth);
+    particle_group->AddFrame(cframe);
+    //_particles_widgets_[volume_name]._tg_frame_ = particle_group;
 
-      // Add color selector
-      TGColorSelect* color_selector = new TGColorSelect(
-          cframe, TColor::Number2Pixel(style_mgr.get_particle_color(particle_name)), id_button);
-      color_selector->Connect("ColorSelected (Pixel_t)",
-                              "snemo::visualization::view::display_options", this,
+    // Add visibility widget and check visibility state
+    TGCheckButton* visibility_check = new TGCheckButton(cframe, particle_name.c_str(), id_button);
+    visibility_check->Connect("Clicked()", "snemo::visualization::view::display_options", this,
                               "process_particle_settings ()");
-      cframe->AddFrame(color_selector);  //, new TGLayoutHints (kLHintsTop // | kLHintsExpandX
-                                         //                    ,
-                                         //                    2, 2, 2, 2));
+    cframe->AddFrame(visibility_check, new TGLayoutHints(kLHintsTop | kLHintsExpandX, 2, 2, 2, 2));
+    _particles_widgets_[particle_name]._tg_visibility_ = visibility_check;
+    _button_dictionnary_[id_button++] = particle_name;
 
-      _particles_widgets_[particle_name]._tg_color_ = color_selector;
-      _button_dictionnary_[id_button++] = particle_name;
-    }
+    // Add color selector
+    TGColorSelect* color_selector = new TGColorSelect(
+        cframe, TColor::Number2Pixel(style_mgr.get_particle_color(particle_name)), id_button);
+    color_selector->Connect("ColorSelected (Pixel_t)",
+                            "snemo::visualization::view::display_options", this,
+                            "process_particle_settings ()");
+    cframe->AddFrame(color_selector);  //, new TGLayoutHints (kLHintsTop // | kLHintsExpandX
+                                       //                    ,
+                                       //                    2, 2, 2, 2));
 
-    return;
+    _particles_widgets_[particle_name]._tg_color_ = color_selector;
+    _button_dictionnary_[id_button++] = particle_name;
   }
 
-  void display_options::_build_misc_buttons_() {
-    // Retrieve misc properties
-    const style_manager& style_mgr = style_manager::get_instance();
+  return;
+}
 
-    // Layout for positionning frame
-    TGLayoutHints* layout = new TGLayoutHints(kLHintsTop | kLHintsLeft, 3, 3, 3, 3);
-    TGGroupFrame* misc_group = new TGGroupFrame(_main_, "Miscellaneous", kVerticalFrame);
-    misc_group->SetTitlePos(TGGroupFrame::kLeft);
-    _main_->AddFrame(misc_group, layout);
+void display_options::_build_misc_buttons_() {
+  // Retrieve misc properties
+  const style_manager& style_mgr = style_manager::get_instance();
 
-    {
-      // Add color selector
-      TGCompositeFrame* cframe =
-          new TGCompositeFrame(misc_group, 200, 1, kHorizontalFrame | kFixedWidth);
-      cframe->AddFrame(new TGLabel(cframe, "background color  "),
-                       new TGLayoutHints(kLHintsLeft | kLHintsExpandX, 1, 1, 2, 2));
-      misc_group->AddFrame(cframe);
+  // Layout for positionning frame
+  TGLayoutHints* layout = new TGLayoutHints(kLHintsTop | kLHintsLeft, 3, 3, 3, 3);
+  TGGroupFrame* misc_group = new TGGroupFrame(_main_, "Miscellaneous", kVerticalFrame);
+  misc_group->SetTitlePos(TGGroupFrame::kLeft);
+  _main_->AddFrame(misc_group, layout);
 
-      _background_color_ = new TGColorSelect(
-          cframe, TColor::Number2Pixel(style_mgr.get_background_color()), COLOR_BACKGROUND);
-      _background_color_->Connect("ColorSelected (Pixel_t)",
-                                  "snemo::visualization::view::display_options", this,
-                                  "process_button_misc_settings ()");
-      cframe->AddFrame(_background_color_);
-    }
+  {
+    // Add color selector
+    TGCompositeFrame* cframe =
+        new TGCompositeFrame(misc_group, 200, 1, kHorizontalFrame | kFixedWidth);
+    cframe->AddFrame(new TGLabel(cframe, "background color  "),
+                     new TGLayoutHints(kLHintsLeft | kLHintsExpandX, 1, 1, 2, 2));
+    misc_group->AddFrame(cframe);
 
-    {
-      // Add line style selector
-      TGCompositeFrame* cframe =
-          new TGCompositeFrame(misc_group, 200, 1, kHorizontalFrame | kFixedWidth);
-      cframe->AddFrame(new TGLabel(cframe, "line style  "),
-                       new TGLayoutHints(kLHintsLeft | kLHintsExpandX, 1, 1, 2, 2));
-      misc_group->AddFrame(cframe);
-      _line_style_ = new TGLineStyleComboBox(cframe, LINE_STYLE);
-      _line_style_->Resize(90, 22);
-      _line_style_->Connect("Selected (int)", "snemo::visualization::view::display_options", this,
-                            "process_combo_misc_settings ()");
-      cframe->AddFrame(_line_style_, new TGLayoutHints(kLHintsRight, 1, 1, 2, 2));
-    }
-
-    {
-      // Add line width selector
-      TGCompositeFrame* cframe =
-          new TGCompositeFrame(misc_group, 200, 1, kHorizontalFrame | kFixedWidth);
-      cframe->AddFrame(new TGLabel(cframe, "line width  "),
-                       new TGLayoutHints(kLHintsLeft | kLHintsExpandX, 1, 1, 2, 2));
-      misc_group->AddFrame(cframe);
-      _line_width_ = new TGLineWidthComboBox(cframe, LINE_WIDTH);
-      _line_width_->Resize(90, 22);
-      _line_width_->Connect("Selected(Int_t)", "snemo::visualization::view::display_options", this,
-                            "process_combo_misc_settings ()");
-      cframe->AddFrame(_line_width_, new TGLayoutHints(kLHintsRight, 1, 1, 2, 2));
-    }
-
-    return;
+    _background_color_ = new TGColorSelect(
+        cframe, TColor::Number2Pixel(style_mgr.get_background_color()), COLOR_BACKGROUND);
+    _background_color_->Connect("ColorSelected (Pixel_t)",
+                                "snemo::visualization::view::display_options", this,
+                                "process_button_misc_settings ()");
+    cframe->AddFrame(_background_color_);
   }
 
-  void display_options::_set_button_values_() {
-    const style_manager& style_mgr = style_manager::get_instance();
-
-    // Volume settings
-    for (std::map<std::string, volume_widgets>::iterator it_widget = _volumes_widgets_.begin();
-         it_widget != _volumes_widgets_.end(); ++it_widget) {
-      const std::string& volume_name = it_widget->first;
-
-      TGCheckButton* visibility_check = it_widget->second._tg_visibility_;
-      switch (style_mgr.get_volume_visibility(volume_name)) {
-        case detector::VISIBLE:
-          visibility_check->SetState(kButtonDown);
-          break;
-        case detector::INVISIBLE:
-          visibility_check->SetState(kButtonUp);
-          break;
-        case detector::DISABLE:
-          visibility_check->SetDisabledAndSelected(false);
-          visibility_check->SetToolTipText("Volume disabled in style file");
-          break;
-        default:
-          break;
-      }
-
-      // Disable special shape volume (too hard to get back later)
-      if (detector::detector_manager::get_instance().is_special_volume(volume_name)) {
-        visibility_check->SetDisabledAndSelected(true);
-        visibility_check->SetToolTipText("Volume disabled due to special shape");
-      }
-
-      TGColorSelect* color_selector = it_widget->second._tg_color_;
-      const unsigned int color = style_mgr.get_volume_color(volume_name);
-      color_selector->SetColor(TColor::Number2Pixel(color), false);
-
-      // TGNumberEntryField* transparency_entry = it_widget->second._tg_transparency_;
-      // const unsigned int value = style_mgr.get_volume_transparency (volume_name);
-      // transparency_entry->SetNumber (value);
-    }
-
-    // MC particle settings
-    for (std::map<std::string, particle_widgets>::iterator it_widget = _particles_widgets_.begin();
-         it_widget != _particles_widgets_.end(); ++it_widget) {
-      const std::string particle_name = it_widget->first;
-
-      TGCheckButton* visibility_check = it_widget->second._tg_visibility_;
-      style_mgr.get_particle_visibility(particle_name) ? visibility_check->SetState(kButtonDown)
-                                                       : visibility_check->SetState(kButtonUp);
-
-      TGColorSelect* color_selector = it_widget->second._tg_color_;
-      const unsigned int color = style_mgr.get_particle_color(particle_name);
-      color_selector->SetColor(TColor::Number2Pixel(color), false);
-    }
-
-    // Misc options
-    const unsigned int color = style_mgr.get_background_color();
-    _background_color_->SetColor(TColor::Number2Pixel(color), false);
-    const unsigned int line_style = style_mgr.get_mc_line_style();
-    _line_style_->Select(line_style, false);
-    const unsigned int line_width = style_mgr.get_mc_line_width();
-    _line_width_->Select(line_width, false);
-
-    return;
+  {
+    // Add line style selector
+    TGCompositeFrame* cframe =
+        new TGCompositeFrame(misc_group, 200, 1, kHorizontalFrame | kFixedWidth);
+    cframe->AddFrame(new TGLabel(cframe, "line style  "),
+                     new TGLayoutHints(kLHintsLeft | kLHintsExpandX, 1, 1, 2, 2));
+    misc_group->AddFrame(cframe);
+    _line_style_ = new TGLineStyleComboBox(cframe, LINE_STYLE);
+    _line_style_->Resize(90, 22);
+    _line_style_->Connect("Selected (int)", "snemo::visualization::view::display_options", this,
+                          "process_combo_misc_settings ()");
+    cframe->AddFrame(_line_style_, new TGLayoutHints(kLHintsRight, 1, 1, 2, 2));
   }
 
-  void display_options::update() { return; }
-
-  void display_options::clear() {
-    // for (map<string, volume_widgets>::iterator
-    //        it_widget = _volumes_widgets_.begin ();
-    //      it_widget != _volumes_widgets_.end (); ++it_widget)
-    //   {
-    //     it_widget->second._tg_frame_->DestroyWindow ();
-    //     it_widget->second._tg_frame_->Cleanup ();
-    //     _main_->RemoveFrame (it_widget->second._tg_frame_);
-
-    //     // delete it_widget->second._tg_color_;
-    //     // delete it_widget->second._tg_transparency_;
-    //     // delete it_widget->second._tg_visibility_;
-    //     delete it_widget->second._tg_frame_;
-    //   }
-
-    _volumes_widgets_.clear();
-    _button_dictionnary_.clear();
-
-    return;
+  {
+    // Add line width selector
+    TGCompositeFrame* cframe =
+        new TGCompositeFrame(misc_group, 200, 1, kHorizontalFrame | kFixedWidth);
+    cframe->AddFrame(new TGLabel(cframe, "line width  "),
+                     new TGLayoutHints(kLHintsLeft | kLHintsExpandX, 1, 1, 2, 2));
+    misc_group->AddFrame(cframe);
+    _line_width_ = new TGLineWidthComboBox(cframe, LINE_WIDTH);
+    _line_width_->Resize(90, 22);
+    _line_width_->Connect("Selected(Int_t)", "snemo::visualization::view::display_options", this,
+                          "process_combo_misc_settings ()");
+    cframe->AddFrame(_line_width_, new TGLayoutHints(kLHintsRight, 1, 1, 2, 2));
   }
 
-  void display_options::reset() {
-    DT_THROW_IF(!is_initialized(), std::logic_error, "Not initialized !");
-    this->clear();
-    _initialized_ = false;
-    return;
-  }
+  return;
+}
 
-  void display_options::process_volume_settings() {
-    // This is a bit brute because one change cause the loading of
-    // all buttons. Each action can be split into one given method
-    TGButton* button = static_cast<TGButton*>(gTQSender);
-    unsigned int id = button->WidgetId();
+void display_options::_set_button_values_() {
+  const style_manager& style_mgr = style_manager::get_instance();
 
-    // Retrieve style manager to change volume properties
-    style_manager& style_mgr = style_manager::get_instance();
-    std::map<std::string, style_manager::volume_properties>& volumes =
-        style_mgr.grab_volumes_properties();
+  // Volume settings
+  for (std::map<std::string, volume_widgets>::iterator it_widget = _volumes_widgets_.begin();
+       it_widget != _volumes_widgets_.end(); ++it_widget) {
+    const std::string& volume_name = it_widget->first;
 
-    // Get corresponding volume name wrt to button id. If id has
-    // not been stored then signal comes from somewhere else. It
-    // is just a safety check
-    if (_button_dictionnary_.find(id) == _button_dictionnary_.end()) return;
-
-    const std::string& volume_name = _button_dictionnary_.at(id);
-
-    // Set visibility
-    _volumes_widgets_[volume_name]._tg_visibility_->IsDown()
-        ? volumes[volume_name]._visibility_ = detector::VISIBLE
-        : volumes[volume_name]._visibility_ = detector::INVISIBLE;
-
-    // Set color: convert Pixel_t value to integer
-    unsigned int color = TColor::GetColor(_volumes_widgets_[volume_name]._tg_color_->GetColor());
-    volumes[volume_name]._color_ = color;
-
-    // // Set transparency
-    // unsigned int transparency
-    //   = _volumes_widgets_[volume_name]._tg_transparency_->GetNumber ();
-    // volumes[volume_name]._transparency_ = transparency;
-
-    // Update detector and event browser
-    detector::detector_manager::get_instance().update();
-    const bool reset_view = false;
-    _browser_->update_browser(reset_view);
-
-    return;
-  }
-
-  void display_options::process_particle_settings() {
-    // This is a bit brute because one change cause the loading of
-    // all buttons. Each action can be split into one given method
-    TGButton* button = static_cast<TGButton*>(gTQSender);
-    unsigned int id = button->WidgetId();
-
-    // Retrieve style manager to change volume properties
-    style_manager& style_mgr = style_manager::get_instance();
-    std::map<std::string, style_manager::particle_properties>& particles =
-        style_mgr.grab_particles_properties();
-
-    // Get corresponding volume name wrt to button id. If id has
-    // not been stored then signal comes from somewhere else. It
-    // is just a safety check
-    if (_button_dictionnary_.find(id) == _button_dictionnary_.end()) return;
-
-    const std::string& particle_name = _button_dictionnary_.at(id);
-
-    // Set visibility
-    _particles_widgets_[particle_name]._tg_visibility_->IsDown()
-        ? particles[particle_name]._visibility_ = true
-        : particles[particle_name]._visibility_ = false;
-
-    // Set color: convert Pixel_t value to integer
-    unsigned int color =
-        TColor::GetColor(_particles_widgets_[particle_name]._tg_color_->GetColor());
-    particles[particle_name]._color_ = color;
-
-    // Update event browser
-    const bool reset_view = false;
-    _browser_->update_browser(reset_view);
-
-    return;
-  }
-
-  void display_options::process_button_misc_settings() {
-    // This is a bit brute because one change cause the loading of
-    // all buttons. Each action can be split into one given method
-    TGButton* button = static_cast<TGButton*>(gTQSender);
-    unsigned int id = button->WidgetId();
-
-    // Retrieve style manager to change misc properties
-    style_manager& style_mgr = style_manager::get_instance();
-
-    switch (id) {
-      case COLOR_BACKGROUND: {
-        unsigned int color = TColor::GetColor(_background_color_->GetColor());
-        style_mgr.set_background_color(color);
+    TGCheckButton* visibility_check = it_widget->second._tg_visibility_;
+    switch (style_mgr.get_volume_visibility(volume_name)) {
+      case detector::VISIBLE:
+        visibility_check->SetState(kButtonDown);
         break;
-      }
-    }
-
-    // Update event browser
-    const bool reset_view = false;
-    _browser_->update_browser(reset_view);
-
-    return;
-  }
-
-  void display_options::process_combo_misc_settings() {
-    TGComboBox* combo = static_cast<TGComboBox*>(gTQSender);
-    unsigned int id = combo->WidgetId();
-
-    // Retrieve style manager to change misc properties
-    style_manager& style_mgr = style_manager::get_instance();
-
-    switch (id) {
-      case LINE_WIDTH: {
-        unsigned int width = _line_width_->GetSelected();
-        style_mgr.set_mc_line_width(width);
+      case detector::INVISIBLE:
+        visibility_check->SetState(kButtonUp);
         break;
-      }
-      case LINE_STYLE: {
-        unsigned int style = _line_style_->GetSelected();
-        style_mgr.set_mc_line_style(style);
+      case detector::DISABLE:
+        visibility_check->SetDisabledAndSelected(false);
+        visibility_check->SetToolTipText("Volume disabled in style file");
         break;
-      }
+      default:
+        break;
     }
 
-    // Update event browser
-    const bool reset_view = false;
-    _browser_->update_browser(reset_view);
-
-    return;
-  }
-
-  void display_options::process_auto_reading() {
-    TGButton* button = static_cast<TGButton*>(gTQSender);
-    unsigned int id = button->WidgetId();
-
-    if (id == AUTO_READ_ENABLE) {
-      options_manager& options_mgr = options_manager::get_instance();
-      options_mgr.set_automatic_event_reading_mode(button->IsDown());
-
-      if (options_mgr.is_automatic_event_reading_mode()) {
-        const unsigned int nbr_seconds =
-            (unsigned int)options_mgr.get_automatic_event_reading_delay() * 1000;
-        TTimer::SingleShot(nbr_seconds, "snemo::visualization::view::event_browser", _browser_,
-                           "change_event ()");
-      }
+    // Disable special shape volume (too hard to get back later)
+    if (detector::detector_manager::get_instance().is_special_volume(volume_name)) {
+      visibility_check->SetDisabledAndSelected(true);
+      visibility_check->SetToolTipText("Volume disabled due to special shape");
     }
 
-    return;
+    TGColorSelect* color_selector = it_widget->second._tg_color_;
+    const unsigned int color = style_mgr.get_volume_color(volume_name);
+    color_selector->SetColor(TColor::Number2Pixel(color), false);
+
+    // TGNumberEntryField* transparency_entry = it_widget->second._tg_transparency_;
+    // const unsigned int value = style_mgr.get_volume_transparency (volume_name);
+    // transparency_entry->SetNumber (value);
   }
 
-  void display_options::reload_style_settings() {
-    // Reload previous style settings
-    style_manager::get_instance().reload();
+  // MC particle settings
+  for (std::map<std::string, particle_widgets>::iterator it_widget = _particles_widgets_.begin();
+       it_widget != _particles_widgets_.end(); ++it_widget) {
+    const std::string particle_name = it_widget->first;
 
-    // Set button values
-    this->_set_button_values_();
+    TGCheckButton* visibility_check = it_widget->second._tg_visibility_;
+    style_mgr.get_particle_visibility(particle_name) ? visibility_check->SetState(kButtonDown)
+                                                     : visibility_check->SetState(kButtonUp);
 
-    // Update detector and event browser
-    detector::detector_manager::get_instance().update();
-    const bool reset_view = false;
-    _browser_->update_browser(reset_view);
-
-    return;
+    TGColorSelect* color_selector = it_widget->second._tg_color_;
+    const unsigned int color = style_mgr.get_particle_color(particle_name);
+    color_selector->SetColor(TColor::Number2Pixel(color), false);
   }
 
-  void display_options::save_style_settings() {
-    const size_t nbr_file_format = 4;
-    const char* save_as_types[nbr_file_format] = {"Style File", "*.sty", 0, 0};
+  // Misc options
+  const unsigned int color = style_mgr.get_background_color();
+  _background_color_->SetColor(TColor::Number2Pixel(color), false);
+  const unsigned int line_style = style_mgr.get_mc_line_style();
+  _line_style_->Select(line_style, false);
+  const unsigned int line_width = style_mgr.get_mc_line_width();
+  _line_width_->Select(line_width, false);
 
-    std::list<std::string> file_format;
-    for (size_t i = 0; i < nbr_file_format / 2 - 1; ++i) {
-      std::string dummy_one;
-      dummy_one.assign(save_as_types[i * 2 + 1]);
-      file_format.push_back(dummy_one);
+  return;
+}
+
+void display_options::update() { return; }
+
+void display_options::clear() {
+  // for (map<string, volume_widgets>::iterator
+  //        it_widget = _volumes_widgets_.begin ();
+  //      it_widget != _volumes_widgets_.end (); ++it_widget)
+  //   {
+  //     it_widget->second._tg_frame_->DestroyWindow ();
+  //     it_widget->second._tg_frame_->Cleanup ();
+  //     _main_->RemoveFrame (it_widget->second._tg_frame_);
+
+  //     // delete it_widget->second._tg_color_;
+  //     // delete it_widget->second._tg_transparency_;
+  //     // delete it_widget->second._tg_visibility_;
+  //     delete it_widget->second._tg_frame_;
+  //   }
+
+  _volumes_widgets_.clear();
+  _button_dictionnary_.clear();
+
+  return;
+}
+
+void display_options::reset() {
+  DT_THROW_IF(!is_initialized(), std::logic_error, "Not initialized !");
+  this->clear();
+  _initialized_ = false;
+  return;
+}
+
+void display_options::process_volume_settings() {
+  // This is a bit brute because one change cause the loading of
+  // all buttons. Each action can be split into one given method
+  TGButton* button = static_cast<TGButton*>(gTQSender);
+  unsigned int id = button->WidgetId();
+
+  // Retrieve style manager to change volume properties
+  style_manager& style_mgr = style_manager::get_instance();
+  std::map<std::string, style_manager::volume_properties>& volumes =
+      style_mgr.grab_volumes_properties();
+
+  // Get corresponding volume name wrt to button id. If id has
+  // not been stored then signal comes from somewhere else. It
+  // is just a safety check
+  if (_button_dictionnary_.find(id) == _button_dictionnary_.end()) return;
+
+  const std::string& volume_name = _button_dictionnary_.at(id);
+
+  // Set visibility
+  _volumes_widgets_[volume_name]._tg_visibility_->IsDown()
+      ? volumes[volume_name]._visibility_ = detector::VISIBLE
+      : volumes[volume_name]._visibility_ = detector::INVISIBLE;
+
+  // Set color: convert Pixel_t value to integer
+  unsigned int color = TColor::GetColor(_volumes_widgets_[volume_name]._tg_color_->GetColor());
+  volumes[volume_name]._color_ = color;
+
+  // // Set transparency
+  // unsigned int transparency
+  //   = _volumes_widgets_[volume_name]._tg_transparency_->GetNumber ();
+  // volumes[volume_name]._transparency_ = transparency;
+
+  // Update detector and event browser
+  detector::detector_manager::get_instance().update();
+  const bool reset_view = false;
+  _browser_->update_browser(reset_view);
+
+  return;
+}
+
+void display_options::process_particle_settings() {
+  // This is a bit brute because one change cause the loading of
+  // all buttons. Each action can be split into one given method
+  TGButton* button = static_cast<TGButton*>(gTQSender);
+  unsigned int id = button->WidgetId();
+
+  // Retrieve style manager to change volume properties
+  style_manager& style_mgr = style_manager::get_instance();
+  std::map<std::string, style_manager::particle_properties>& particles =
+      style_mgr.grab_particles_properties();
+
+  // Get corresponding volume name wrt to button id. If id has
+  // not been stored then signal comes from somewhere else. It
+  // is just a safety check
+  if (_button_dictionnary_.find(id) == _button_dictionnary_.end()) return;
+
+  const std::string& particle_name = _button_dictionnary_.at(id);
+
+  // Set visibility
+  _particles_widgets_[particle_name]._tg_visibility_->IsDown()
+      ? particles[particle_name]._visibility_ = true
+      : particles[particle_name]._visibility_ = false;
+
+  // Set color: convert Pixel_t value to integer
+  unsigned int color = TColor::GetColor(_particles_widgets_[particle_name]._tg_color_->GetColor());
+  particles[particle_name]._color_ = color;
+
+  // Update event browser
+  const bool reset_view = false;
+  _browser_->update_browser(reset_view);
+
+  return;
+}
+
+void display_options::process_button_misc_settings() {
+  // This is a bit brute because one change cause the loading of
+  // all buttons. Each action can be split into one given method
+  TGButton* button = static_cast<TGButton*>(gTQSender);
+  unsigned int id = button->WidgetId();
+
+  // Retrieve style manager to change misc properties
+  style_manager& style_mgr = style_manager::get_instance();
+
+  switch (id) {
+    case COLOR_BACKGROUND: {
+      unsigned int color = TColor::GetColor(_background_color_->GetColor());
+      style_mgr.set_background_color(color);
+      break;
     }
-
-    std::list<std::string>::iterator it =
-        find(file_format.begin(), file_format.end(), std::string("*.sty"));
-
-    int typeidx = distance(file_format.begin(), it) * 2;
-    bool overwr = false;
-
-    const std::string default_dir = falaise::get_resource_dir() + "/modules/EventBrowser/styles";
-    TGFileInfo file_info;
-    file_info.fFileTypes = save_as_types;
-    file_info.fIniDir = StrDup(default_dir.c_str());
-    file_info.fFileTypeIdx = typeidx;
-    file_info.fOverwrite = overwr;
-
-    new TGFileDialog(gClient->GetRoot(), 0, kFDSave, &file_info);
-    if (!file_info.fFilename) return;
-
-    std::string file_name = file_info.fFilename;
-    std::string file_type = file_info.fFileTypes[file_info.fFileTypeIdx + 1];
-    std::string directory = file_info.fIniDir;
-
-    // remove asterisk
-    file_type.erase(0, 1);
-
-    // if extension is missing to filename
-    if (!TString(file_name).EndsWith(file_type.c_str())) {
-      file_name += file_type;
-    }
-
-    DT_LOG_NOTICE(datatools::logger::PRIO_NOTICE, file_name << " saved");
-
-    style_manager::get_instance().dump_into_file(file_name);
-    return;
   }
 
-  void display_options::do_slider(const int delay_) {
+  // Update event browser
+  const bool reset_view = false;
+  _browser_->update_browser(reset_view);
+
+  return;
+}
+
+void display_options::process_combo_misc_settings() {
+  TGComboBox* combo = static_cast<TGComboBox*>(gTQSender);
+  unsigned int id = combo->WidgetId();
+
+  // Retrieve style manager to change misc properties
+  style_manager& style_mgr = style_manager::get_instance();
+
+  switch (id) {
+    case LINE_WIDTH: {
+      unsigned int width = _line_width_->GetSelected();
+      style_mgr.set_mc_line_width(width);
+      break;
+    }
+    case LINE_STYLE: {
+      unsigned int style = _line_style_->GetSelected();
+      style_mgr.set_mc_line_style(style);
+      break;
+    }
+  }
+
+  // Update event browser
+  const bool reset_view = false;
+  _browser_->update_browser(reset_view);
+
+  return;
+}
+
+void display_options::process_auto_reading() {
+  TGButton* button = static_cast<TGButton*>(gTQSender);
+  unsigned int id = button->WidgetId();
+
+  if (id == AUTO_READ_ENABLE) {
     options_manager& options_mgr = options_manager::get_instance();
-    options_mgr.set_automatic_event_reading_delay(delay_);
-    std::ostringstream oss;
-    oss << delay_;
-    _show_delay_->SetText(oss.str().c_str());
+    options_mgr.set_automatic_event_reading_mode(button->IsDown());
+
+    if (options_mgr.is_automatic_event_reading_mode()) {
+      const unsigned int nbr_seconds =
+          (unsigned int)options_mgr.get_automatic_event_reading_delay() * 1000;
+      TTimer::SingleShot(nbr_seconds, "snemo::visualization::view::event_browser", _browser_,
+                         "change_event ()");
+    }
   }
 
-  void display_options::test_add_frame() {
-    // this->clear ();
+  return;
+}
 
-    // cout << "cocuou" << endl;
-    // this->_build_volume_buttons_ ();
-    // cout << "caca" << endl;
+void display_options::reload_style_settings() {
+  // Reload previous style settings
+  style_manager::get_instance().reload();
 
-    // _main_->UnmapWindow ();
-    // _main_->RemoveAll ();
+  // Set button values
+  this->_set_button_values_();
 
-    TGGroupFrame* volume_group = new TGGroupFrame(_main_, "toto", kHorizontalFrame);
-    volume_group->SetTitlePos(TGGroupFrame::kLeft);
-    _main_->AddFrame(volume_group);
+  // Update detector and event browser
+  detector::detector_manager::get_instance().update();
+  const bool reset_view = false;
+  _browser_->update_browser(reset_view);
 
-    TGCheckButton* test = new TGCheckButton(volume_group, "test toto", 10000);
-    volume_group->AddFrame(test, new TGLayoutHints(kLHintsTop & kLHintsLeft, 2, 2, 2, 2));
+  return;
+}
 
-    volume_group->MapWindow();
-    // _main_->MapWindow ();
-    // _browser_->MapSubwindows ();
-    // _browser_->MapWindow ();
+void display_options::save_style_settings() {
+  const size_t nbr_file_format = 4;
+  const char* save_as_types[nbr_file_format] = {"Style File", "*.sty", 0, 0};
+
+  std::list<std::string> file_format;
+  for (size_t i = 0; i < nbr_file_format / 2 - 1; ++i) {
+    std::string dummy_one;
+    dummy_one.assign(save_as_types[i * 2 + 1]);
+    file_format.push_back(dummy_one);
   }
 
-  }  // end of namespace view
+  std::list<std::string>::iterator it =
+      find(file_format.begin(), file_format.end(), std::string("*.sty"));
 
-  }  // end of namespace visualization
+  int typeidx = distance(file_format.begin(), it) * 2;
+  bool overwr = false;
+
+  const std::string default_dir = falaise::get_resource_dir() + "/modules/EventBrowser/styles";
+  TGFileInfo file_info;
+  file_info.fFileTypes = save_as_types;
+  file_info.fIniDir = StrDup(default_dir.c_str());
+  file_info.fFileTypeIdx = typeidx;
+  file_info.fOverwrite = overwr;
+
+  new TGFileDialog(gClient->GetRoot(), 0, kFDSave, &file_info);
+  if (!file_info.fFilename) return;
+
+  std::string file_name = file_info.fFilename;
+  std::string file_type = file_info.fFileTypes[file_info.fFileTypeIdx + 1];
+  std::string directory = file_info.fIniDir;
+
+  // remove asterisk
+  file_type.erase(0, 1);
+
+  // if extension is missing to filename
+  if (!TString(file_name).EndsWith(file_type.c_str())) {
+    file_name += file_type;
+  }
+
+  DT_LOG_NOTICE(datatools::logger::PRIO_NOTICE, file_name << " saved");
+
+  style_manager::get_instance().dump_into_file(file_name);
+  return;
+}
+
+void display_options::do_slider(const int delay_) {
+  options_manager& options_mgr = options_manager::get_instance();
+  options_mgr.set_automatic_event_reading_delay(delay_);
+  std::ostringstream oss;
+  oss << delay_;
+  _show_delay_->SetText(oss.str().c_str());
+}
+
+void display_options::test_add_frame() {
+  // this->clear ();
+
+  // cout << "cocuou" << endl;
+  // this->_build_volume_buttons_ ();
+  // cout << "caca" << endl;
+
+  // _main_->UnmapWindow ();
+  // _main_->RemoveAll ();
+
+  TGGroupFrame* volume_group = new TGGroupFrame(_main_, "toto", kHorizontalFrame);
+  volume_group->SetTitlePos(TGGroupFrame::kLeft);
+  _main_->AddFrame(volume_group);
+
+  TGCheckButton* test = new TGCheckButton(volume_group, "test toto", 10000);
+  volume_group->AddFrame(test, new TGLayoutHints(kLHintsTop & kLHintsLeft, 2, 2, 2, 2));
+
+  volume_group->MapWindow();
+  // _main_->MapWindow ();
+  // _browser_->MapSubwindows ();
+  // _browser_->MapWindow ();
+}
+
+}  // end of namespace view
+
+}  // end of namespace visualization
 
 }  // end of namespace snemo
 

--- a/modules/EventBrowser/source/display_options.cc
+++ b/modules/EventBrowser/source/display_options.cc
@@ -54,7 +54,11 @@
 // - Falaise
 #include <falaise/resource.h>
 
+// Need trailing ; to satisfy clang-format, but leads to -pedantic error, ignore
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 ClassImp(snemo::visualization::view::display_options);
+#pragma GCC diagnostic pop
 
 namespace snemo {
 namespace visualization {

--- a/modules/EventBrowser/source/event_browser.cc
+++ b/modules/EventBrowser/source/event_browser.cc
@@ -47,7 +47,11 @@
 #include <TROOT.h>
 #include <TSystem.h>
 
+// Need trailing ; to satisfy clang-format, but leads to -pedantic error, ignore
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 ClassImp(snemo::visualization::view::event_browser);
+#pragma GCC diagnostic pop
 
 namespace snemo {
 namespace visualization {

--- a/modules/EventBrowser/source/event_browser.cc
+++ b/modules/EventBrowser/source/event_browser.cc
@@ -49,533 +49,531 @@
 
 ClassImp(snemo::visualization::view::event_browser);
 
-    namespace snemo {
-  namespace visualization {
+namespace snemo {
+namespace visualization {
 
-  namespace view {
+namespace view {
 
-  const io::event_server& event_browser::get_event_server() const { return *_event_server_; }
+const io::event_server& event_browser::get_event_server() const { return *_event_server_; }
 
-  io::event_server& event_browser::grab_event_server() { return *_event_server_; }
+io::event_server& event_browser::grab_event_server() { return *_event_server_; }
 
-  bool event_browser::is_initialized() const { return _initialized_; }
+bool event_browser::is_initialized() const { return _initialized_; }
 
-  void event_browser::welcome() const {
-    std::cout << std::endl;
-    std::cout << "\tSuperNEMO Event Browser                          " << std::endl
-              << "\tVersion " << EventBrowser::version::get_version() << std::endl
-              << "                                                   " << std::endl
-              << "\tCopyright (C) 2010-2017                          " << std::endl
-              << "\tSuperNEMO Collaboration                          " << std::endl
-              << "                                                   " << std::endl
-              << "\tCompiled with ROOT v" << gROOT->GetVersion() << std::endl;
-    std::cout << std::endl;
-    return;
-  }
+void event_browser::welcome() const {
+  std::cout << std::endl;
+  std::cout << "\tSuperNEMO Event Browser                          " << std::endl
+            << "\tVersion " << EventBrowser::version::get_version() << std::endl
+            << "                                                   " << std::endl
+            << "\tCopyright (C) 2010-2017                          " << std::endl
+            << "\tSuperNEMO Collaboration                          " << std::endl
+            << "                                                   " << std::endl
+            << "\tCompiled with ROOT v" << gROOT->GetVersion() << std::endl;
+  std::cout << std::endl;
+  return;
+}
 
-  // ctor:
-  event_browser::event_browser(const TGWindow* window_, const unsigned int width_,
-                               const unsigned int height_)
-      : TGMainFrame(window_, width_, height_) {
-    _menu_ = 0;
-    _display_ = 0;
+// ctor:
+event_browser::event_browser(const TGWindow* window_, const unsigned int width_,
+                             const unsigned int height_)
+    : TGMainFrame(window_, width_, height_) {
+  _menu_ = 0;
+  _display_ = 0;
+  _full_2d_display_ = 0;
+  _status_ = 0;
+  _handlers_ = 0;
+  _tabs_ = 0;
+  _event_server_ = 0;
+  _thread_ctrl_ = 0;
+  _initialized_ = false;
+  return;
+}
+
+// dtor:
+event_browser::~event_browser() {
+  this->reset();
+  return;
+}
+
+void event_browser::initialize() {
+  DT_THROW_IF(is_initialized(), std::logic_error, "Already initialized !");
+  this->_at_init_();
+  _initialized_ = true;
+  return;
+}
+
+void event_browser::reset() {
+  DT_THROW_IF(!is_initialized(), std::logic_error, "Not initialized !");
+  delete _event_server_;
+  _event_server_ = 0;
+
+  delete _display_;
+  _display_ = 0;
+
+  if (_full_2d_display_) {
+    delete _full_2d_display_;
     _full_2d_display_ = 0;
-    _status_ = 0;
-    _handlers_ = 0;
-    _tabs_ = 0;
-    _event_server_ = 0;
-    _thread_ctrl_ = 0;
-    _initialized_ = false;
+  }
+
+  delete _status_;
+  _status_ = 0;
+  delete _handlers_;
+  _status_ = 0;
+
+  delete _tabs_;
+  _tabs_ = 0;
+  delete _menu_;
+  _menu_ = 0;
+
+  _initialized_ = false;
+  return;
+}
+
+void event_browser::_at_init_() {
+  // Welcome printout
+  this->welcome();
+
+  // Event server
+  _event_server_ = new io::event_server;
+
+  // Initialize browser components
+  this->initialize_gui();
+  this->initialize_event_server();
+  return;
+}
+
+void event_browser::initialize_gui() {
+  // Connect virtual method CloseWindow to close_window
+  this->Connect("CloseWindow()", "snemo::visualization::view::event_browser", this,
+                "close_window()");
+
+  // Avoid double deletions.
+  this->DontCallClose();
+
+  // Use hierarchical cleaning
+  this->SetCleanup(kDeepCleanup);
+
+  // Add the menu
+  _menu_ = new event_browser_menu(this);
+
+  // Add the tabs
+  _tabs_ = new TGTab(this, this->GetWidth(), this->GetHeight());
+
+  TGCompositeFrame* event_display_frame = _tabs_->AddTab("Event Display");
+  // TGCompositeFrame * raw_data_frame      = _tabs_->AddTab("Raw Data");
+
+  // Raw data off by default
+  _tabs_->SetEnabled(ONLINE_DISPLAY, false);
+
+  // Set startup tab
+  _tabs_->SetTab(style_manager::get_instance().get_startup_tab());
+
+  _tab_is_uptodate_[EVENT_DISPLAY] = false;
+  _tab_is_uptodate_[ONLINE_DISPLAY] = false;
+
+  this->AddFrame(_tabs_, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY, 3, 3, 3, 3));
+
+  // Status bar
+  _status_ = new status_bar;
+  _status_->set_event_server(_event_server_);
+  _status_->initialize(this);
+
+  // Create plot objects
+  _display_ = new event_display;
+  _display_->set_event_server(_event_server_);
+  _display_->set_status_bar(_status_);
+  _display_->initialize(event_display_frame);
+  if (options_manager::get_instance().get_option_flag(FULL_2D_VIEW)) {
+    this->add_full_2d_view();
+  }
+
+  // Bindings
+  _handlers_ = new signal_handling(this);
+
+  this->SetIconPixmap("");
+  this->SetWindowName("SuperNEMO Event Browser - no input data ");
+  this->MapSubwindows();
+  this->Resize(this->GetDefaultSize());
+  this->MapWindow();
+  return;
+}
+
+void event_browser::initialize_event_server() {
+  const options_manager& options_mgr = options_manager::get_instance();
+  const std::vector<std::string> filenames = options_mgr.get_input_files();
+  // Check here the existence of file
+  std::vector<std::string> existing_files;
+  for (std::vector<std::string>::const_iterator it_file = filenames.begin();
+       it_file != filenames.end(); ++it_file) {
+    const std::string& a_file = *it_file;
+    if (!boost::filesystem::exists(a_file)) {
+      DT_LOG_WARNING(options_mgr.get_logging_priority(), a_file << " does not exist");
+      continue;
+    }
+    existing_files.push_back(a_file);
+  }
+
+  // No file bye bye
+  if (existing_files.empty()) {
+    DT_LOG_WARNING(options_mgr.get_logging_priority(), "No existing file specified!");
     return;
   }
 
-  // dtor:
-  event_browser::~event_browser() {
-    this->reset();
+  // Initialize event server
+  io::event_server& server = *_event_server_;
+  if (server.is_initialized()) server.reset();
+  if (!server.initialize(existing_files)) {
+    DT_LOG_WARNING(options_mgr.get_logging_priority(), "Cannot open data source!");
     return;
   }
 
-  void event_browser::initialize() {
-    DT_THROW_IF(is_initialized(), std::logic_error, "Already initialized !");
-    this->_at_init_();
-    _initialized_ = true;
-    return;
+  std::ostringstream message;
+  message << "Identified input data as: '" << server.get_file_type_as_string() << "' ";
+  if (server.has_sequential_data()) {
+    message << " (sequential reading mode)";
+  } else {
+    message << "(" << server.get_number_of_events() << " entries)";
+  }
+  DT_LOG_NOTICE(options_mgr.get_logging_priority(), message.str());
+
+  // Window title
+  std::ostringstream info;
+  info << "SuperNEMO snvisualization - reading from: ";
+  if (existing_files.size() < 1) {
+    info << "unknown...";
+  } else {
+    info << existing_files[0];
+    if (existing_files.size() > 1) info << " (and others)";
   }
 
-  void event_browser::reset() {
-    DT_THROW_IF(!is_initialized(), std::logic_error, "Not initialized !");
-    delete _event_server_;
-    _event_server_ = 0;
-
-    delete _display_;
-    _display_ = 0;
-
-    if (_full_2d_display_) {
-      delete _full_2d_display_;
-      _full_2d_display_ = 0;
-    }
-
-    delete _status_;
-    _status_ = 0;
-    delete _handlers_;
-    _status_ = 0;
-
-    delete _tabs_;
-    _tabs_ = 0;
-    delete _menu_;
-    _menu_ = 0;
-
-    _initialized_ = false;
+  this->SetWindowName(info.str().c_str());
+  if (!server.has_sequential_data() && server.get_number_of_events() == 0) {
+    DT_LOG_WARNING(options_mgr.get_logging_priority(), "No events found in the given file!");
     return;
   }
+  _status_->update(true);
 
-  void event_browser::_at_init_() {
-    // Welcome printout
-    this->welcome();
+  this->change_event(server.has_sequential_data() ? NEXT_EVENT : FIRST_EVENT);
+  return;
+}
 
-    // Event server
-    _event_server_ = new io::event_server;
+void event_browser::track_select() {
+  _display_->update(false, false);
+  return;
+}
 
-    // Initialize browser components
-    this->initialize_gui();
-    this->initialize_event_server();
-    return;
-  }
-
-  void event_browser::initialize_gui() {
-    // Connect virtual method CloseWindow to close_window
-    this->Connect("CloseWindow()", "snemo::visualization::view::event_browser", this,
-                  "close_window()");
-
-    // Avoid double deletions.
-    this->DontCallClose();
-
-    // Use hierarchical cleaning
-    this->SetCleanup(kDeepCleanup);
-
-    // Add the menu
-    _menu_ = new event_browser_menu(this);
-
-    // Add the tabs
-    _tabs_ = new TGTab(this, this->GetWidth(), this->GetHeight());
-
-    TGCompositeFrame* event_display_frame = _tabs_->AddTab("Event Display");
-    // TGCompositeFrame * raw_data_frame      = _tabs_->AddTab("Raw Data");
-
-    // Raw data off by default
-    _tabs_->SetEnabled(ONLINE_DISPLAY, false);
-
-    // Set startup tab
-    _tabs_->SetTab(style_manager::get_instance().get_startup_tab());
-
-    _tab_is_uptodate_[EVENT_DISPLAY] = false;
-    _tab_is_uptodate_[ONLINE_DISPLAY] = false;
-
-    this->AddFrame(_tabs_, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY, 3, 3, 3, 3));
-
-    // Status bar
-    _status_ = new status_bar;
-    _status_->set_event_server(_event_server_);
-    _status_->initialize(this);
-
-    // Create plot objects
-    _display_ = new event_display;
-    _display_->set_event_server(_event_server_);
-    _display_->set_status_bar(_status_);
-    _display_->initialize(event_display_frame);
-    if (options_manager::get_instance().get_option_flag(FULL_2D_VIEW)) {
-      this->add_full_2d_view();
-    }
-
-    // Bindings
-    _handlers_ = new signal_handling(this);
-
-    this->SetIconPixmap("");
-    this->SetWindowName("SuperNEMO Event Browser - no input data ");
-    this->MapSubwindows();
-    this->Resize(this->GetDefaultSize());
-    this->MapWindow();
-    return;
-  }
-
-  void event_browser::initialize_event_server() {
-    const options_manager& options_mgr = options_manager::get_instance();
-    const std::vector<std::string> filenames = options_mgr.get_input_files();
-    // Check here the existence of file
-    std::vector<std::string> existing_files;
-    for (std::vector<std::string>::const_iterator it_file = filenames.begin();
-         it_file != filenames.end(); ++it_file) {
-      const std::string& a_file = *it_file;
-      if (!boost::filesystem::exists(a_file)) {
-        DT_LOG_WARNING(options_mgr.get_logging_priority(), a_file << " does not exist");
-        continue;
-      }
-      existing_files.push_back(a_file);
-    }
-
-    // No file bye bye
-    if (existing_files.empty()) {
-      DT_LOG_WARNING(options_mgr.get_logging_priority(), "No existing file specified!");
-      return;
-    }
-
-    // Initialize event server
-    io::event_server& server = *_event_server_;
-    if (server.is_initialized()) server.reset();
-    if (!server.initialize(existing_files)) {
-      DT_LOG_WARNING(options_mgr.get_logging_priority(), "Cannot open data source!");
-      return;
-    }
-
-    std::ostringstream message;
-    message << "Identified input data as: '" << server.get_file_type_as_string() << "' ";
-    if (server.has_sequential_data()) {
-      message << " (sequential reading mode)";
-    } else {
-      message << "(" << server.get_number_of_events() << " entries)";
-    }
-    DT_LOG_NOTICE(options_mgr.get_logging_priority(), message.str());
-
-    // Window title
-    std::ostringstream info;
-    info << "SuperNEMO snvisualization - reading from: ";
-    if (existing_files.size() < 1) {
-      info << "unknown...";
-    } else {
-      info << existing_files[0];
-      if (existing_files.size() > 1) info << " (and others)";
-    }
-
-    this->SetWindowName(info.str().c_str());
-    if (!server.has_sequential_data() && server.get_number_of_events() == 0) {
-      DT_LOG_WARNING(options_mgr.get_logging_priority(), "No events found in the given file!");
-      return;
-    }
-    _status_->update(true);
-
-    this->change_event(server.has_sequential_data() ? NEXT_EVENT : FIRST_EVENT);
-    return;
-  }
-
-  void event_browser::track_select() {
-    _display_->update(false, false);
-    return;
-  }
-
-  void event_browser::add_full_2d_view() {
-    if (_full_2d_display_) {
-      // Remove full 2D view
-      _tabs_->RemoveTab(FULL_2D_DISPLAY);
-      delete _full_2d_display_;
-      _full_2d_display_ = 0;
-    } else {
-      // Create a new frame
-      TGCompositeFrame* full_2d_frame = _tabs_->AddTab("Full 2D View");
-      _tab_is_uptodate_[FULL_2D_DISPLAY] = false;
-
-      // Create additional 2D plot objects
-      _full_2d_display_ = new event_display;
-      _full_2d_display_->set_event_server(_event_server_);
-      _full_2d_display_->set_full_2d_display(true);
-      _full_2d_display_->initialize(full_2d_frame);
-    }
-    _tabs_->MapSubwindows();
-    _tabs_->Layout();
-    _tabs_->SetTab(FULL_2D_DISPLAY);
-    return;
-  }
-
-  void event_browser::update_browser(const bool reset_view_) {
-    _tab_is_uptodate_[EVENT_DISPLAY] = false;
+void event_browser::add_full_2d_view() {
+  if (_full_2d_display_) {
+    // Remove full 2D view
+    _tabs_->RemoveTab(FULL_2D_DISPLAY);
+    delete _full_2d_display_;
+    _full_2d_display_ = 0;
+  } else {
+    // Create a new frame
+    TGCompositeFrame* full_2d_frame = _tabs_->AddTab("Full 2D View");
     _tab_is_uptodate_[FULL_2D_DISPLAY] = false;
-    this->update_tab((tab_id_index_type)_tabs_->GetCurrent(), reset_view_);
-    return;
+
+    // Create additional 2D plot objects
+    _full_2d_display_ = new event_display;
+    _full_2d_display_->set_event_server(_event_server_);
+    _full_2d_display_->set_full_2d_display(true);
+    _full_2d_display_->initialize(full_2d_frame);
+  }
+  _tabs_->MapSubwindows();
+  _tabs_->Layout();
+  _tabs_->SetTab(FULL_2D_DISPLAY);
+  return;
+}
+
+void event_browser::update_browser(const bool reset_view_) {
+  _tab_is_uptodate_[EVENT_DISPLAY] = false;
+  _tab_is_uptodate_[FULL_2D_DISPLAY] = false;
+  this->update_tab((tab_id_index_type)_tabs_->GetCurrent(), reset_view_);
+  return;
+}
+
+void event_browser::update_tab(const tab_id_index_type index_, const bool reset_view_) {
+  if (_tab_is_uptodate_[index_]) return;
+
+  _menu_->set_default_option(*_event_server_);
+  switch (index_) {
+    case EVENT_DISPLAY:
+      _display_->update(reset_view_);
+      break;
+    case FULL_2D_DISPLAY:
+      _full_2d_display_->update(reset_view_);
+      break;
+    default:
+      break;
+  }
+  _tab_is_uptodate_[index_] = true;
+  return;
+}
+
+void event_browser::update_menu(const button_signals_type signal_) {
+  switch (signal_) {
+    case FULL_2D_VIEW:
+      this->add_full_2d_view();
+      _menu_->update(signal_);
+      break;
+    case VIEW_X3D:
+    case VIEW_OGL:
+    case PRINT_3D:
+    case PRINT_3D_AS_EPS:
+    case PRINT_2D:
+    case PRINT_2D_AS_EPS:
+    case SHOW_ALL_VERTICES:
+    case SHOW_ALL_MC_TRACKS:
+    case SHOW_ALL_MC_HITS:
+    case SHOW_ALL_MC_TRACKS_AND_HITS:
+    case SHOW_ALL_CALIBRATED_HITS:
+      _display_->handle_button_signals(signal_);
+      break;
+    case DUMP_EVENT:
+      _event_server_->dump_event(std::clog);
+      break;
+    case DUMP_INTO_TOOLTIP:
+    case DUMP_INTO_TERMINAL:
+    case DUMP_INTO_WINDOW:
+      _menu_->update(signal_);
+      _display_->update(false, true);
+      break;
+    default:
+      _menu_->update(signal_);
+      break;
+  }
+  return;
+}
+
+void event_browser::change_event(const button_signals_type signal_, const int event_selected_) {
+  // Change status bar icon following the reading mode
+  _status_->update_buttons(signal_);
+
+  // Sequential and external mode only allow NEXT_EVENT signal
+  if (_event_server_->has_sequential_data() || _event_server_->has_external_data()) {
+    if (signal_ != NEXT_EVENT) return;
   }
 
-  void event_browser::update_tab(const tab_id_index_type index_, const bool reset_view_) {
-    if (_tab_is_uptodate_[index_]) return;
+  // Event selection
+  _display_->handle_button_signals(signal_, event_selected_);
 
-    _menu_->set_default_option(*_event_server_);
-    switch (index_) {
-      case EVENT_DISPLAY:
-        _display_->update(reset_view_);
-        break;
-      case FULL_2D_DISPLAY:
-        _full_2d_display_->update(reset_view_);
-        break;
-      default:
-        break;
-    }
-    _tab_is_uptodate_[index_] = true;
-    return;
+  // Update browser
+  this->update_browser();
+
+  // Auto event reading logic
+  const options_manager& options_mgr = options_manager::get_instance();
+  if (options_mgr.is_automatic_event_reading_mode()) {
+    const size_t time_in_second = (size_t)options_mgr.get_automatic_event_reading_delay() * 1000;
+    TTimer::SingleShot(time_in_second, "snemo::visualization::view::event_browser", this,
+                       "change_event()");
   }
 
-  void event_browser::update_menu(const button_signals_type signal_) {
-    switch (signal_) {
-      case FULL_2D_VIEW:
-        this->add_full_2d_view();
-        _menu_->update(signal_);
-        break;
-      case VIEW_X3D:
-      case VIEW_OGL:
-      case PRINT_3D:
-      case PRINT_3D_AS_EPS:
-      case PRINT_2D:
-      case PRINT_2D_AS_EPS:
-      case SHOW_ALL_VERTICES:
-      case SHOW_ALL_MC_TRACKS:
-      case SHOW_ALL_MC_HITS:
-      case SHOW_ALL_MC_TRACKS_AND_HITS:
-      case SHOW_ALL_CALIBRATED_HITS:
-        _display_->handle_button_signals(signal_);
-        break;
-      case DUMP_EVENT:
-        _event_server_->dump_event(std::clog);
-        break;
-      case DUMP_INTO_TOOLTIP:
-      case DUMP_INTO_TERMINAL:
-      case DUMP_INTO_WINDOW:
-        _menu_->update(signal_);
-        _display_->update(false, true);
-        break;
-      default:
-        _menu_->update(signal_);
-        break;
-    }
-    return;
+  // Release thread
+  if (has_thread_ctrl()) {
+    this->unlock_thread();
   }
 
-  void event_browser::change_event(const button_signals_type signal_, const int event_selected_) {
-    // Change status bar icon following the reading mode
-    _status_->update_buttons(signal_);
+  return;
+}
 
-    // Sequential and external mode only allow NEXT_EVENT signal
-    if (_event_server_->has_sequential_data() || _event_server_->has_external_data()) {
-      if (signal_ != NEXT_EVENT) return;
-    }
+void event_browser::change_tab(const button_signals_type signal_) {
+  int ntabs = _tabs_->GetNumberOfTabs();
+  int current_tab = _tabs_->GetCurrent();
 
-    // Event selection
-    _display_->handle_button_signals(signal_, event_selected_);
-
-    // Update browser
-    this->update_browser();
-
-    // Auto event reading logic
-    const options_manager& options_mgr = options_manager::get_instance();
-    if (options_mgr.is_automatic_event_reading_mode()) {
-      const size_t time_in_second = (size_t)options_mgr.get_automatic_event_reading_delay() * 1000;
-      TTimer::SingleShot(time_in_second, "snemo::visualization::view::event_browser", this,
-                         "change_event()");
-    }
-
-    // Release thread
-    if (has_thread_ctrl()) {
-      this->unlock_thread();
-    }
-
-    return;
-  }
-
-  void event_browser::change_tab(const button_signals_type signal_) {
-    int ntabs = _tabs_->GetNumberOfTabs();
-    int current_tab = _tabs_->GetCurrent();
-
-    if (signal_ == NEXT_TAB) {
-      for (int itab = current_tab + 1; itab < ntabs; itab++) {
-        if (_tabs_->IsEnabled(itab)) {
-          _tabs_->SetTab(itab);
-          return;
-        }
-      }
-      for (int itab = 0; itab < current_tab; itab++) {
-        if (_tabs_->IsEnabled(itab)) {
-          _tabs_->SetTab(itab);
-          return;
-        }
-      }
-    }
-
-    if (signal_ == PREVIOUS_TAB) {
-      for (int itab = current_tab - 1; itab > -1; itab--) {
-        if (_tabs_->IsEnabled(itab)) {
-          _tabs_->SetTab(itab);
-          return;
-        }
-      }
-      for (int itab = ntabs - 1; itab > current_tab; itab--) {
-        if (_tabs_->IsEnabled(itab)) {
-          _tabs_->SetTab(itab);
-          return;
-        }
+  if (signal_ == NEXT_TAB) {
+    for (int itab = current_tab + 1; itab < ntabs; itab++) {
+      if (_tabs_->IsEnabled(itab)) {
+        _tabs_->SetTab(itab);
+        return;
       }
     }
-    return;
-  }
-
-  void event_browser::close_window() {
-    if (has_thread_ctrl()) {
-      event_browser_ctrl& thread_ctrl = grab_thread_ctrl();
-      thread_ctrl.event_availability_status = event_browser_ctrl::ABORT;
-      stop_threading();
-      unlock_thread();
-    } else {
-      gApplication->Terminate();
-    }
-    return;
-  }
-
-  bool event_browser::handle_key(Event_t* event_) { return _handlers_->handle_key(event_); }
-
-  bool event_browser::process_message(long msg_, long parm1_, long parm2_) {
-    return _handlers_->process_message(msg_, parm1_, parm2_);
-  }
-
-  /*************************************************************/
-
-  bool event_browser::has_thread_ctrl() const { return _thread_ctrl_ != 0; }
-
-  void event_browser::set_thread_ctrl(event_browser_ctrl& thread_ctrl_) {
-    DT_THROW_IF(has_thread_ctrl(), std::logic_error,
-                "Operation prohibited ! Event browser already got a 'thread ctrl' object !");
-    _thread_ctrl_ = &thread_ctrl_;
-    return;
-  }
-
-  const event_browser_ctrl& event_browser::get_thread_ctrl() const {
-    DT_THROW_IF(!has_thread_ctrl(), std::logic_error, "Manager has no 'thread ctrl' object !");
-    return *_thread_ctrl_;
-  }
-
-  event_browser_ctrl& event_browser::grab_thread_ctrl() {
-    DT_THROW_IF(!has_thread_ctrl(), std::logic_error, "Manager has no 'thread ctrl' object !");
-    return *_thread_ctrl_;
-  }
-
-  void event_browser::unlock_thread() {
-    // Debugging...
-    bool must_abort_run = false;
-
-    // External threaded run control :
-    if (has_thread_ctrl()) {
-      DT_LOG_TRACE(options_manager::get_instance().get_logging_priority(),
-                   "Using event control...");
-      event_browser_ctrl& thread_ctrl = grab_thread_ctrl();
-      {
-        DT_LOG_TRACE(options_manager::get_instance().get_logging_priority(),
-                     "Acquire the event control lock...");
-        boost::mutex::scoped_lock lock(*thread_ctrl.event_mutex);
-        DT_LOG_TRACE(options_manager::get_instance().get_logging_priority(),
-                     "Wait for event control to be available again...");
-        while (thread_ctrl.event_availability_status != event_browser_ctrl::AVAILABLE_FOR_ROOT) {
-          DT_LOG_TRACE(options_manager::get_instance().get_logging_priority(), "Not yet...");
-          thread_ctrl.event_available_condition->wait(*thread_ctrl.event_mutex);
-        }
-        DT_LOG_TRACE(options_manager::get_instance().get_logging_priority(), "Ok let's go on...");
-        if (thread_ctrl.event_availability_status == event_browser_ctrl::ABORT) {
-          must_abort_run = true;
-        }
-        thread_ctrl.event_availability_status = event_browser_ctrl::NOT_AVAILABLE_FOR_ROOT;
-        thread_ctrl.counts++;
-        DT_LOG_TRACE(options_manager::get_instance().get_logging_priority(),
-                     "Notify the event browser...");
-        thread_ctrl.event_available_condition->notify_one();
-      }
-
-      // Wait for the release of the event control by the external process :
-      {
-        DT_LOG_TRACE(options_manager::get_instance().get_logging_priority(),
-                     "Wait for the release of the event control by the external process...");
-        boost::mutex::scoped_lock lock(*thread_ctrl.event_mutex);
-        while (thread_ctrl.event_availability_status ==
-               event_browser_ctrl::NOT_AVAILABLE_FOR_ROOT) {
-          DT_LOG_TRACE(options_manager::get_instance().get_logging_priority(), "Not yet...");
-          thread_ctrl.event_available_condition->wait(*thread_ctrl.event_mutex);
-        }
-        DT_LOG_TRACE(options_manager::get_instance().get_logging_priority(),
-                     "Ok ! The event control is released by the external process...");
-        if (thread_ctrl.event_availability_status == event_browser_ctrl::ABORT) {
-          DT_LOG_WARNING(options_manager::get_instance().get_logging_priority(),
-                         "Detected an 'Abort' request from the external process...");
-          must_abort_run = true;
-        }
-      }
-
-      if (thread_ctrl.is_stop_requested()) {
-        must_abort_run = true;
-      }
-      if (thread_ctrl.max_counts > 0 && thread_ctrl.counts > thread_ctrl.max_counts) {
-        must_abort_run = true;
+    for (int itab = 0; itab < current_tab; itab++) {
+      if (_tabs_->IsEnabled(itab)) {
+        _tabs_->SetTab(itab);
+        return;
       }
     }
-
-    // Abort run condition :
-    if (must_abort_run) {
-      stop_threading();
-    }
-    return;
   }
 
-  void event_browser::lock_thread() {
-    if (!has_thread_ctrl()) {
-      DT_LOG_TRACE(options_manager::get_instance().get_logging_priority(), "No thread ctrl !");
-      return;
+  if (signal_ == PREVIOUS_TAB) {
+    for (int itab = current_tab - 1; itab > -1; itab--) {
+      if (_tabs_->IsEnabled(itab)) {
+        _tabs_->SetTab(itab);
+        return;
+      }
     }
-    DT_LOG_TRACE(options_manager::get_instance().get_logging_priority(), "Check point.");
+    for (int itab = ntabs - 1; itab > current_tab; itab--) {
+      if (_tabs_->IsEnabled(itab)) {
+        _tabs_->SetTab(itab);
+        return;
+      }
+    }
+  }
+  return;
+}
+
+void event_browser::close_window() {
+  if (has_thread_ctrl()) {
+    event_browser_ctrl& thread_ctrl = grab_thread_ctrl();
+    thread_ctrl.event_availability_status = event_browser_ctrl::ABORT;
+    stop_threading();
+    unlock_thread();
+  } else {
+    gApplication->Terminate();
+  }
+  return;
+}
+
+bool event_browser::handle_key(Event_t* event_) { return _handlers_->handle_key(event_); }
+
+bool event_browser::process_message(long msg_, long parm1_, long parm2_) {
+  return _handlers_->process_message(msg_, parm1_, parm2_);
+}
+
+/*************************************************************/
+
+bool event_browser::has_thread_ctrl() const { return _thread_ctrl_ != 0; }
+
+void event_browser::set_thread_ctrl(event_browser_ctrl& thread_ctrl_) {
+  DT_THROW_IF(has_thread_ctrl(), std::logic_error,
+              "Operation prohibited ! Event browser already got a 'thread ctrl' object !");
+  _thread_ctrl_ = &thread_ctrl_;
+  return;
+}
+
+const event_browser_ctrl& event_browser::get_thread_ctrl() const {
+  DT_THROW_IF(!has_thread_ctrl(), std::logic_error, "Manager has no 'thread ctrl' object !");
+  return *_thread_ctrl_;
+}
+
+event_browser_ctrl& event_browser::grab_thread_ctrl() {
+  DT_THROW_IF(!has_thread_ctrl(), std::logic_error, "Manager has no 'thread ctrl' object !");
+  return *_thread_ctrl_;
+}
+
+void event_browser::unlock_thread() {
+  // Debugging...
+  bool must_abort_run = false;
+
+  // External threaded run control :
+  if (has_thread_ctrl()) {
+    DT_LOG_TRACE(options_manager::get_instance().get_logging_priority(), "Using event control...");
     event_browser_ctrl& thread_ctrl = grab_thread_ctrl();
     {
-      DT_LOG_TRACE(options_manager::get_instance().get_logging_priority(), "Acquire the lock...");
+      DT_LOG_TRACE(options_manager::get_instance().get_logging_priority(),
+                   "Acquire the event control lock...");
       boost::mutex::scoped_lock lock(*thread_ctrl.event_mutex);
       DT_LOG_TRACE(options_manager::get_instance().get_logging_priority(),
-                   "Wait for the event control to be available again for ROOT "
-                       << "and for event loop start ...");
+                   "Wait for event control to be available again...");
+      while (thread_ctrl.event_availability_status != event_browser_ctrl::AVAILABLE_FOR_ROOT) {
+        DT_LOG_TRACE(options_manager::get_instance().get_logging_priority(), "Not yet...");
+        thread_ctrl.event_available_condition->wait(*thread_ctrl.event_mutex);
+      }
+      DT_LOG_TRACE(options_manager::get_instance().get_logging_priority(), "Ok let's go on...");
+      if (thread_ctrl.event_availability_status == event_browser_ctrl::ABORT) {
+        must_abort_run = true;
+      }
+      thread_ctrl.event_availability_status = event_browser_ctrl::NOT_AVAILABLE_FOR_ROOT;
+      thread_ctrl.counts++;
+      DT_LOG_TRACE(options_manager::get_instance().get_logging_priority(),
+                   "Notify the event browser...");
+      thread_ctrl.event_available_condition->notify_one();
+    }
+
+    // Wait for the release of the event control by the external process :
+    {
+      DT_LOG_TRACE(options_manager::get_instance().get_logging_priority(),
+                   "Wait for the release of the event control by the external process...");
+      boost::mutex::scoped_lock lock(*thread_ctrl.event_mutex);
       while (thread_ctrl.event_availability_status == event_browser_ctrl::NOT_AVAILABLE_FOR_ROOT) {
         DT_LOG_TRACE(options_manager::get_instance().get_logging_priority(), "Not yet...");
         thread_ctrl.event_available_condition->wait(*thread_ctrl.event_mutex);
       }
+      DT_LOG_TRACE(options_manager::get_instance().get_logging_priority(),
+                   "Ok ! The event control is released by the external process...");
       if (thread_ctrl.event_availability_status == event_browser_ctrl::ABORT) {
         DT_LOG_WARNING(options_manager::get_instance().get_logging_priority(),
-                       "Detect a 'Abort' request from the external process !");
-        stop_threading();
-      }
-      DT_LOG_TRACE(options_manager::get_instance().get_logging_priority(),
-                   "Starting the ROOT browsing...");
-    }
-    return;
-  }
-
-  void event_browser::wait() {
-    if (has_thread_ctrl()) {
-      const event_browser_ctrl& thread_ctrl = get_thread_ctrl();
-      while (thread_ctrl.event_availability_status != event_browser_ctrl::ABORT) {
-        gSystem->Sleep(100);
-        gSystem->ProcessEvents();
+                       "Detected an 'Abort' request from the external process...");
+        must_abort_run = true;
       }
     }
-    return;
+
+    if (thread_ctrl.is_stop_requested()) {
+      must_abort_run = true;
+    }
+    if (thread_ctrl.max_counts > 0 && thread_ctrl.counts > thread_ctrl.max_counts) {
+      must_abort_run = true;
+    }
   }
 
-  void event_browser::start_threading() {
-    DT_THROW_IF(!has_thread_ctrl(), std::logic_error, "Event browser has no connected thread !");
-    lock_thread();
-    std::ostringstream window_name;
-    window_name << "SuperNEMO Event Browser Module - automatic event processing";
-    this->SetWindowName(window_name.str().c_str());
-    _menu_->set_default_option(*_event_server_);
-    change_event(NEXT_EVENT);
-    wait();
+  // Abort run condition :
+  if (must_abort_run) {
+    stop_threading();
+  }
+  return;
+}
+
+void event_browser::lock_thread() {
+  if (!has_thread_ctrl()) {
+    DT_LOG_TRACE(options_manager::get_instance().get_logging_priority(), "No thread ctrl !");
     return;
   }
-
-  void event_browser::stop_threading() {
-    DT_THROW_IF(!has_thread_ctrl(), std::logic_error, "Event browser has no connected thread !");
-    DT_LOG_NOTICE(options_manager::get_instance().get_logging_priority(), "Visualization stops !");
-    //        close_window();
-    return;
+  DT_LOG_TRACE(options_manager::get_instance().get_logging_priority(), "Check point.");
+  event_browser_ctrl& thread_ctrl = grab_thread_ctrl();
+  {
+    DT_LOG_TRACE(options_manager::get_instance().get_logging_priority(), "Acquire the lock...");
+    boost::mutex::scoped_lock lock(*thread_ctrl.event_mutex);
+    DT_LOG_TRACE(options_manager::get_instance().get_logging_priority(),
+                 "Wait for the event control to be available again for ROOT "
+                     << "and for event loop start ...");
+    while (thread_ctrl.event_availability_status == event_browser_ctrl::NOT_AVAILABLE_FOR_ROOT) {
+      DT_LOG_TRACE(options_manager::get_instance().get_logging_priority(), "Not yet...");
+      thread_ctrl.event_available_condition->wait(*thread_ctrl.event_mutex);
+    }
+    if (thread_ctrl.event_availability_status == event_browser_ctrl::ABORT) {
+      DT_LOG_WARNING(options_manager::get_instance().get_logging_priority(),
+                     "Detect a 'Abort' request from the external process !");
+      stop_threading();
+    }
+    DT_LOG_TRACE(options_manager::get_instance().get_logging_priority(),
+                 "Starting the ROOT browsing...");
   }
+  return;
+}
 
-  }  // end of namespace view
+void event_browser::wait() {
+  if (has_thread_ctrl()) {
+    const event_browser_ctrl& thread_ctrl = get_thread_ctrl();
+    while (thread_ctrl.event_availability_status != event_browser_ctrl::ABORT) {
+      gSystem->Sleep(100);
+      gSystem->ProcessEvents();
+    }
+  }
+  return;
+}
 
-  }  // end of namespace visualization
+void event_browser::start_threading() {
+  DT_THROW_IF(!has_thread_ctrl(), std::logic_error, "Event browser has no connected thread !");
+  lock_thread();
+  std::ostringstream window_name;
+  window_name << "SuperNEMO Event Browser Module - automatic event processing";
+  this->SetWindowName(window_name.str().c_str());
+  _menu_->set_default_option(*_event_server_);
+  change_event(NEXT_EVENT);
+  wait();
+  return;
+}
+
+void event_browser::stop_threading() {
+  DT_THROW_IF(!has_thread_ctrl(), std::logic_error, "Event browser has no connected thread !");
+  DT_LOG_NOTICE(options_manager::get_instance().get_logging_priority(), "Visualization stops !");
+  //        close_window();
+  return;
+}
+
+}  // end of namespace view
+
+}  // end of namespace visualization
 
 }  // end of namespace snemo
 

--- a/modules/EventBrowser/source/event_browser.cc
+++ b/modules/EventBrowser/source/event_browser.cc
@@ -47,7 +47,7 @@
 #include <TROOT.h>
 #include <TSystem.h>
 
-ClassImp(snemo::visualization::view::event_browser)
+ClassImp(snemo::visualization::view::event_browser);
 
     namespace snemo {
   namespace visualization {

--- a/modules/EventBrowser/source/event_selection.cc
+++ b/modules/EventBrowser/source/event_selection.cc
@@ -48,871 +48,866 @@
 
 ClassImp(snemo::visualization::view::event_selection);
 
-    namespace snemo {
-  namespace visualization {
+namespace snemo {
+namespace visualization {
 
-  namespace view {
+namespace view {
 
-  const std::string &multi_and_cut_label() {
-    static const std::string _label("_visu.and.cut");
-    return _label;
+const std::string &multi_and_cut_label() {
+  static const std::string _label("_visu.and.cut");
+  return _label;
+}
+
+const std::string &multi_or_cut_label() {
+  static const std::string _label("_visu.or.cut");
+  return _label;
+}
+
+const std::string &multi_xor_cut_label() {
+  static const std::string _label("_visu.xor.cut");
+  return _label;
+}
+
+const std::string &eh_cut_label() {
+  static const std::string _label("_visu.eh.cut");
+  return _label;
+}
+
+const std::string &sd_cut_label() {
+  static const std::string _label("_visu.sd.cut");
+  return _label;
+}
+
+// Private data member not to expose
+class base_widget {
+ public:
+  base_widget(event_selection *selection_, int id_ = 0);
+  virtual ~base_widget();
+  virtual void initialize() = 0;
+  virtual void set_state() = 0;
+  virtual bool get_state() const = 0;
+  virtual void build(TGCompositeFrame *frame_) = 0;
+  virtual std::string get_cut_name() = 0;
+  virtual int id();
+
+ protected:
+  event_selection *_selection;
+  int _id;
+};
+
+/// Structure hosting GUI widgets
+class selection_widget : public base_widget {
+ public:
+  selection_widget(event_selection *selection_);
+  virtual void initialize();
+  virtual void set_state();
+  virtual bool get_state() const;
+  virtual void build(TGCompositeFrame *frame_);
+  virtual std::string get_cut_name();
+
+ private:
+  TGRadioButton *_or_button_;
+  TGRadioButton *_and_button_;
+  TGRadioButton *_xor_button_;
+};
+
+/// Structure hosting complex selection widgets
+class complex_selection_widget : public base_widget {
+ public:
+  complex_selection_widget(event_selection *selection_);
+  virtual void initialize();
+  virtual void set_state();
+  virtual bool get_state() const;
+  virtual void build(TGCompositeFrame *frame_);
+  virtual std::string get_cut_name();
+
+ private:
+  TGCheckButton *_enable_;
+  TGComboBox *_combo_;
+};
+
+/// Structure hosting event header selection widgets
+class event_header_selection_widget : public base_widget {
+ public:
+  event_header_selection_widget(event_selection *selection_);
+  virtual void initialize();
+  virtual void set_state();
+  virtual bool get_state() const;
+  virtual void build(TGCompositeFrame *frame_);
+  virtual std::string get_cut_name();
+
+ private:
+  TGCheckButton *_enable_;
+  TGNumberEntry *_run_id_min_;
+  TGNumberEntry *_run_id_max_;
+  TGNumberEntry *_event_id_min_;
+  TGNumberEntry *_event_id_max_;
+};
+
+// struct simulated_data_selection_widget : public base_widget
+// {
+// public:
+//   simulated_data_selection_widget(event_selection * selection_);
+//   virtual void initialize();
+//   virtual void set_state(const bool enable_ = true);
+//   virtual void build(TGCompositeFrame * frame_);
+// private:
+//   TGCheckButton * _enable_;
+//   TGTextEntry * _hit_category_;
+// };
+
+base_widget::base_widget(event_selection *selection_, int id_) : _selection(selection_), _id(id_) {
+  return;
+}
+
+base_widget::~base_widget() { return; }
+
+int base_widget::id() { return _id; }
+
+selection_widget::selection_widget(event_selection *selection_)
+    : base_widget(selection_, ENABLE_LOGIC_SELECTION) {
+  return;
+}
+
+void selection_widget::initialize() {
+  _or_button_->SetOn(false);
+  _and_button_->SetOn(true);
+  _xor_button_->SetOn(false);
+  return;
+}
+
+void selection_widget::set_state() { return; }
+
+bool selection_widget::get_state() const {
+  // Always return false since there is no activation check box associated
+  return false;
+}
+
+void selection_widget::build(TGCompositeFrame *frame_) {
+  TGHButtonGroup *bgroup = new TGHButtonGroup(frame_, "Event selection logic");
+  bgroup->SetTitlePos(TGGroupFrame::kLeft);
+  frame_->AddFrame(bgroup, new TGLayoutHints(kLHintsBottom | kLHintsLeft, 3, 3, 3, 3));
+
+  _or_button_ = new TGRadioButton(bgroup, "or ", OR_SELECTION);
+  _and_button_ = new TGRadioButton(bgroup, "and ", AND_SELECTION);
+  _xor_button_ = new TGRadioButton(bgroup, "xor ", XOR_SELECTION);
+  _or_button_->Connect("Clicked()", "snemo::visualization::view::event_selection", _selection,
+                       "process()");
+  _and_button_->Connect("Clicked()", "snemo::visualization::view::event_selection", _selection,
+                        "process()");
+  _xor_button_->Connect("Clicked()", "snemo::visualization::view::event_selection", _selection,
+                        "process()");
+
+  // Initialize values
+  initialize();
+  return;
+}
+
+std::string selection_widget::get_cut_name() {
+  std::string cut_name;
+  if (_and_button_->IsDown()) {
+    cut_name = multi_and_cut_label();
+  } else if (_or_button_->IsDown()) {
+    cut_name = multi_or_cut_label();
+  } else if (_xor_button_->IsDown()) {
+    cut_name = multi_xor_cut_label();
+  } else {
+    DT_THROW_IF(true, std::logic_error, "None of the cut (AND, XOR, OR) have been registered !");
   }
 
-  const std::string &multi_or_cut_label() {
-    static const std::string _label("_visu.or.cut");
-    return _label;
+  // Instantiate cut if needed
+  cuts::cut_manager &a_cut_mgr = _selection->grab_cut_manager();
+  cuts::cut_handle_dict_type &the_cuts = a_cut_mgr.get_cuts();
+  cuts::cut_handle_dict_type::iterator found = the_cuts.find(cut_name);
+  DT_THROW_IF(found == the_cuts.end(), std::logic_error,
+              "Cut '" << cut_name << "' has not been registered !");
+  found = the_cuts.find(cut_name);
+
+  // Reset cut
+  cuts::cut_entry_type &a_cet = found->second;
+  if (a_cet.is_initialized()) {
+    a_cet.grab_cut().reset();
+    a_cet.set_uninitialized();
   }
+  return cut_name;
+}
 
-  const std::string &multi_xor_cut_label() {
-    static const std::string _label("_visu.xor.cut");
-    return _label;
-  }
+complex_selection_widget::complex_selection_widget(event_selection *selection_)
+    : base_widget(selection_, ENABLE_COMPLEX_SELECTION) {
+  return;
+}
 
-  const std::string &eh_cut_label() {
-    static const std::string _label("_visu.eh.cut");
-    return _label;
-  }
-
-  const std::string &sd_cut_label() {
-    static const std::string _label("_visu.sd.cut");
-    return _label;
-  }
-
-  // Private data member not to expose
-  class base_widget {
-   public:
-    base_widget(event_selection *selection_, int id_ = 0);
-    virtual ~base_widget();
-    virtual void initialize() = 0;
-    virtual void set_state() = 0;
-    virtual bool get_state() const = 0;
-    virtual void build(TGCompositeFrame *frame_) = 0;
-    virtual std::string get_cut_name() = 0;
-    virtual int id();
-
-   protected:
-    event_selection *_selection;
-    int _id;
-  };
-
-  /// Structure hosting GUI widgets
-  class selection_widget : public base_widget {
-   public:
-    selection_widget(event_selection *selection_);
-    virtual void initialize();
-    virtual void set_state();
-    virtual bool get_state() const;
-    virtual void build(TGCompositeFrame *frame_);
-    virtual std::string get_cut_name();
-
-   private:
-    TGRadioButton *_or_button_;
-    TGRadioButton *_and_button_;
-    TGRadioButton *_xor_button_;
-  };
-
-  /// Structure hosting complex selection widgets
-  class complex_selection_widget : public base_widget {
-   public:
-    complex_selection_widget(event_selection *selection_);
-    virtual void initialize();
-    virtual void set_state();
-    virtual bool get_state() const;
-    virtual void build(TGCompositeFrame *frame_);
-    virtual std::string get_cut_name();
-
-   private:
-    TGCheckButton *_enable_;
-    TGComboBox *_combo_;
-  };
-
-  /// Structure hosting event header selection widgets
-  class event_header_selection_widget : public base_widget {
-   public:
-    event_header_selection_widget(event_selection *selection_);
-    virtual void initialize();
-    virtual void set_state();
-    virtual bool get_state() const;
-    virtual void build(TGCompositeFrame *frame_);
-    virtual std::string get_cut_name();
-
-   private:
-    TGCheckButton *_enable_;
-    TGNumberEntry *_run_id_min_;
-    TGNumberEntry *_run_id_max_;
-    TGNumberEntry *_event_id_min_;
-    TGNumberEntry *_event_id_max_;
-  };
-
-  // struct simulated_data_selection_widget : public base_widget
-  // {
-  // public:
-  //   simulated_data_selection_widget(event_selection * selection_);
-  //   virtual void initialize();
-  //   virtual void set_state(const bool enable_ = true);
-  //   virtual void build(TGCompositeFrame * frame_);
-  // private:
-  //   TGCheckButton * _enable_;
-  //   TGTextEntry * _hit_category_;
-  // };
-
-  base_widget::base_widget(event_selection *selection_, int id_)
-      : _selection(selection_), _id(id_) {
-    return;
-  }
-
-  base_widget::~base_widget() { return; }
-
-  int base_widget::id() { return _id; }
-
-  selection_widget::selection_widget(event_selection *selection_)
-      : base_widget(selection_, ENABLE_LOGIC_SELECTION) {
-    return;
-  }
-
-  void selection_widget::initialize() {
-    _or_button_->SetOn(false);
-    _and_button_->SetOn(true);
-    _xor_button_->SetOn(false);
-    return;
-  }
-
-  void selection_widget::set_state() { return; }
-
-  bool selection_widget::get_state() const {
-    // Always return false since there is no activation check box associated
-    return false;
-  }
-
-  void selection_widget::build(TGCompositeFrame *frame_) {
-    TGHButtonGroup *bgroup = new TGHButtonGroup(frame_, "Event selection logic");
-    bgroup->SetTitlePos(TGGroupFrame::kLeft);
-    frame_->AddFrame(bgroup, new TGLayoutHints(kLHintsBottom | kLHintsLeft, 3, 3, 3, 3));
-
-    _or_button_ = new TGRadioButton(bgroup, "or ", OR_SELECTION);
-    _and_button_ = new TGRadioButton(bgroup, "and ", AND_SELECTION);
-    _xor_button_ = new TGRadioButton(bgroup, "xor ", XOR_SELECTION);
-    _or_button_->Connect("Clicked()", "snemo::visualization::view::event_selection", _selection,
-                         "process()");
-    _and_button_->Connect("Clicked()", "snemo::visualization::view::event_selection", _selection,
-                          "process()");
-    _xor_button_->Connect("Clicked()", "snemo::visualization::view::event_selection", _selection,
-                          "process()");
-
-    // Initialize values
-    initialize();
-    return;
-  }
-
-  std::string selection_widget::get_cut_name() {
-    std::string cut_name;
-    if (_and_button_->IsDown()) {
-      cut_name = multi_and_cut_label();
-    } else if (_or_button_->IsDown()) {
-      cut_name = multi_or_cut_label();
-    } else if (_xor_button_->IsDown()) {
-      cut_name = multi_xor_cut_label();
-    } else {
-      DT_THROW_IF(true, std::logic_error, "None of the cut (AND, XOR, OR) have been registered !");
+void complex_selection_widget::initialize() {
+  _enable_->SetState(kButtonUp);
+  _combo_->RemoveAll();
+  size_t j = 1;
+  for (const auto &i : _selection->get_cut_manager().get_cuts()) {
+    const std::string &the_cut_name = i.first;
+    if (the_cut_name[0] != '_') {
+      _combo_->AddEntry(the_cut_name.c_str(), j++);
     }
+  }
+  if (j == 1) {
+    _combo_->AddEntry(" +++ NO CUTS +++ ", 0);
+    _combo_->SetEnabled(false);
+    _enable_->SetEnabled(false);
+    _enable_->SetToolTipText("no complex cuts defined");
+  } else {
+    _combo_->AddEntry(" +++ SELECT CUT NAME +++ ", 0);
+    _combo_->SetEnabled(true);
+  }
+  _combo_->Select(0);
+  return;
+}
 
-    // Instantiate cut if needed
-    cuts::cut_manager &a_cut_mgr = _selection->grab_cut_manager();
-    cuts::cut_handle_dict_type &the_cuts = a_cut_mgr.get_cuts();
-    cuts::cut_handle_dict_type::iterator found = the_cuts.find(cut_name);
-    DT_THROW_IF(found == the_cuts.end(), std::logic_error,
-                "Cut '" << cut_name << "' has not been registered !");
-    found = the_cuts.find(cut_name);
+void complex_selection_widget::set_state() {
+  bool enable = _enable_->IsDown();
+  _combo_->SetEnabled(enable);
+  return;
+}
 
-    // Reset cut
-    cuts::cut_entry_type &a_cet = found->second;
-    if (a_cet.is_initialized()) {
-      a_cet.grab_cut().reset();
-      a_cet.set_uninitialized();
+bool complex_selection_widget::get_state() const {
+  if (_enable_->IsEnabled()) {
+    return _enable_->IsDown();
+  }
+  return false;
+}
+
+void complex_selection_widget::build(TGCompositeFrame *frame_) {
+  TGGroupFrame *gframe = new TGGroupFrame(frame_, "      Complex cuts", kVerticalFrame);
+  gframe->SetTitlePos(TGGroupFrame::kLeft);
+  frame_->AddFrame(gframe, new TGLayoutHints(kLHintsTop | kLHintsLeft, 3, 3, 3, 3));
+  _enable_ = new TGCheckButton(gframe, "", ENABLE_COMPLEX_SELECTION);
+  _enable_->Connect("Clicked()", "snemo::visualization::view::event_selection", _selection,
+                    "process()");
+  gframe->AddFrame(_enable_, new TGLayoutHints(kLHintsTop | kLHintsLeft, 0, 0, -15, 0));
+
+  TGCompositeFrame *cframe = new TGCompositeFrame(gframe, 200, 1, kHorizontalFrame | kFixedWidth);
+  gframe->AddFrame(cframe);
+
+  _combo_ = new TGComboBox(cframe, COMBO_SELECTION);
+  _combo_->Connect("Selected(int)", "snemo::visualization::view::event_selection", _selection,
+                   "process()");
+  _combo_->Resize(200, 20);
+  cframe->AddFrame(
+      _combo_,
+      new TGLayoutHints(kLHintsTop | kLHintsLeft | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
+  initialize();
+  return;
+}
+
+std::string complex_selection_widget::get_cut_name() {
+  if (!_enable_->IsDown()) return {};  // empty string
+
+  std::string cut_label;
+  if (_combo_->GetSelected() != 0) {
+    TGTextLBEntry *tgt = (TGTextLBEntry *)_combo_->GetSelectedEntry();
+    cut_label = tgt->GetText()->GetString();
+  }
+
+  return cut_label;
+}
+
+event_header_selection_widget::event_header_selection_widget(event_selection *selection_)
+    : base_widget(selection_, ENABLE_EH_SELECTION) {
+  return;
+}
+
+void event_header_selection_widget::initialize() {
+  _enable_->SetState(kButtonUp);
+  _run_id_min_->SetNumber(datatools::event_id::INVALID_RUN_NUMBER);
+  _run_id_max_->SetNumber(datatools::event_id::INVALID_RUN_NUMBER);
+  _event_id_min_->SetNumber(datatools::event_id::INVALID_EVENT_NUMBER);
+  _event_id_max_->SetNumber(datatools::event_id::INVALID_EVENT_NUMBER);
+}
+
+void event_header_selection_widget::set_state() {
+  bool enable = _enable_->IsDown();
+  const io::event_server &server = _selection->get_event_server();
+  if (!server.get_event().has(io::EH_LABEL)) {
+    DT_LOG_WARNING(options_manager::get_instance().get_logging_priority(),
+                   "No event header data bank");
+    _enable_->SetToolTipText("no event header bank");
+    _enable_->SetState(kButtonDisabled);
+    enable = false;
+  } else {
+    if (!_enable_->IsEnabled()) {
+      _enable_->SetState(kButtonEngaged);
     }
-    return cut_name;
   }
+  _run_id_min_->SetState(enable);
+  _run_id_max_->SetState(enable);
+  _event_id_min_->SetState(enable);
+  _event_id_max_->SetState(enable);
+  return;
+}
 
-  complex_selection_widget::complex_selection_widget(event_selection *selection_)
-      : base_widget(selection_, ENABLE_COMPLEX_SELECTION) {
-    return;
+bool event_header_selection_widget::get_state() const {
+  if (_enable_->IsEnabled()) {
+    return _enable_->IsDown();
   }
+  return false;
+}
 
-  void complex_selection_widget::initialize() {
-    _enable_->SetState(kButtonUp);
-    _combo_->RemoveAll();
-    size_t j = 1;
-    for (const auto &i : _selection->get_cut_manager().get_cuts()) {
-      const std::string &the_cut_name = i.first;
-      if (the_cut_name[0] != '_') {
-        _combo_->AddEntry(the_cut_name.c_str(), j++);
-      }
-    }
-    if (j == 1) {
-      _combo_->AddEntry(" +++ NO CUTS +++ ", 0);
-      _combo_->SetEnabled(false);
-      _enable_->SetEnabled(false);
-      _enable_->SetToolTipText("no complex cuts defined");
-    } else {
-      _combo_->AddEntry(" +++ SELECT CUT NAME +++ ", 0);
-      _combo_->SetEnabled(true);
-    }
-    _combo_->Select(0);
-    return;
-  }
+void event_header_selection_widget::build(TGCompositeFrame *frame_) {
+  // Layout for positionning frame
+  TGLayoutHints *field_layout = new TGLayoutHints(kLHintsTop | kLHintsRight, 2, 2, 20, 2);
+  TGLayoutHints *label_layout = new TGLayoutHints(kLHintsTop | kLHintsLeft, 2, 2, 2, 2);
+  TGGroupFrame *gframe = new TGGroupFrame(frame_, "      Event header cut", kVerticalFrame);
+  gframe->SetTitlePos(TGGroupFrame::kLeft);
+  frame_->AddFrame(gframe, new TGLayoutHints(kLHintsTop | kLHintsLeft, 3, 3, 3, 3));
 
-  void complex_selection_widget::set_state() {
-    bool enable = _enable_->IsDown();
-    _combo_->SetEnabled(enable);
-    return;
-  }
+  _enable_ = new TGCheckButton(gframe, "", ENABLE_EH_SELECTION);
+  _enable_->SetToolTipText("enable selection on event header bank");
+  _enable_->Connect("Clicked()", "snemo::visualization::view::event_selection", _selection,
+                    "process()");
+  gframe->AddFrame(_enable_, new TGLayoutHints(kLHintsTop | kLHintsLeft, 0, 0, -15, 0));
 
-  bool complex_selection_widget::get_state() const {
-    if (_enable_->IsEnabled()) {
-      return _enable_->IsDown();
-    }
-    return false;
-  }
-
-  void complex_selection_widget::build(TGCompositeFrame *frame_) {
-    TGGroupFrame *gframe = new TGGroupFrame(frame_, "      Complex cuts", kVerticalFrame);
-    gframe->SetTitlePos(TGGroupFrame::kLeft);
-    frame_->AddFrame(gframe, new TGLayoutHints(kLHintsTop | kLHintsLeft, 3, 3, 3, 3));
-    _enable_ = new TGCheckButton(gframe, "", ENABLE_COMPLEX_SELECTION);
-    _enable_->Connect("Clicked()", "snemo::visualization::view::event_selection", _selection,
-                      "process()");
-    gframe->AddFrame(_enable_, new TGLayoutHints(kLHintsTop | kLHintsLeft, 0, 0, -15, 0));
-
+  {
     TGCompositeFrame *cframe = new TGCompositeFrame(gframe, 200, 1, kHorizontalFrame | kFixedWidth);
     gframe->AddFrame(cframe);
-
-    _combo_ = new TGComboBox(cframe, COMBO_SELECTION);
-    _combo_->Connect("Selected(int)", "snemo::visualization::view::event_selection", _selection,
-                     "process()");
-    _combo_->Resize(200, 20);
-    cframe->AddFrame(
-        _combo_,
-        new TGLayoutHints(kLHintsTop | kLHintsLeft | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2));
-    initialize();
-    return;
+    cframe->AddFrame(new TGLabel(cframe, "Run ID (min - max):"), label_layout);
+    _run_id_max_ = new TGNumberEntry(cframe, datatools::event_id::INVALID_RUN_NUMBER, 10, -1,
+                                     TGNumberFormat::kNESInteger);
+    _run_id_max_->Connect("ValueSet(Long_t)", "snemo::visualization::view::event_selection",
+                          _selection, "process()");
+    cframe->AddFrame(_run_id_max_, field_layout);
+    _run_id_min_ = new TGNumberEntry(cframe, datatools::event_id::INVALID_RUN_NUMBER, 10, -1,
+                                     TGNumberFormat::kNESInteger);
+    _run_id_min_->Connect("ValueSet(Long_t)", "snemo::visualization::view::event_selection",
+                          _selection, "process()");
+    cframe->AddFrame(_run_id_min_, field_layout);
   }
-
-  std::string complex_selection_widget::get_cut_name() {
-    if (!_enable_->IsDown()) return {};  // empty string
-
-    std::string cut_label;
-    if (_combo_->GetSelected() != 0) {
-      TGTextLBEntry *tgt = (TGTextLBEntry *)_combo_->GetSelectedEntry();
-      cut_label = tgt->GetText()->GetString();
-    }
-
-    return cut_label;
-  }
-
-  event_header_selection_widget::event_header_selection_widget(event_selection *selection_)
-      : base_widget(selection_, ENABLE_EH_SELECTION) {
-    return;
-  }
-
-  void event_header_selection_widget::initialize() {
-    _enable_->SetState(kButtonUp);
-    _run_id_min_->SetNumber(datatools::event_id::INVALID_RUN_NUMBER);
-    _run_id_max_->SetNumber(datatools::event_id::INVALID_RUN_NUMBER);
-    _event_id_min_->SetNumber(datatools::event_id::INVALID_EVENT_NUMBER);
-    _event_id_max_->SetNumber(datatools::event_id::INVALID_EVENT_NUMBER);
-  }
-
-  void event_header_selection_widget::set_state() {
-    bool enable = _enable_->IsDown();
-    const io::event_server &server = _selection->get_event_server();
-    if (!server.get_event().has(io::EH_LABEL)) {
-      DT_LOG_WARNING(options_manager::get_instance().get_logging_priority(),
-                     "No event header data bank");
-      _enable_->SetToolTipText("no event header bank");
-      _enable_->SetState(kButtonDisabled);
-      enable = false;
-    } else {
-      if (!_enable_->IsEnabled()) {
-        _enable_->SetState(kButtonEngaged);
-      }
-    }
-    _run_id_min_->SetState(enable);
-    _run_id_max_->SetState(enable);
-    _event_id_min_->SetState(enable);
-    _event_id_max_->SetState(enable);
-    return;
-  }
-
-  bool event_header_selection_widget::get_state() const {
-    if (_enable_->IsEnabled()) {
-      return _enable_->IsDown();
-    }
-    return false;
-  }
-
-  void event_header_selection_widget::build(TGCompositeFrame *frame_) {
-    // Layout for positionning frame
-    TGLayoutHints *field_layout = new TGLayoutHints(kLHintsTop | kLHintsRight, 2, 2, 20, 2);
-    TGLayoutHints *label_layout = new TGLayoutHints(kLHintsTop | kLHintsLeft, 2, 2, 2, 2);
-    TGGroupFrame *gframe = new TGGroupFrame(frame_, "      Event header cut", kVerticalFrame);
-    gframe->SetTitlePos(TGGroupFrame::kLeft);
-    frame_->AddFrame(gframe, new TGLayoutHints(kLHintsTop | kLHintsLeft, 3, 3, 3, 3));
-
-    _enable_ = new TGCheckButton(gframe, "", ENABLE_EH_SELECTION);
-    _enable_->SetToolTipText("enable selection on event header bank");
-    _enable_->Connect("Clicked()", "snemo::visualization::view::event_selection", _selection,
-                      "process()");
-    gframe->AddFrame(_enable_, new TGLayoutHints(kLHintsTop | kLHintsLeft, 0, 0, -15, 0));
-
-    {
-      TGCompositeFrame *cframe =
-          new TGCompositeFrame(gframe, 200, 1, kHorizontalFrame | kFixedWidth);
-      gframe->AddFrame(cframe);
-      cframe->AddFrame(new TGLabel(cframe, "Run ID (min - max):"), label_layout);
-      _run_id_max_ = new TGNumberEntry(cframe, datatools::event_id::INVALID_RUN_NUMBER, 10, -1,
+  {
+    TGCompositeFrame *cframe = new TGCompositeFrame(gframe, 200, 1, kHorizontalFrame | kFixedWidth);
+    gframe->AddFrame(cframe);
+    cframe->AddFrame(new TGLabel(cframe, "Event ID (min - max):"), label_layout);
+    _event_id_max_ = new TGNumberEntry(cframe, datatools::event_id::INVALID_EVENT_NUMBER, 10, -1,
                                        TGNumberFormat::kNESInteger);
-      _run_id_max_->Connect("ValueSet(Long_t)", "snemo::visualization::view::event_selection",
+    _event_id_max_->Connect("ValueSet(Long_t)", "snemo::visualization::view::event_selection",
                             _selection, "process()");
-      cframe->AddFrame(_run_id_max_, field_layout);
-      _run_id_min_ = new TGNumberEntry(cframe, datatools::event_id::INVALID_RUN_NUMBER, 10, -1,
+    cframe->AddFrame(_event_id_max_, field_layout);
+    _event_id_min_ = new TGNumberEntry(cframe, datatools::event_id::INVALID_RUN_NUMBER, 10, -1,
                                        TGNumberFormat::kNESInteger);
-      _run_id_min_->Connect("ValueSet(Long_t)", "snemo::visualization::view::event_selection",
+    _event_id_min_->Connect("ValueSet(Long_t)", "snemo::visualization::view::event_selection",
                             _selection, "process()");
-      cframe->AddFrame(_run_id_min_, field_layout);
-    }
-    {
-      TGCompositeFrame *cframe =
-          new TGCompositeFrame(gframe, 200, 1, kHorizontalFrame | kFixedWidth);
-      gframe->AddFrame(cframe);
-      cframe->AddFrame(new TGLabel(cframe, "Event ID (min - max):"), label_layout);
-      _event_id_max_ = new TGNumberEntry(cframe, datatools::event_id::INVALID_EVENT_NUMBER, 10, -1,
-                                         TGNumberFormat::kNESInteger);
-      _event_id_max_->Connect("ValueSet(Long_t)", "snemo::visualization::view::event_selection",
-                              _selection, "process()");
-      cframe->AddFrame(_event_id_max_, field_layout);
-      _event_id_min_ = new TGNumberEntry(cframe, datatools::event_id::INVALID_RUN_NUMBER, 10, -1,
-                                         TGNumberFormat::kNESInteger);
-      _event_id_min_->Connect("ValueSet(Long_t)", "snemo::visualization::view::event_selection",
-                              _selection, "process()");
-      cframe->AddFrame(_event_id_min_, field_layout);
-    }
-
-    // Initialize values
-    initialize();
-    return;
+    cframe->AddFrame(_event_id_min_, field_layout);
   }
 
-  std::string event_header_selection_widget::get_cut_name() {
-    if (!_enable_->IsDown()) return {};  // empty string
+  // Initialize values
+  initialize();
+  return;
+}
 
-    cuts::cut_manager &a_cut_mgr = _selection->grab_cut_manager();
-    cuts::cut_handle_dict_type &the_cuts = a_cut_mgr.get_cuts();
-    cuts::cut_handle_dict_type::iterator found = the_cuts.find(eh_cut_label());
-    DT_THROW_IF(found == the_cuts.end(), std::logic_error,
-                "Cut '" << eh_cut_label() << "' has not been registered !");
+std::string event_header_selection_widget::get_cut_name() {
+  if (!_enable_->IsDown()) return {};  // empty string
 
-    // Reset cut
-    cuts::cut_entry_type &a_cet = found->second;
-    if (a_cet.is_initialized()) {
-      a_cet.grab_cut().reset();
-      a_cet.set_uninitialized();
-    }
+  cuts::cut_manager &a_cut_mgr = _selection->grab_cut_manager();
+  cuts::cut_handle_dict_type &the_cuts = a_cut_mgr.get_cuts();
+  cuts::cut_handle_dict_type::iterator found = the_cuts.find(eh_cut_label());
+  DT_THROW_IF(found == the_cuts.end(), std::logic_error,
+              "Cut '" << eh_cut_label() << "' has not been registered !");
 
-    datatools::properties &cuts_prop = a_cet.grab_cut_config();
-    bool cut_updated = false;
-    // Run number
-    const int run_number_selected_min = _run_id_min_->GetIntNumber();
-    const int run_number_selected_max = _run_id_max_->GetIntNumber();
-    if (run_number_selected_min != datatools::event_id::INVALID_RUN_NUMBER ||
-        run_number_selected_max != datatools::event_id::INVALID_RUN_NUMBER) {
-      cuts_prop.update_flag("mode.run_number");
-      if (run_number_selected_min != datatools::event_id::INVALID_RUN_NUMBER)
-        cuts_prop.update_integer("run_number.min", run_number_selected_min);
-      if (run_number_selected_max != datatools::event_id::INVALID_RUN_NUMBER)
-        cuts_prop.update_integer("run_number.max", run_number_selected_max);
-      cut_updated = true;
-    }
-    // Event number
-    const int event_number_selected_min = _event_id_min_->GetIntNumber();
-    const int event_number_selected_max = _event_id_max_->GetIntNumber();
-    if (event_number_selected_min != datatools::event_id::INVALID_EVENT_NUMBER ||
-        event_number_selected_max != datatools::event_id::INVALID_EVENT_NUMBER) {
-      cuts_prop.update_flag("mode.event_number");
-      if (event_number_selected_min != datatools::event_id::INVALID_EVENT_NUMBER)
-        cuts_prop.update_integer("event_number.min", event_number_selected_min);
-      if (event_number_selected_max != datatools::event_id::INVALID_EVENT_NUMBER)
-        cuts_prop.update_integer("event_number.max", event_number_selected_max);
-      cut_updated = true;
-    }
-
-    if (!cut_updated) {
-      DT_LOG_WARNING(options_manager::get_instance().get_logging_priority(),
-                     "Missing run id or event id !");
-      return {};
-    }
-
-    return eh_cut_label();
+  // Reset cut
+  cuts::cut_entry_type &a_cet = found->second;
+  if (a_cet.is_initialized()) {
+    a_cet.grab_cut().reset();
+    a_cet.set_uninitialized();
   }
 
-  // simulated_data_selection_widget::simulated_data_selection_widget(event_selection * selection_)
-  //   : base_widget(selection_)
-  // {
-  //   return;
-  // }
-
-  // void simulated_data_selection_widget::initialize()
-  // {
-  //   if (_hit_category_) _hit_category_->Clear();
-  //   this->set_state(false);
-  // }
-
-  // void simulated_data_selection_widget::set_state(const bool enable_)
-  // {
-  //   if (_hit_category_) _hit_category_->SetState(enable_);
-  //   return;
-  // }
-
-  // void simulated_data_selection_widget::build(TGCompositeFrame * frame_)
-  // {
-  //   // Layout for positionning frame
-  //   // TGLayoutHints * field_layout = new TGLayoutHints(kLHintsTop | kLHintsRight,
-  //   //                                                  2, 2, 20, 2);
-  //   // TGLayoutHints * label_layout = new TGLayoutHints(kLHintsTop | kLHintsLeft,
-  //   //                                                  2, 2, 2, 2);
-  //   TGGroupFrame * gframe = new TGGroupFrame(frame_, "      Simulated data cut", kVerticalFrame);
-  //   gframe->SetTitlePos(TGGroupFrame::kLeft);
-  //   frame_->AddFrame(gframe, new TGLayoutHints(kLHintsTop | kLHintsLeft, 3, 3, 3, 3));
-  //   {
-  //     _enable_ = new TGCheckButton(gframe, "", ENABLE_SD_SELECTION);
-  //     _enable_->SetToolTipText("enable selection on simulated data bank");
-  //     _enable_->Connect("Clicked()", "snemo::visualization::view::event_selection",
-  //                       _selection, "process()");
-  //     gframe->AddFrame(_enable_, new TGLayoutHints(kLHintsTop | kLHintsLeft, 0, 0, -15, 0));
-  //   }
-
-  //   {
-  //     TGCompositeFrame * cframe = new TGCompositeFrame(gframe, 200, 1,
-  //                                                      kHorizontalFrame | kFixedWidth);
-  //     gframe->AddFrame(cframe);
-  //     cframe->AddFrame(new TGLabel(cframe, "Hit category name:"),
-  //                      new TGLayoutHints(kLHintsTop | kLHintsLeft, 2, 2, 2, 2));
-  //     _hit_category_ = new TGTextEntry(cframe, "", -1);
-  //     // _hit_category_->Connect("ValueSet(Long_t)",
-  //     //                         "snemo::visualization::view::event_selection",
-  //     //                         _selection, "process()");
-  //     cframe->AddFrame(_hit_category_, new TGLayoutHints(kLHintsTop | kLHintsLeft, 2, 2, 0, 2));
-  //   }
-
-  //   // Initialize values
-  //   initialize();
-  //   return;
-  // }
-
-  //*************************************************************//
-
-  bool event_selection::is_initialized() const { return _initialized_; }
-
-  bool event_selection::is_selection_enable() const { return _selection_enable_; }
-
-  // ctor:
-  event_selection::event_selection() {
-    _main_ = 0;
-    _server_ = 0;
-    _browser_ = 0;
-    _status_ = 0;
-    _cut_manager_ = 0;
-    _initialized_ = false;
-    _selection_enable_ = false;
-    _initial_event_id_ = 0;
-    return;
+  datatools::properties &cuts_prop = a_cet.grab_cut_config();
+  bool cut_updated = false;
+  // Run number
+  const int run_number_selected_min = _run_id_min_->GetIntNumber();
+  const int run_number_selected_max = _run_id_max_->GetIntNumber();
+  if (run_number_selected_min != datatools::event_id::INVALID_RUN_NUMBER ||
+      run_number_selected_max != datatools::event_id::INVALID_RUN_NUMBER) {
+    cuts_prop.update_flag("mode.run_number");
+    if (run_number_selected_min != datatools::event_id::INVALID_RUN_NUMBER)
+      cuts_prop.update_integer("run_number.min", run_number_selected_min);
+    if (run_number_selected_max != datatools::event_id::INVALID_RUN_NUMBER)
+      cuts_prop.update_integer("run_number.max", run_number_selected_max);
+    cut_updated = true;
+  }
+  // Event number
+  const int event_number_selected_min = _event_id_min_->GetIntNumber();
+  const int event_number_selected_max = _event_id_max_->GetIntNumber();
+  if (event_number_selected_min != datatools::event_id::INVALID_EVENT_NUMBER ||
+      event_number_selected_max != datatools::event_id::INVALID_EVENT_NUMBER) {
+    cuts_prop.update_flag("mode.event_number");
+    if (event_number_selected_min != datatools::event_id::INVALID_EVENT_NUMBER)
+      cuts_prop.update_integer("event_number.min", event_number_selected_min);
+    if (event_number_selected_max != datatools::event_id::INVALID_EVENT_NUMBER)
+      cuts_prop.update_integer("event_number.max", event_number_selected_max);
+    cut_updated = true;
   }
 
-  // dtor:
-  event_selection::~event_selection() {
+  if (!cut_updated) {
+    DT_LOG_WARNING(options_manager::get_instance().get_logging_priority(),
+                   "Missing run id or event id !");
+    return {};
+  }
+
+  return eh_cut_label();
+}
+
+// simulated_data_selection_widget::simulated_data_selection_widget(event_selection * selection_)
+//   : base_widget(selection_)
+// {
+//   return;
+// }
+
+// void simulated_data_selection_widget::initialize()
+// {
+//   if (_hit_category_) _hit_category_->Clear();
+//   this->set_state(false);
+// }
+
+// void simulated_data_selection_widget::set_state(const bool enable_)
+// {
+//   if (_hit_category_) _hit_category_->SetState(enable_);
+//   return;
+// }
+
+// void simulated_data_selection_widget::build(TGCompositeFrame * frame_)
+// {
+//   // Layout for positionning frame
+//   // TGLayoutHints * field_layout = new TGLayoutHints(kLHintsTop | kLHintsRight,
+//   //                                                  2, 2, 20, 2);
+//   // TGLayoutHints * label_layout = new TGLayoutHints(kLHintsTop | kLHintsLeft,
+//   //                                                  2, 2, 2, 2);
+//   TGGroupFrame * gframe = new TGGroupFrame(frame_, "      Simulated data cut", kVerticalFrame);
+//   gframe->SetTitlePos(TGGroupFrame::kLeft);
+//   frame_->AddFrame(gframe, new TGLayoutHints(kLHintsTop | kLHintsLeft, 3, 3, 3, 3));
+//   {
+//     _enable_ = new TGCheckButton(gframe, "", ENABLE_SD_SELECTION);
+//     _enable_->SetToolTipText("enable selection on simulated data bank");
+//     _enable_->Connect("Clicked()", "snemo::visualization::view::event_selection",
+//                       _selection, "process()");
+//     gframe->AddFrame(_enable_, new TGLayoutHints(kLHintsTop | kLHintsLeft, 0, 0, -15, 0));
+//   }
+
+//   {
+//     TGCompositeFrame * cframe = new TGCompositeFrame(gframe, 200, 1,
+//                                                      kHorizontalFrame | kFixedWidth);
+//     gframe->AddFrame(cframe);
+//     cframe->AddFrame(new TGLabel(cframe, "Hit category name:"),
+//                      new TGLayoutHints(kLHintsTop | kLHintsLeft, 2, 2, 2, 2));
+//     _hit_category_ = new TGTextEntry(cframe, "", -1);
+//     // _hit_category_->Connect("ValueSet(Long_t)",
+//     //                         "snemo::visualization::view::event_selection",
+//     //                         _selection, "process()");
+//     cframe->AddFrame(_hit_category_, new TGLayoutHints(kLHintsTop | kLHintsLeft, 2, 2, 0, 2));
+//   }
+
+//   // Initialize values
+//   initialize();
+//   return;
+// }
+
+//*************************************************************//
+
+bool event_selection::is_initialized() const { return _initialized_; }
+
+bool event_selection::is_selection_enable() const { return _selection_enable_; }
+
+// ctor:
+event_selection::event_selection() {
+  _main_ = 0;
+  _server_ = 0;
+  _browser_ = 0;
+  _status_ = 0;
+  _cut_manager_ = 0;
+  _initialized_ = false;
+  _selection_enable_ = false;
+  _initial_event_id_ = 0;
+  return;
+}
+
+// dtor:
+event_selection::~event_selection() {
+  this->reset();
+  return;
+}
+
+void event_selection::set_event_server(io::event_server *server_) {
+  DT_THROW_IF(is_initialized(), std::logic_error, "Already initialized !");
+  _server_ = server_;
+  return;
+}
+
+io::event_server &event_selection::get_event_server() const {
+  DT_THROW_IF(_server_ == 0, std::logic_error, "Event server is not set !");
+  return *_server_;
+}
+
+void event_selection::set_status_bar(view::status_bar *status_) {
+  DT_THROW_IF(is_initialized(), std::logic_error, "Already initialized !");
+  _status_ = status_;
+  return;
+}
+
+const cuts::cut_manager &event_selection::get_cut_manager() const {
+  DT_THROW_IF(_cut_manager_ == 0, std::logic_error, "Cut manager is not set !");
+  return *_cut_manager_;
+}
+
+cuts::cut_manager &event_selection::grab_cut_manager() {
+  DT_THROW_IF(_cut_manager_ == 0, std::logic_error, "Cut manager is not set !");
+  return *_cut_manager_;
+}
+
+void event_selection::initialize(TGCompositeFrame *main_) {
+  DT_THROW_IF(is_initialized(), std::logic_error, "Already initialized !");
+
+  // Keep track of main frame in order to regenerate it for
+  // different detector setup
+  _main_ = main_;
+  _main_->SetCleanup(kDeepCleanup);
+
+  // Get pointer to browser for button connections
+  TGCompositeFrame *parent = (TGCompositeFrame *)_main_->GetParent()
+                                 ->GetParent()
+                                 ->GetParent()
+                                 ->GetParent()
+                                 ->GetParent()
+                                 ->GetParent();
+  _browser_ = dynamic_cast<event_browser *>(parent);
+  DT_THROW_IF(!_browser_, std::logic_error, "Event_browser can't be cast from frame!");
+
+  _cut_manager_ = new cuts::cut_manager;
+  this->_build_();
+  this->_install_cut_manager_();
+
+  _initialized_ = true;
+  return;
+}
+
+void event_selection::reset() {
+  if (_cut_manager_) {
+    delete _cut_manager_;
+  }
+  _cut_manager_ = 0;
+  return;
+}
+
+void event_selection::process() {
+  TGButton *button = static_cast<TGButton *>(gTQSender);
+  const unsigned int id = button->WidgetId();
+
+  if (id == LOAD_SELECTION) {
+    const std::string dir = falaise::get_resource_dir();
+    TString directory(dir.c_str());
+    TGFileInfo file_info;
+    const char *config_file_types[] = {"Config. file", "*.conf", "All files", "*", 0, 0};
+    file_info.fFileTypes = config_file_types;
+    file_info.fIniDir = StrDup(directory.Data());
+    new TGFileDialog(gClient->GetRoot(), _browser_, kFDOpen, &file_info);
+    if (!file_info.fFilename) return;
+
+    std::string file_name = file_info.fFilename;
+    std::string file_type = file_info.fFileTypes[file_info.fFileTypeIdx + 1];
+
+    // remove asterisk
+    file_type.erase(0, 1);
+
+    // if extension is missing to filename
+    if (!TString(file_name).EndsWith(file_type.c_str())) {
+      file_name += file_type;
+    }
+
+    options_manager::get_instance().set_cut_config_file(file_name);
     this->reset();
-    return;
-  }
-
-  void event_selection::set_event_server(io::event_server *server_) {
-    DT_THROW_IF(is_initialized(), std::logic_error, "Already initialized !");
-    _server_ = server_;
-    return;
-  }
-
-  io::event_server &event_selection::get_event_server() const {
-    DT_THROW_IF(_server_ == 0, std::logic_error, "Event server is not set !");
-    return *_server_;
-  }
-
-  void event_selection::set_status_bar(view::status_bar *status_) {
-    DT_THROW_IF(is_initialized(), std::logic_error, "Already initialized !");
-    _status_ = status_;
-    return;
-  }
-
-  const cuts::cut_manager &event_selection::get_cut_manager() const {
-    DT_THROW_IF(_cut_manager_ == 0, std::logic_error, "Cut manager is not set !");
-    return *_cut_manager_;
-  }
-
-  cuts::cut_manager &event_selection::grab_cut_manager() {
-    DT_THROW_IF(_cut_manager_ == 0, std::logic_error, "Cut manager is not set !");
-    return *_cut_manager_;
-  }
-
-  void event_selection::initialize(TGCompositeFrame *main_) {
-    DT_THROW_IF(is_initialized(), std::logic_error, "Already initialized !");
-
-    // Keep track of main frame in order to regenerate it for
-    // different detector setup
-    _main_ = main_;
-    _main_->SetCleanup(kDeepCleanup);
-
-    // Get pointer to browser for button connections
-    TGCompositeFrame *parent = (TGCompositeFrame *)_main_->GetParent()
-                                   ->GetParent()
-                                   ->GetParent()
-                                   ->GetParent()
-                                   ->GetParent()
-                                   ->GetParent();
-    _browser_ = dynamic_cast<event_browser *>(parent);
-    DT_THROW_IF(!_browser_, std::logic_error, "Event_browser can't be cast from frame!");
-
-    _cut_manager_ = new cuts::cut_manager;
-    this->_build_();
     this->_install_cut_manager_();
-
-    _initialized_ = true;
-    return;
-  }
-
-  void event_selection::reset() {
-    if (_cut_manager_) {
-      delete _cut_manager_;
-    }
-    _cut_manager_ = 0;
-    return;
-  }
-
-  void event_selection::process() {
-    TGButton *button = static_cast<TGButton *>(gTQSender);
-    const unsigned int id = button->WidgetId();
-
-    if (id == LOAD_SELECTION) {
-      const std::string dir = falaise::get_resource_dir();
-      TString directory(dir.c_str());
-      TGFileInfo file_info;
-      const char *config_file_types[] = {"Config. file", "*.conf", "All files", "*", 0, 0};
-      file_info.fFileTypes = config_file_types;
-      file_info.fIniDir = StrDup(directory.Data());
-      new TGFileDialog(gClient->GetRoot(), _browser_, kFDOpen, &file_info);
-      if (!file_info.fFilename) return;
-
-      std::string file_name = file_info.fFilename;
-      std::string file_type = file_info.fFileTypes[file_info.fFileTypeIdx + 1];
-
-      // remove asterisk
-      file_type.erase(0, 1);
-
-      // if extension is missing to filename
-      if (!TString(file_name).EndsWith(file_type.c_str())) {
-        file_name += file_type;
-      }
-
-      options_manager::get_instance().set_cut_config_file(file_name);
-      this->reset();
-      this->_install_cut_manager_();
-    } else if (id == RESET_SELECTION) {
-      for (widget_collection_type::iterator i = _widgets_.begin(); i != _widgets_.end(); ++i) {
-        i->second->initialize();
-      }
-
-      _server_->clear_selection();
-      _server_->fill_selection();
-      _status_->update(true);
-
-      this->_build_cuts_();
-
-      _browser_->change_event(CURRENT_EVENT);  //, _initial_event_id_);
-      return;
-    } else if (id == UPDATE_SELECTION) {
-      this->_build_cuts_();
-      if (is_selection_enable()) {
-        DT_LOG_DEBUG(options_manager::get_instance().get_logging_priority(),
-                     "Selection is enable !");
-        _server_->clear_selection();
-        _server_->fill_selection();
-        _initial_event_id_ = _server_->get_current_event_number();
-        _browser_->change_event(FIRST_EVENT);
-      }
-      return;
-    }
-
-    widget_collection_type::iterator found = _widgets_.find(id);
-    if (found != _widgets_.end()) {
-      found->second->set_state();
-    }
-
-    // Change update button state
-    for (const auto &i : _widgets_) {
-      if (i.second->get_state()) {
-        _update_button_->SetState(kButtonUp);
-        return;
-      }
-    }
-    _update_button_->SetState(kButtonDisabled);
-    _selection_enable_ = false;
-    return;
-  }
-
-  void event_selection::select_events(const button_signals_type signal_,
-                                      const int event_selected_) {
-    io::event_server &the_server = *_server_;
-
-    if (the_server.has_external_data()) {
-      DT_LOG_TRACE(options_manager::get_instance().get_logging_priority(),
-                   "No selection since data record comes from external part !");
-      return;
-    }
-
-    if (is_selection_enable()) {
-      DT_LOG_DEBUG(options_manager::get_instance().get_logging_priority(),
-                   "Looking for event filling selection...");
-    }
-
-    button_signals_type the_signal = signal_;
-
-    int current_event_id = the_server.get_current_event_number();
-    if (event_selected_ != -1) current_event_id = event_selected_;
-
-    bool is_selected = false;
-    while (!is_selected) {
-      if (the_signal == NEXT_EVENT) {
-        current_event_id++;
-      } else if (the_signal == PREVIOUS_EVENT) {
-        current_event_id--;
-      } else if (the_signal == LAST_EVENT) {
-        current_event_id = _server_->get_last_selected_event();
-      } else if (the_signal == FIRST_EVENT) {
-        current_event_id = _server_->get_first_selected_event();
-      }
-
-      // Reach the end of events
-      if (current_event_id > _server_->get_last_selected_event()) {
-        current_event_id = _server_->get_last_selected_event();
-      }
-      // Reach the begin of events
-      if (current_event_id < _server_->get_first_selected_event()) {
-        current_event_id = _server_->get_first_selected_event();
-      }
-
-      if (!the_server.read_event(current_event_id)) {
-        DT_LOG_ERROR(options_manager::get_instance().get_logging_priority(),
-                     "Something gets wrong when reading event #" << current_event_id << " !");
-        break;
-      }
-
-      if (is_selection_enable()) {
-        DT_LOG_TRACE(options_manager::get_instance().get_logging_priority(), "Selection enable");
-        // Get selected events
-        if (this->_check_cuts_()) {
-          _server_->select_event(current_event_id);
-          is_selected = true;
-        } else {
-          _server_->remove_event(current_event_id);
-          if (the_signal == FIRST_EVENT) the_signal = NEXT_EVENT;
-          if (the_signal == LAST_EVENT) the_signal = PREVIOUS_EVENT;
-        }
-
-        // No more events to look for
-        if (!_server_->has_selected_event()) {
-          EMsgBoxIcon icon_type = kMBIconExclamation;
-          EMsgBoxButton button_type = kMBClose;
-          int retval;
-          std::ostringstream info;
-          info << "No record full fills the selection cuts !";
-          DT_LOG_INFORMATION(options_manager::get_instance().get_logging_priority(), info.str());
-          new TGMsgBox(gClient->GetRoot(), _browser_, "Event selection", info.str().c_str(),
-                       icon_type, button_type, &retval);
-
-          break;
-        }
-      } else {
-        is_selected = true;
-      }
-    }
-
-    // Update buttons given avalaible banks
-    for (auto &i : _widgets_) i.second->set_state();
-
-    // Update status bar
-    _status_->update(is_selection_enable(), is_selection_enable());
-    _status_->update_buttons(signal_);
-
-    return;
-  }
-
-  void event_selection::_build_() {
-    // Add buttons to save, reset and apply selection
-    TGVerticalFrame *vframe = new TGVerticalFrame(_main_);
-    _main_->AddFrame(vframe, new TGLayoutHints(kLHintsBottom | kLHintsRight, 10, 10, 10, 10));
-
-    TGHorizontalFrame *hframe = new TGHorizontalFrame(vframe);
-    vframe->AddFrame(hframe);
-
-    _load_button_ = new TGTextButton(hframe, "Load selection file", LOAD_SELECTION);
-    _load_button_->SetToolTipText("save current selection into file");
-    _load_button_->Connect("Clicked()", "snemo::visualization::view::event_selection", this,
-                           "process()");
-    hframe->AddFrame(_load_button_, new TGLayoutHints(kLHintsNoHints, 2, 2, 2, 2));
-
-    _save_button_ = new TGTextButton(hframe, "Save selection as...", SAVE_SELECTION);
-    _save_button_->SetToolTipText("save current selection into file");
-    _save_button_->Connect("Clicked()", "snemo::visualization::view::event_selection", this,
-                           "process()");
-    _save_button_->SetState(kButtonDisabled);
-    hframe->AddFrame(_save_button_, new TGLayoutHints(kLHintsNoHints, 2, 2, 2, 2));
-
-    _reset_button_ = new TGTextButton(hframe, "Reset selection", RESET_SELECTION);
-    _reset_button_->SetToolTipText("reset current selection");
-    _reset_button_->Connect("Clicked()", "snemo::visualization::view::event_selection", this,
-                            "process()");
-    hframe->AddFrame(_reset_button_, new TGLayoutHints(kLHintsNoHints, 2, 2, 2, 2));
-
-    _update_button_ = new TGTextButton(hframe, "Update selection", UPDATE_SELECTION);
-    _update_button_->SetToolTipText("update selection");
-    _update_button_->Connect("Clicked()", "snemo::visualization::view::event_selection", this,
-                             "process()");
-    _update_button_->SetState(kButtonDisabled);
-    hframe->AddFrame(_update_button_, new TGLayoutHints(kLHintsNoHints, 2, 2, 2, 2));
-
-    // Build selection widget
-    _widgets_[ENABLE_LOGIC_SELECTION] = new selection_widget(this);
-    auto *ehsw = new event_header_selection_widget(this);
-    _widgets_[ehsw->id()] = ehsw;
-    auto *csw = new complex_selection_widget(this);
-    _widgets_[csw->id()] = csw;
-    // _widgets_.push_back(new simulated_data_selection_widget(this));
-    for (auto &i : _widgets_) {
-      i.second->build(_main_);
-    }
-    return;
-  }
-
-  bool event_selection::_check_cuts_() {
-    int cut_status = cuts::SELECTION_REJECTED;
-    try {
-      DT_THROW_IF(!_cut_manager_->has(_current_cut_name_), std::logic_error,
-                  "None of the cut (AND, XOR, OR) have been registered !");
-      cuts::i_cut &the_cut = _cut_manager_->grab(_current_cut_name_);
-      const io::event_record &a_record = _server_->get_event();
-      the_cut.set_user_data(a_record);
-      cut_status = the_cut.process();
-      the_cut.reset_user_data();
-    } catch (std::exception &x) {
-      DT_LOG_WARNING(options_manager::get_instance().get_logging_priority(), x.what());
-    }
-
-    if (cut_status != cuts::SELECTION_ACCEPTED) {
-      DT_LOG_TRACE(options_manager::get_instance().get_logging_priority(), "Event rejected");
-      return false;
-    }
-
-    DT_LOG_TRACE(options_manager::get_instance().get_logging_priority(), "Event accepted");
-    return true;
-  }
-
-  void event_selection::_build_cuts_() {
-    std::vector<std::string> cut_lists;
-    for (auto &a_widget : _widgets_) {
-      if (a_widget.first == ENABLE_LOGIC_SELECTION) continue;
-      const std::string a_cut_name = a_widget.second->get_cut_name();
-      if (!a_cut_name.empty()) cut_lists.push_back(a_cut_name);
-    }
-
-    if (cut_lists.empty()) {
-      DT_LOG_WARNING(options_manager::get_instance().get_logging_priority(),
-                     "No cuts have been enabled !");
-      _selection_enable_ = false;
-      return;
-    }
-
-    _current_cut_name_ = _widgets_[ENABLE_LOGIC_SELECTION]->get_cut_name();
-    cuts::cut_handle_dict_type &the_cuts = _cut_manager_->get_cuts();
-    cuts::cut_handle_dict_type::iterator found = the_cuts.find(_current_cut_name_);
-    datatools::properties &cuts_prop = found->second.grab_cut_config();
-    cuts_prop.update("cuts", cut_lists);
-
-    _selection_enable_ = true;
-    return;
-  }
-
-  void event_selection::_install_cut_manager_() {
-    const options_manager &opt_mgr = options_manager::get_instance();
-    _cut_manager_->set_logging_priority(opt_mgr.get_logging_priority());
-
-    // Load event browser cuts before cut manager is initialized
-    this->_install_private_cuts_();
-
-    const std::string &config_filename = opt_mgr.get_cut_config_file();
-
-    if (!config_filename.empty()) {
-      std::string filename = config_filename;
-      datatools::fetch_path_with_env(filename);
-      datatools::properties cut_manager_config;
-      datatools::properties::read_config(filename, cut_manager_config);
-      _cut_manager_->initialize(cut_manager_config);
-    } else {
-      datatools::properties dummy;
-      _cut_manager_->initialize(dummy);
-    }
-    if (opt_mgr.get_logging_priority() >= datatools::logger::PRIO_DEBUG) {
-      _cut_manager_->tree_dump(std::clog);
-    }
-
+  } else if (id == RESET_SELECTION) {
     for (widget_collection_type::iterator i = _widgets_.begin(); i != _widgets_.end(); ++i) {
       i->second->initialize();
     }
+
+    _server_->clear_selection();
+    _server_->fill_selection();
+    _status_->update(true);
+
+    this->_build_cuts_();
+
+    _browser_->change_event(CURRENT_EVENT);  //, _initial_event_id_);
+    return;
+  } else if (id == UPDATE_SELECTION) {
+    this->_build_cuts_();
+    if (is_selection_enable()) {
+      DT_LOG_DEBUG(options_manager::get_instance().get_logging_priority(), "Selection is enable !");
+      _server_->clear_selection();
+      _server_->fill_selection();
+      _initial_event_id_ = _server_->get_current_event_number();
+      _browser_->change_event(FIRST_EVENT);
+    }
     return;
   }
 
-  void event_selection::_install_private_cuts_() {
-    const std::string priority_str = datatools::logger::get_priority_label(
-        options_manager::get_instance().get_logging_priority());
+  widget_collection_type::iterator found = _widgets_.find(id);
+  if (found != _widgets_.end()) {
+    found->second->set_state();
+  }
 
-    // Cut logic
-    {
-      datatools::properties cuts_prop;
-      cuts_prop.store_string("logging.priority", priority_str);
-
-      // Install a 'multi_and_cut' and a 'multi_or_cut'
-      _cut_manager_->load_cut(multi_and_cut_label(), "cuts::multi_and_cut", cuts_prop);
-      _cut_manager_->load_cut(multi_or_cut_label(), "cuts::multi_or_cut", cuts_prop);
-      _cut_manager_->load_cut(multi_xor_cut_label(), "cuts::multi_xor_cut", cuts_prop);
+  // Change update button state
+  for (const auto &i : _widgets_) {
+    if (i.second->get_state()) {
+      _update_button_->SetState(kButtonUp);
+      return;
     }
+  }
+  _update_button_->SetState(kButtonDisabled);
+  _selection_enable_ = false;
+  return;
+}
 
-    // Event header cut
-    {
-      datatools::properties cuts_prop;
-      cuts_prop.store_string("logging.priority", priority_str);
-      cuts_prop.store_string("EH_label", io::EH_LABEL);
-      _cut_manager_->load_cut(eh_cut_label(), "snemo::cut::event_header_cut", cuts_prop);
-    }
+void event_selection::select_events(const button_signals_type signal_, const int event_selected_) {
+  io::event_server &the_server = *_server_;
 
-    // Simulated data cut
-    {
-      datatools::properties cuts_prop;
-      cuts_prop.store_string("logging.priority", priority_str);
-      cuts_prop.store_string("SD_label", io::SD_LABEL);
-      _cut_manager_->load_cut(sd_cut_label(), "snemo::cut::simulated_data_cut", cuts_prop);
-    }
-
+  if (the_server.has_external_data()) {
+    DT_LOG_TRACE(options_manager::get_instance().get_logging_priority(),
+                 "No selection since data record comes from external part !");
     return;
   }
 
-  }  // end of namespace view
+  if (is_selection_enable()) {
+    DT_LOG_DEBUG(options_manager::get_instance().get_logging_priority(),
+                 "Looking for event filling selection...");
+  }
 
-  }  // end of namespace visualization
+  button_signals_type the_signal = signal_;
+
+  int current_event_id = the_server.get_current_event_number();
+  if (event_selected_ != -1) current_event_id = event_selected_;
+
+  bool is_selected = false;
+  while (!is_selected) {
+    if (the_signal == NEXT_EVENT) {
+      current_event_id++;
+    } else if (the_signal == PREVIOUS_EVENT) {
+      current_event_id--;
+    } else if (the_signal == LAST_EVENT) {
+      current_event_id = _server_->get_last_selected_event();
+    } else if (the_signal == FIRST_EVENT) {
+      current_event_id = _server_->get_first_selected_event();
+    }
+
+    // Reach the end of events
+    if (current_event_id > _server_->get_last_selected_event()) {
+      current_event_id = _server_->get_last_selected_event();
+    }
+    // Reach the begin of events
+    if (current_event_id < _server_->get_first_selected_event()) {
+      current_event_id = _server_->get_first_selected_event();
+    }
+
+    if (!the_server.read_event(current_event_id)) {
+      DT_LOG_ERROR(options_manager::get_instance().get_logging_priority(),
+                   "Something gets wrong when reading event #" << current_event_id << " !");
+      break;
+    }
+
+    if (is_selection_enable()) {
+      DT_LOG_TRACE(options_manager::get_instance().get_logging_priority(), "Selection enable");
+      // Get selected events
+      if (this->_check_cuts_()) {
+        _server_->select_event(current_event_id);
+        is_selected = true;
+      } else {
+        _server_->remove_event(current_event_id);
+        if (the_signal == FIRST_EVENT) the_signal = NEXT_EVENT;
+        if (the_signal == LAST_EVENT) the_signal = PREVIOUS_EVENT;
+      }
+
+      // No more events to look for
+      if (!_server_->has_selected_event()) {
+        EMsgBoxIcon icon_type = kMBIconExclamation;
+        EMsgBoxButton button_type = kMBClose;
+        int retval;
+        std::ostringstream info;
+        info << "No record full fills the selection cuts !";
+        DT_LOG_INFORMATION(options_manager::get_instance().get_logging_priority(), info.str());
+        new TGMsgBox(gClient->GetRoot(), _browser_, "Event selection", info.str().c_str(),
+                     icon_type, button_type, &retval);
+
+        break;
+      }
+    } else {
+      is_selected = true;
+    }
+  }
+
+  // Update buttons given avalaible banks
+  for (auto &i : _widgets_) i.second->set_state();
+
+  // Update status bar
+  _status_->update(is_selection_enable(), is_selection_enable());
+  _status_->update_buttons(signal_);
+
+  return;
+}
+
+void event_selection::_build_() {
+  // Add buttons to save, reset and apply selection
+  TGVerticalFrame *vframe = new TGVerticalFrame(_main_);
+  _main_->AddFrame(vframe, new TGLayoutHints(kLHintsBottom | kLHintsRight, 10, 10, 10, 10));
+
+  TGHorizontalFrame *hframe = new TGHorizontalFrame(vframe);
+  vframe->AddFrame(hframe);
+
+  _load_button_ = new TGTextButton(hframe, "Load selection file", LOAD_SELECTION);
+  _load_button_->SetToolTipText("save current selection into file");
+  _load_button_->Connect("Clicked()", "snemo::visualization::view::event_selection", this,
+                         "process()");
+  hframe->AddFrame(_load_button_, new TGLayoutHints(kLHintsNoHints, 2, 2, 2, 2));
+
+  _save_button_ = new TGTextButton(hframe, "Save selection as...", SAVE_SELECTION);
+  _save_button_->SetToolTipText("save current selection into file");
+  _save_button_->Connect("Clicked()", "snemo::visualization::view::event_selection", this,
+                         "process()");
+  _save_button_->SetState(kButtonDisabled);
+  hframe->AddFrame(_save_button_, new TGLayoutHints(kLHintsNoHints, 2, 2, 2, 2));
+
+  _reset_button_ = new TGTextButton(hframe, "Reset selection", RESET_SELECTION);
+  _reset_button_->SetToolTipText("reset current selection");
+  _reset_button_->Connect("Clicked()", "snemo::visualization::view::event_selection", this,
+                          "process()");
+  hframe->AddFrame(_reset_button_, new TGLayoutHints(kLHintsNoHints, 2, 2, 2, 2));
+
+  _update_button_ = new TGTextButton(hframe, "Update selection", UPDATE_SELECTION);
+  _update_button_->SetToolTipText("update selection");
+  _update_button_->Connect("Clicked()", "snemo::visualization::view::event_selection", this,
+                           "process()");
+  _update_button_->SetState(kButtonDisabled);
+  hframe->AddFrame(_update_button_, new TGLayoutHints(kLHintsNoHints, 2, 2, 2, 2));
+
+  // Build selection widget
+  _widgets_[ENABLE_LOGIC_SELECTION] = new selection_widget(this);
+  auto *ehsw = new event_header_selection_widget(this);
+  _widgets_[ehsw->id()] = ehsw;
+  auto *csw = new complex_selection_widget(this);
+  _widgets_[csw->id()] = csw;
+  // _widgets_.push_back(new simulated_data_selection_widget(this));
+  for (auto &i : _widgets_) {
+    i.second->build(_main_);
+  }
+  return;
+}
+
+bool event_selection::_check_cuts_() {
+  int cut_status = cuts::SELECTION_REJECTED;
+  try {
+    DT_THROW_IF(!_cut_manager_->has(_current_cut_name_), std::logic_error,
+                "None of the cut (AND, XOR, OR) have been registered !");
+    cuts::i_cut &the_cut = _cut_manager_->grab(_current_cut_name_);
+    const io::event_record &a_record = _server_->get_event();
+    the_cut.set_user_data(a_record);
+    cut_status = the_cut.process();
+    the_cut.reset_user_data();
+  } catch (std::exception &x) {
+    DT_LOG_WARNING(options_manager::get_instance().get_logging_priority(), x.what());
+  }
+
+  if (cut_status != cuts::SELECTION_ACCEPTED) {
+    DT_LOG_TRACE(options_manager::get_instance().get_logging_priority(), "Event rejected");
+    return false;
+  }
+
+  DT_LOG_TRACE(options_manager::get_instance().get_logging_priority(), "Event accepted");
+  return true;
+}
+
+void event_selection::_build_cuts_() {
+  std::vector<std::string> cut_lists;
+  for (auto &a_widget : _widgets_) {
+    if (a_widget.first == ENABLE_LOGIC_SELECTION) continue;
+    const std::string a_cut_name = a_widget.second->get_cut_name();
+    if (!a_cut_name.empty()) cut_lists.push_back(a_cut_name);
+  }
+
+  if (cut_lists.empty()) {
+    DT_LOG_WARNING(options_manager::get_instance().get_logging_priority(),
+                   "No cuts have been enabled !");
+    _selection_enable_ = false;
+    return;
+  }
+
+  _current_cut_name_ = _widgets_[ENABLE_LOGIC_SELECTION]->get_cut_name();
+  cuts::cut_handle_dict_type &the_cuts = _cut_manager_->get_cuts();
+  cuts::cut_handle_dict_type::iterator found = the_cuts.find(_current_cut_name_);
+  datatools::properties &cuts_prop = found->second.grab_cut_config();
+  cuts_prop.update("cuts", cut_lists);
+
+  _selection_enable_ = true;
+  return;
+}
+
+void event_selection::_install_cut_manager_() {
+  const options_manager &opt_mgr = options_manager::get_instance();
+  _cut_manager_->set_logging_priority(opt_mgr.get_logging_priority());
+
+  // Load event browser cuts before cut manager is initialized
+  this->_install_private_cuts_();
+
+  const std::string &config_filename = opt_mgr.get_cut_config_file();
+
+  if (!config_filename.empty()) {
+    std::string filename = config_filename;
+    datatools::fetch_path_with_env(filename);
+    datatools::properties cut_manager_config;
+    datatools::properties::read_config(filename, cut_manager_config);
+    _cut_manager_->initialize(cut_manager_config);
+  } else {
+    datatools::properties dummy;
+    _cut_manager_->initialize(dummy);
+  }
+  if (opt_mgr.get_logging_priority() >= datatools::logger::PRIO_DEBUG) {
+    _cut_manager_->tree_dump(std::clog);
+  }
+
+  for (widget_collection_type::iterator i = _widgets_.begin(); i != _widgets_.end(); ++i) {
+    i->second->initialize();
+  }
+  return;
+}
+
+void event_selection::_install_private_cuts_() {
+  const std::string priority_str =
+      datatools::logger::get_priority_label(options_manager::get_instance().get_logging_priority());
+
+  // Cut logic
+  {
+    datatools::properties cuts_prop;
+    cuts_prop.store_string("logging.priority", priority_str);
+
+    // Install a 'multi_and_cut' and a 'multi_or_cut'
+    _cut_manager_->load_cut(multi_and_cut_label(), "cuts::multi_and_cut", cuts_prop);
+    _cut_manager_->load_cut(multi_or_cut_label(), "cuts::multi_or_cut", cuts_prop);
+    _cut_manager_->load_cut(multi_xor_cut_label(), "cuts::multi_xor_cut", cuts_prop);
+  }
+
+  // Event header cut
+  {
+    datatools::properties cuts_prop;
+    cuts_prop.store_string("logging.priority", priority_str);
+    cuts_prop.store_string("EH_label", io::EH_LABEL);
+    _cut_manager_->load_cut(eh_cut_label(), "snemo::cut::event_header_cut", cuts_prop);
+  }
+
+  // Simulated data cut
+  {
+    datatools::properties cuts_prop;
+    cuts_prop.store_string("logging.priority", priority_str);
+    cuts_prop.store_string("SD_label", io::SD_LABEL);
+    _cut_manager_->load_cut(sd_cut_label(), "snemo::cut::simulated_data_cut", cuts_prop);
+  }
+
+  return;
+}
+
+}  // end of namespace view
+
+}  // end of namespace visualization
 
 }  // end of namespace snemo
 

--- a/modules/EventBrowser/source/event_selection.cc
+++ b/modules/EventBrowser/source/event_selection.cc
@@ -46,7 +46,7 @@
 // - Falaise
 #include <falaise/resource.h>
 
-ClassImp(snemo::visualization::view::event_selection)
+ClassImp(snemo::visualization::view::event_selection);
 
     namespace snemo {
   namespace visualization {

--- a/modules/EventBrowser/source/event_selection.cc
+++ b/modules/EventBrowser/source/event_selection.cc
@@ -46,7 +46,11 @@
 // - Falaise
 #include <falaise/resource.h>
 
+// Need trailing ; to satisfy clang-format, but leads to -pedantic error, ignore
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 ClassImp(snemo::visualization::view::event_selection);
+#pragma GCC diagnostic pop
 
 namespace snemo {
 namespace visualization {

--- a/modules/EventBrowser/source/inc/falaise/snemo/view/event_browser_linkdef.h
+++ b/modules/EventBrowser/source/inc/falaise/snemo/view/event_browser_linkdef.h
@@ -1,3 +1,5 @@
+// No clang-format in linkdefs!
+// clang-format off
 #ifdef __CINT__
 
 #pragma link off all globals;
@@ -8,14 +10,14 @@
 #pragma link C++ nestedtypedef;  // added for namespace
 #pragma link C++ namespace snemo::visualization::view;
 
-#pragma link C++ class snemo::visualization::view::event_browser + ;
-#pragma link C++ class snemo::visualization::view::display_2d + ;
-#pragma link C++ class snemo::visualization::view::display_3d + ;
-#pragma link C++ class snemo::visualization::view::display_options + ;
-#pragma link C++ class snemo::visualization::view::browser_tracks + ;
-#pragma link C++ class snemo::visualization::view::event_selection + ;
-#pragma link C++ class snemo::visualization::view::progress_bar + ;
-#pragma link C++ class snemo::visualization::view::status_bar + ;
+#pragma link C++ class snemo::visualization::view::event_browser+;
+#pragma link C++ class snemo::visualization::view::display_2d+;
+#pragma link C++ class snemo::visualization::view::display_3d+;
+#pragma link C++ class snemo::visualization::view::display_options+;
+#pragma link C++ class snemo::visualization::view::browser_tracks+;
+#pragma link C++ class snemo::visualization::view::event_selection+;
+#pragma link C++ class snemo::visualization::view::progress_bar+;
+#pragma link C++ class snemo::visualization::view::status_bar+;
 
 #endif
 /*

--- a/modules/EventBrowser/source/progress_bar.cc
+++ b/modules/EventBrowser/source/progress_bar.cc
@@ -29,7 +29,7 @@
 
 #include <iostream>
 
-ClassImp(snemo::visualization::view::progress_bar)
+ClassImp(snemo::visualization::view::progress_bar);
 
     namespace snemo {
   namespace visualization {

--- a/modules/EventBrowser/source/progress_bar.cc
+++ b/modules/EventBrowser/source/progress_bar.cc
@@ -29,7 +29,11 @@
 
 #include <iostream>
 
+// Need trailing ; to satisfy clang-format, but leads to -pedantic error, ignore
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 ClassImp(snemo::visualization::view::progress_bar);
+#pragma GCC diagnostic pop
 
 namespace snemo {
 namespace visualization {

--- a/modules/EventBrowser/source/progress_bar.cc
+++ b/modules/EventBrowser/source/progress_bar.cc
@@ -31,98 +31,96 @@
 
 ClassImp(snemo::visualization::view::progress_bar);
 
-    namespace snemo {
-  namespace visualization {
+namespace snemo {
+namespace visualization {
 
-  namespace view {
+namespace view {
 
-  // ctor:
-  progress_bar::progress_bar(const TGWindow* window_, const int width_, const int height_,
-                             const std::string& window_name_, const std::string& label_format_)
-      : TGMainFrame(window_, width_, height_),
-        _bar_(0),
-        _is_progressing_(true),
-        _is_killing_application_(false) {
-    // connect virtual method CloseWindow to close_window
-    this->Connect("CloseWindow ()", "snemo::visualization::view::progress_bar", this,
-                  "do_close ()");
+// ctor:
+progress_bar::progress_bar(const TGWindow* window_, const int width_, const int height_,
+                           const std::string& window_name_, const std::string& label_format_)
+    : TGMainFrame(window_, width_, height_),
+      _bar_(0),
+      _is_progressing_(true),
+      _is_killing_application_(false) {
+  // connect virtual method CloseWindow to close_window
+  this->Connect("CloseWindow ()", "snemo::visualization::view::progress_bar", this, "do_close ()");
 
-    // to avoid double deletions.
-    this->DontCallClose();
+  // to avoid double deletions.
+  this->DontCallClose();
 
-    // use hierarchical cleaning
-    this->SetCleanup(kDeepCleanup);
+  // use hierarchical cleaning
+  this->SetCleanup(kDeepCleanup);
 
-    this->ChangeOptions((this->GetOptions() & ~kVerticalFrame) | kHorizontalFrame);
+  this->ChangeOptions((this->GetOptions() & ~kVerticalFrame) | kHorizontalFrame);
 
-    TGVerticalFrame* main_frame = new TGVerticalFrame(this, 0, 0, 0);
+  TGVerticalFrame* main_frame = new TGVerticalFrame(this, 0, 0, 0);
 
-    _bar_ = new TGHProgressBar(main_frame, TGProgressBar::kFancy, width_);
-    _bar_->SetBarColor("lightblue");
-    _bar_->ShowPosition(kTRUE, kFALSE, label_format_.c_str());
+  _bar_ = new TGHProgressBar(main_frame, TGProgressBar::kFancy, width_);
+  _bar_->SetBarColor("lightblue");
+  _bar_->ShowPosition(kTRUE, kFALSE, label_format_.c_str());
 
-    TGTextButton* stop_button = new TGTextButton(main_frame, " Stop process ", 10);
-    stop_button->Connect("Clicked()", "snemo::visualization::view::progress_bar", this,
-                         "do_close ()");
+  TGTextButton* stop_button = new TGTextButton(main_frame, " Stop process ", 10);
+  stop_button->Connect("Clicked()", "snemo::visualization::view::progress_bar", this,
+                       "do_close ()");
 
-    main_frame->AddFrame(_bar_,
-                         new TGLayoutHints(kLHintsTop | kLHintsLeft | kLHintsExpandX, 5, 5, 5, 10));
-    main_frame->AddFrame(stop_button,
-                         new TGLayoutHints(kLHintsTop | kLHintsCenterX, 10, 10, 10, 10));
+  main_frame->AddFrame(_bar_,
+                       new TGLayoutHints(kLHintsTop | kLHintsLeft | kLHintsExpandX, 5, 5, 5, 10));
+  main_frame->AddFrame(stop_button, new TGLayoutHints(kLHintsTop | kLHintsCenterX, 10, 10, 10, 10));
 
-    this->AddFrame(main_frame, new TGLayoutHints(kLHintsTop | kLHintsCenterX, 0, 0, 0, 0));
+  this->AddFrame(main_frame, new TGLayoutHints(kLHintsTop | kLHintsCenterX, 0, 0, 0, 0));
 
-    this->SetWindowName(window_name_.c_str());
+  this->SetWindowName(window_name_.c_str());
 
-    TGDimension size = this->GetDefaultSize();
-    this->Resize(size);
+  TGDimension size = this->GetDefaultSize();
+  this->Resize(size);
 
-    this->MapSubwindows();
-    this->MapWindow();
-    return;
+  this->MapSubwindows();
+  this->MapWindow();
+  return;
+}
+
+// dtor:
+progress_bar::~progress_bar() { return; }
+
+void progress_bar::close_window() {
+  // Called when window is closed via the window manager.
+  TGMainFrame::CloseWindow();
+
+  if (_is_killing_application_) gApplication->Terminate();
+  return;
+}
+
+void progress_bar::do_close() {
+  if (!_is_progressing_)
+    close_window();
+  else {
+    _is_progressing_ = false;
+    TTimer::SingleShot(150, "snemo::visualization::view::progress_bar", this, "close_window ()");
   }
+  return;
+}
 
-  // dtor:
-  progress_bar::~progress_bar() { return; }
+void progress_bar::kill_application(const bool killed_) {
+  _is_killing_application_ = killed_;
+  return;
+}
 
-  void progress_bar::close_window() {
-    // Called when window is closed via the window manager.
-    TGMainFrame::CloseWindow();
+bool progress_bar::increment(const unsigned int i_) {
+  _bar_->Increment(i_);
+  gSystem->ProcessEvents();
 
-    if (_is_killing_application_) gApplication->Terminate();
-    return;
-  }
+  return _is_progressing_;
+}
 
-  void progress_bar::do_close() {
-    if (!_is_progressing_)
-      close_window();
-    else {
-      _is_progressing_ = false;
-      TTimer::SingleShot(150, "snemo::visualization::view::progress_bar", this, "close_window ()");
-    }
-    return;
-  }
+void progress_bar::set_range(const unsigned int min_, const unsigned int max_) {
+  _bar_->SetRange(min_, max_);
+  return;
+}
 
-  void progress_bar::kill_application(const bool killed_) {
-    _is_killing_application_ = killed_;
-    return;
-  }
+}  // namespace view
 
-  bool progress_bar::increment(const unsigned int i_) {
-    _bar_->Increment(i_);
-    gSystem->ProcessEvents();
-
-    return _is_progressing_;
-  }
-
-  void progress_bar::set_range(const unsigned int min_, const unsigned int max_) {
-    _bar_->SetRange(min_, max_);
-    return;
-  }
-
-  }  // namespace view
-
-  }  // end of namespace visualization
+}  // end of namespace visualization
 
 }  // end of namespace snemo
 

--- a/modules/EventBrowser/source/status_bar.cc
+++ b/modules/EventBrowser/source/status_bar.cc
@@ -39,237 +39,235 @@
 
 ClassImp(snemo::visualization::view::status_bar);
 
-    namespace snemo {
-  namespace visualization {
+namespace snemo {
+namespace visualization {
 
-  namespace view {
+namespace view {
 
-  bool status_bar::is_initialized() const { return _initialized_; }
+bool status_bar::is_initialized() const { return _initialized_; }
 
-  // ctor:
-  status_bar::status_bar() {
-    _server_ = 0;
-    _initialized_ = false;
-    return;
+// ctor:
+status_bar::status_bar() {
+  _server_ = 0;
+  _initialized_ = false;
+  return;
+}
+
+// dtor:
+status_bar::~status_bar() {
+  this->reset();
+  return;
+}
+
+void status_bar::set_event_server(io::event_server* server_) {
+  DT_THROW_IF(is_initialized(), std::logic_error, "Already initialized !");
+  _server_ = server_;
+  return;
+}
+
+void status_bar::initialize(TGCompositeFrame* main_) {
+  DT_THROW_IF(is_initialized(), std::logic_error, "Already initialized !");
+  this->_at_init_(main_);
+  _initialized_ = true;
+  return;
+}
+
+void status_bar::_at_init_(TGCompositeFrame* main_) {
+  const int width = main_->GetWidth();
+  const int height = main_->GetHeight();
+
+  // a horizontal frame
+  TGHorizontalFrame* main_frame = new TGHorizontalFrame(main_, width, int(height * 0.1));
+  main_->AddFrame(main_frame,
+                  new TGLayoutHints(kLHintsTop | kLHintsLeft | kLHintsExpandX, 3, 3, 3, 3));
+
+  // A combo box for the events
+  _event_list_ = new TGComboBox(main_frame, STATUS_BAR);
+  _event_list_->Resize(int(0.5 * width), 20);
+  _event_list_->Associate(main_);
+  main_frame->AddFrame(_event_list_, new TGLayoutHints(kLHintsTop | kLHintsLeft, 1, 1, 1, 1));
+
+  // Goto event number
+  main_frame->AddFrame(new TGLabel(main_frame, "Goto event"),
+                       new TGLayoutHints(kLHintsTop | kLHintsLeft, 10, 10, 2, 2));
+  _goto_event_ = new TGNumberEntryField(main_frame, GOTO_EVENT, 0, TGNumberFormat::kNESInteger,
+                                        TGNumberFormat::kNEAPositive);
+  _goto_event_->Resize(int(0.05 * width), 20);
+  _goto_event_->Associate(main_);
+  _goto_event_->Connect("ReturnPressed()", "snemo::visualization::view::status_bar", this,
+                        "process()");
+  main_frame->AddFrame(_goto_event_, new TGLayoutHints(kLHintsTop | kLHintsLeft, 1, 5, 1, 1));
+
+  // Navigation buttons
+  _button_first_ = new TGPictureButton(main_frame, gClient->GetPicture("first_t.xpm"), FIRST_EVENT);
+  _button_previous_ =
+      new TGPictureButton(main_frame, gClient->GetPicture("previous_t.xpm"), PREVIOUS_EVENT);
+  _button_next_ = new TGPictureButton(main_frame, gClient->GetPicture("next_t.xpm"), NEXT_EVENT);
+  _button_last_ = new TGPictureButton(main_frame, gClient->GetPicture("last_t.xpm"), LAST_EVENT);
+
+  _button_first_->Associate(main_);
+  _button_previous_->Associate(main_);
+  _button_next_->Associate(main_);
+  _button_last_->Associate(main_);
+
+  this->reset();
+
+  TGLayoutHints* layout = new TGLayoutHints(kLHintsTop | kLHintsLeft | kLHintsExpandX, 1, 1, 3, 1);
+
+  main_frame->AddFrame(_button_first_, layout);
+  main_frame->AddFrame(_button_previous_, layout);
+  main_frame->AddFrame(_button_next_, layout);
+  main_frame->AddFrame(_button_last_, layout);
+  return;
+}
+
+void status_bar::reset() {
+  io::event_server& server = *_server_;
+
+  // clear list
+  _event_list_->RemoveAll();
+  _event_list_->SetEnabled(true);
+
+  if (!server.is_opened()) {
+    _event_list_->AddEntry(" +++ NO EVENT LOADED +++ ", 0);
+    _event_list_->Select(0);
+    _event_list_->SetEnabled(false);
   }
 
-  // dtor:
-  status_bar::~status_bar() {
-    this->reset();
-    return;
-  }
+  this->reset_buttons();
+  return;
+}
 
-  void status_bar::set_event_server(io::event_server* server_) {
-    DT_THROW_IF(is_initialized(), std::logic_error, "Already initialized !");
-    _server_ = server_;
-    return;
-  }
+void status_bar::update(const bool reset_, const bool disable_) {
+  io::event_server& server = *_server_;
 
-  void status_bar::initialize(TGCompositeFrame* main_) {
-    DT_THROW_IF(is_initialized(), std::logic_error, "Already initialized !");
-    this->_at_init_(main_);
-    _initialized_ = true;
-    return;
-  }
-
-  void status_bar::_at_init_(TGCompositeFrame* main_) {
-    const int width = main_->GetWidth();
-    const int height = main_->GetHeight();
-
-    // a horizontal frame
-    TGHorizontalFrame* main_frame = new TGHorizontalFrame(main_, width, int(height * 0.1));
-    main_->AddFrame(main_frame,
-                    new TGLayoutHints(kLHintsTop | kLHintsLeft | kLHintsExpandX, 3, 3, 3, 3));
-
-    // A combo box for the events
-    _event_list_ = new TGComboBox(main_frame, STATUS_BAR);
-    _event_list_->Resize(int(0.5 * width), 20);
-    _event_list_->Associate(main_);
-    main_frame->AddFrame(_event_list_, new TGLayoutHints(kLHintsTop | kLHintsLeft, 1, 1, 1, 1));
-
-    // Goto event number
-    main_frame->AddFrame(new TGLabel(main_frame, "Goto event"),
-                         new TGLayoutHints(kLHintsTop | kLHintsLeft, 10, 10, 2, 2));
-    _goto_event_ = new TGNumberEntryField(main_frame, GOTO_EVENT, 0, TGNumberFormat::kNESInteger,
-                                          TGNumberFormat::kNEAPositive);
-    _goto_event_->Resize(int(0.05 * width), 20);
-    _goto_event_->Associate(main_);
-    _goto_event_->Connect("ReturnPressed()", "snemo::visualization::view::status_bar", this,
-                          "process()");
-    main_frame->AddFrame(_goto_event_, new TGLayoutHints(kLHintsTop | kLHintsLeft, 1, 5, 1, 1));
-
-    // Navigation buttons
-    _button_first_ =
-        new TGPictureButton(main_frame, gClient->GetPicture("first_t.xpm"), FIRST_EVENT);
-    _button_previous_ =
-        new TGPictureButton(main_frame, gClient->GetPicture("previous_t.xpm"), PREVIOUS_EVENT);
-    _button_next_ = new TGPictureButton(main_frame, gClient->GetPicture("next_t.xpm"), NEXT_EVENT);
-    _button_last_ = new TGPictureButton(main_frame, gClient->GetPicture("last_t.xpm"), LAST_EVENT);
-
-    _button_first_->Associate(main_);
-    _button_previous_->Associate(main_);
-    _button_next_->Associate(main_);
-    _button_last_->Associate(main_);
-
-    this->reset();
-
-    TGLayoutHints* layout =
-        new TGLayoutHints(kLHintsTop | kLHintsLeft | kLHintsExpandX, 1, 1, 3, 1);
-
-    main_frame->AddFrame(_button_first_, layout);
-    main_frame->AddFrame(_button_previous_, layout);
-    main_frame->AddFrame(_button_next_, layout);
-    main_frame->AddFrame(_button_last_, layout);
-    return;
-  }
-
-  void status_bar::reset() {
-    io::event_server& server = *_server_;
-
-    // clear list
+  // Special mode
+  if (!server.has_random_data()) {
+    const int event_number = server.get_current_event_number();
+    std::ostringstream status;
+    status << " +++ EVENT " << event_number;
+    if (server.has_sequential_data()) {
+      status << " +++ SEQUENTIAL READING ONLY +++ ";
+    }
+    if (server.has_external_data()) {
+      status << " +++ EXTERNAL PROCESSING +++ ";
+    }
     _event_list_->RemoveAll();
-    _event_list_->SetEnabled(true);
-
-    if (!server.is_opened()) {
-      _event_list_->AddEntry(" +++ NO EVENT LOADED +++ ", 0);
-      _event_list_->Select(0);
-      _event_list_->SetEnabled(false);
-    }
-
-    this->reset_buttons();
+    _event_list_->AddEntry(status.str().c_str(), 0);
+    _event_list_->Select(0);
+    _event_list_->SetEnabled(false);
+    _goto_event_->SetEnabled(false);
     return;
   }
 
-  void status_bar::update(const bool reset_, const bool disable_) {
-    io::event_server& server = *_server_;
-
-    // Special mode
-    if (!server.has_random_data()) {
-      const int event_number = server.get_current_event_number();
-      std::ostringstream status;
-      status << " +++ EVENT " << event_number;
-      if (server.has_sequential_data()) {
-        status << " +++ SEQUENTIAL READING ONLY +++ ";
-      }
-      if (server.has_external_data()) {
-        status << " +++ EXTERNAL PROCESSING +++ ";
-      }
-      _event_list_->RemoveAll();
-      _event_list_->AddEntry(status.str().c_str(), 0);
+  if (reset_) {
+    this->reset();
+    const io::event_server::event_selection_list_type& event_selection_list =
+        server.get_event_selection();
+    if (event_selection_list.empty()) {
+      _event_list_->AddEntry(" +++ NO EVENT MATCHED SELECTION +++ ", 0);
       _event_list_->Select(0);
-      _event_list_->SetEnabled(false);
-      _goto_event_->SetEnabled(false);
-      return;
+    } else {
+      for (io::event_server::event_selection_list_type::const_iterator i_selection =
+               event_selection_list.begin();
+           i_selection != event_selection_list.end(); ++i_selection) {
+        const size_t ievent = *i_selection;
+        const size_t total = server.get_number_of_events() - 1;
+        std::ostringstream label;
+        label << "event #" << ievent << "/" << total << " ("
+              << (total > 0 ? int(double(ievent) / total * 100) : 100) << "% complete)";
+        _event_list_->AddEntry(label.str().c_str(), ievent);
+      }
     }
+  }
 
-    if (reset_) {
-      this->reset();
-      const io::event_server::event_selection_list_type& event_selection_list =
-          server.get_event_selection();
-      if (event_selection_list.empty()) {
-        _event_list_->AddEntry(" +++ NO EVENT MATCHED SELECTION +++ ", 0);
-        _event_list_->Select(0);
+  _event_list_->SetEnabled(!disable_);
+  _event_list_->Select(server.get_current_event_number());
+  _goto_event_->SetEnabled(!disable_);
+  return;
+}
+
+void status_bar::update_buttons(const button_signals_type signal_) {
+  this->reset_buttons();
+
+  switch (signal_) {
+    case NEXT_EVENT: {
+      const options_manager& options_mgr = options_manager::get_instance();
+      if (options_mgr.is_automatic_event_reading_mode()) {
+        _button_next_->SetPicture(gClient->GetPicture("ed_interrupt.png"));
+        _button_next_->SetToolTipText("Auto reading mode");
       } else {
-        for (io::event_server::event_selection_list_type::const_iterator i_selection =
-                 event_selection_list.begin();
-             i_selection != event_selection_list.end(); ++i_selection) {
-          const size_t ievent = *i_selection;
-          const size_t total = server.get_number_of_events() - 1;
-          std::ostringstream label;
-          label << "event #" << ievent << "/" << total << " ("
-                << (total > 0 ? int(double(ievent) / total * 100) : 100) << "% complete)";
-          _event_list_->AddEntry(label.str().c_str(), ievent);
-        }
+        _button_next_->SetPicture(gClient->GetPicture("next_t.xpm"));
+        _button_next_->SetToolTipText("Next event");
       }
-    }
-
-    _event_list_->SetEnabled(!disable_);
-    _event_list_->Select(server.get_current_event_number());
-    _goto_event_->SetEnabled(!disable_);
-    return;
-  }
-
-  void status_bar::update_buttons(const button_signals_type signal_) {
-    this->reset_buttons();
-
-    switch (signal_) {
-      case NEXT_EVENT: {
-        const options_manager& options_mgr = options_manager::get_instance();
-        if (options_mgr.is_automatic_event_reading_mode()) {
-          _button_next_->SetPicture(gClient->GetPicture("ed_interrupt.png"));
-          _button_next_->SetToolTipText("Auto reading mode");
-        } else {
-          _button_next_->SetPicture(gClient->GetPicture("next_t.xpm"));
-          _button_next_->SetToolTipText("Next event");
-        }
-      } break;
-      case LAST_EVENT: {
-        _button_next_->SetEnabled(false);
-        _button_last_->SetEnabled(false);
-      } break;
-      case FIRST_EVENT: {
-        _button_first_->SetEnabled(false);
-        _button_previous_->SetEnabled(false);
-      } break;
-      default:
-        break;
-    }
-
-    if (_server_->get_current_event_number() == _server_->get_last_selected_event()) {
+    } break;
+    case LAST_EVENT: {
       _button_next_->SetEnabled(false);
       _button_last_->SetEnabled(false);
-    }
-
-    if (_server_->get_current_event_number() == _server_->get_first_selected_event()) {
+    } break;
+    case FIRST_EVENT: {
       _button_first_->SetEnabled(false);
       _button_previous_->SetEnabled(false);
-    }
-
-    return;
+    } break;
+    default:
+      break;
   }
 
-  void status_bar::reset_buttons() {
-    _button_first_->SetToolTipText("First event");
-    _button_previous_->SetToolTipText("Previous event");
-    _button_next_->SetToolTipText("Next event");
-    _button_last_->SetToolTipText("Last event");
-
-    _button_first_->SetEnabled(false);
-    _button_previous_->SetEnabled(false);
+  if (_server_->get_current_event_number() == _server_->get_last_selected_event()) {
     _button_next_->SetEnabled(false);
     _button_last_->SetEnabled(false);
-
-    if (!_server_->is_initialized()) return;
-
-    if (_server_->has_random_data()) {
-      _button_first_->SetEnabled(true);
-      _button_previous_->SetEnabled(true);
-      _button_next_->SetEnabled(true);
-      _button_last_->SetEnabled(true);
-    } else {
-      _button_first_->SetEnabled(false);
-      _button_previous_->SetEnabled(false);
-      _button_next_->SetEnabled(true);
-      _button_last_->SetEnabled(false);
-    }
-    return;
   }
 
-  void status_bar::process() {
-    const size_t a_nbr = _goto_event_->GetIntNumber();
-    if (a_nbr >= _server_->get_number_of_events()) {
-      DT_LOG_WARNING(options_manager::get_instance().get_logging_priority(),
-                     "Event number (#" << a_nbr << ") larger than the total number of events !");
-    } else {
-      _event_list_->Select(a_nbr);
-      _server_->set_current_event_number(a_nbr);
-    }
-    return;
+  if (_server_->get_current_event_number() == _server_->get_first_selected_event()) {
+    _button_first_->SetEnabled(false);
+    _button_previous_->SetEnabled(false);
   }
 
-  }  // end of namespace view
+  return;
+}
 
-  }  // end of namespace visualization
+void status_bar::reset_buttons() {
+  _button_first_->SetToolTipText("First event");
+  _button_previous_->SetToolTipText("Previous event");
+  _button_next_->SetToolTipText("Next event");
+  _button_last_->SetToolTipText("Last event");
+
+  _button_first_->SetEnabled(false);
+  _button_previous_->SetEnabled(false);
+  _button_next_->SetEnabled(false);
+  _button_last_->SetEnabled(false);
+
+  if (!_server_->is_initialized()) return;
+
+  if (_server_->has_random_data()) {
+    _button_first_->SetEnabled(true);
+    _button_previous_->SetEnabled(true);
+    _button_next_->SetEnabled(true);
+    _button_last_->SetEnabled(true);
+  } else {
+    _button_first_->SetEnabled(false);
+    _button_previous_->SetEnabled(false);
+    _button_next_->SetEnabled(true);
+    _button_last_->SetEnabled(false);
+  }
+  return;
+}
+
+void status_bar::process() {
+  const size_t a_nbr = _goto_event_->GetIntNumber();
+  if (a_nbr >= _server_->get_number_of_events()) {
+    DT_LOG_WARNING(options_manager::get_instance().get_logging_priority(),
+                   "Event number (#" << a_nbr << ") larger than the total number of events !");
+  } else {
+    _event_list_->Select(a_nbr);
+    _server_->set_current_event_number(a_nbr);
+  }
+  return;
+}
+
+}  // end of namespace view
+
+}  // end of namespace visualization
 
 }  // end of namespace snemo
 

--- a/modules/EventBrowser/source/status_bar.cc
+++ b/modules/EventBrowser/source/status_bar.cc
@@ -37,7 +37,7 @@
 #include <TGLabel.h>
 #include <TGNumberEntry.h>
 
-ClassImp(snemo::visualization::view::status_bar)
+ClassImp(snemo::visualization::view::status_bar);
 
     namespace snemo {
   namespace visualization {

--- a/modules/EventBrowser/source/status_bar.cc
+++ b/modules/EventBrowser/source/status_bar.cc
@@ -37,7 +37,11 @@
 #include <TGLabel.h>
 #include <TGNumberEntry.h>
 
+// Need trailing ; to satisfy clang-format, but leads to -pedantic error, ignore
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 ClassImp(snemo::visualization::view::status_bar);
+#pragma GCC diagnostic pop
 
 namespace snemo {
 namespace visualization {


### PR DESCRIPTION
Please fill in the following details as appropriate for your pull request.
You can leave any entries that aren't relevant blank.

Changes proprosed in this pull request:
- Make `clang-format` ignore ROOT pragmas
- Use a semicolon after `ClassImp` to help `clang-format` understand it

Does this pull request fix any reported issues?
- Fixes #64 

Additional comments or information
----------------------------------

Use of semicolon *might* cause compiler warnings.
