### PR TITLE
Feature add topology data

### DIFF
--- a/documentation/flreconstruct/PipelineOutput.md
+++ b/documentation/flreconstruct/PipelineOutput.md
@@ -365,3 +365,55 @@ TODO:
  - Describe the `snemo::datamodel::particle_track_solution` object.
  - Describe the `snemo::datamodel::particle_track` object.
  - Describe the `geomtools::blur_spot` object.
+
+Topology measurements {#flreconstructpipelineoutput_topologymeasurements}
+=====================
+
+While all previous data banks determine and compute new information at the
+level of the individual particles involved in an event, topology measurements are
+performed at the event scale. The **T** opology **D** data bank contains
+information relevant only on the full event scale, such as the Time-Of-Flight measurement
+(computed only when at least two particles are involved) or the vertex of the event.
+
+Each `snemo::datamodel::topology_data` object contains:
+ - a collection of auxiliary properties (a `datatools::properties` instance)
+ - a shared handle to the topology pattern.
+
+Several types of topology patterns are supported:
+ - the `snemo::datamodel::topology_1e_pattern` class is used for single electron event,
+ - the `snemo::datamodel::topology_1e1a_pattern` class is used for 1 electron +
+   1 alpha event,
+ - the `snemo::datamodel::topology_1eNg_pattern` class is used for 1 electron +
+   N gammas event,
+ - the `snemo::datamodel::topology_2e_pattern` class is used for 2 electrons event,
+ - the `snemo::datamodel::topology_2eNg_pattern` class is used for 2 electrons +
+   N gammas event.
+
+The classes inherit from the `snemo::datamodel::base_topology_pattern` class which
+contains :
+ - a dictionary of shared handles on `snemo::datamodel::particle_track` belonging
+   to the event. Each particle track object is key-mapped with a unique
+   name like `e1` and `e2` for two-electrons topology pattern.
+ - a dictionary of shared handles on
+   `snemo::datamodel::base_topology_measurement` holding the different
+   topological measurements performed on the event given its pattern.
+
+The `snemo::datamodel::base_topology_pattern` holds the topological data as well
+as a link to the particle tracks whereas the inherited classes from
+`snemo::datamodel::base_topology_pattern` only provide an *interface* and do not
+hold the data.
+
+Several topological measurements, all inherited from `snemo::datamodel::base_topology_measurement`, are provided :
+- a `snemo::datamodel::tof_measurement`, which contains Time-Of-Flight-related
+  measurements:
+  - a list of internal probabilities,
+  - a list of external probabilities.
+- a `snemo::datamodel::energy_measurement`, which contains the total energy of the event
+  as well as the energy associated to every individual particle,
+- a `snemo::datamodel::angle_measurement`, which contains the angle between two
+  given particles,
+- a `snemo::datamodel::vertex_measurement` which contains the 3D position of the
+  event vertex (determined by selecting the hypothesis with the best Χ² probability) and the errors on the extrapolated vertices.
+
+These topological measurements are only performed when relevant. For instance,
+TOF measurements do not make any sense for 1 electron topology patterns.

--- a/source/falaise/snemo.cmake
+++ b/source/falaise/snemo.cmake
@@ -63,6 +63,31 @@ list(APPEND FalaiseLibrary_HEADERS
   snemo/datamodels/particle_track_data.h
   snemo/datamodels/particle_track_data.ipp
 
+  snemo/datamodels/base_topology_measurement.h
+  snemo/datamodels/base_topology_measurement.ipp
+  snemo/datamodels/angle_measurement.h
+  snemo/datamodels/angle_measurement.ipp
+  snemo/datamodels/energy_measurement.h
+  snemo/datamodels/energy_measurement.ipp
+  snemo/datamodels/tof_measurement.h
+  snemo/datamodels/tof_measurement.ipp
+  snemo/datamodels/vertex_measurement.h
+  snemo/datamodels/vertex_measurement.ipp
+  snemo/datamodels/base_topology_pattern.h
+  snemo/datamodels/base_topology_pattern.ipp
+  snemo/datamodels/topology_1e_pattern.h
+  snemo/datamodels/topology_1e_pattern.ipp
+  snemo/datamodels/topology_1eNg_pattern.h
+  snemo/datamodels/topology_1eNg_pattern.ipp
+  snemo/datamodels/topology_1e1a_pattern.h
+  snemo/datamodels/topology_1e1a_pattern.ipp
+  snemo/datamodels/topology_2e_pattern.h
+  snemo/datamodels/topology_2e_pattern.ipp
+  snemo/datamodels/topology_2eNg_pattern.h
+  snemo/datamodels/topology_2eNg_pattern.ipp
+  snemo/datamodels/topology_data.h
+  snemo/datamodels/topology_data.ipp
+
   snemo/datamodels/data_model.h
 
   snemo/datamodels/the_serializable.h
@@ -135,6 +160,19 @@ list(APPEND FalaiseLibrary_SOURCES
   snemo/datamodels/the_serializable.cc
   snemo/datamodels/gg_track_utils.cc
 
+  snemo/datamodels/base_topology_measurement.cc
+  snemo/datamodels/angle_measurement.cc
+  snemo/datamodels/energy_measurement.cc
+  snemo/datamodels/tof_measurement.cc
+  snemo/datamodels/vertex_measurement.cc
+  snemo/datamodels/base_topology_pattern.cc
+  snemo/datamodels/topology_1e_pattern.cc
+  snemo/datamodels/topology_1eNg_pattern.cc
+  snemo/datamodels/topology_1e1a_pattern.cc
+  snemo/datamodels/topology_2e_pattern.cc
+  snemo/datamodels/topology_2eNg_pattern.cc
+  snemo/datamodels/topology_data.cc
+
   snemo/datamodels/sim_trigger_digi_data.cc
   snemo/datamodels/sim_readout_digi_data.cc
   snemo/datamodels/sim_tracker_digi_hit.cc
@@ -197,6 +235,10 @@ list(APPEND FalaiseLibrary_TESTS
   snemo/testing/test_snemo_datamodel_tracker_trajectory_solution.cxx
   snemo/testing/test_snemo_datamodel_particle_track.cxx
   snemo/testing/test_snemo_datamodel_particle_track_data.cxx
+  snemo/testing/test_snemo_datamodel_vertex_measurement.cxx
+  snemo/testing/test_snemo_datamodel_tof_measurement.cxx
+  snemo/testing/test_snemo_datamodel_base_topology_pattern.cxx
+  snemo/testing/test_snemo_datamodel_topology_data.cxx
   snemo/testing/test_snemo_geometry_calo_locator_1.cxx
   snemo/testing/test_snemo_geometry_gg_locator_1.cxx
   snemo/testing/test_snemo_geometry_gveto_locator_1.cxx

--- a/source/falaise/snemo/datamodels/angle_measurement.cc
+++ b/source/falaise/snemo/datamodels/angle_measurement.cc
@@ -1,0 +1,62 @@
+/** \file falaise/snemo/datamodels/angle_measurement.cc
+ */
+
+// Ourselves:
+#include <falaise/snemo/datamodels/angle_measurement.h>
+
+// Third party:
+// - Bayeux/datatools:
+#include <bayeux/datatools/clhep_units.h>
+
+namespace snemo {
+
+namespace datamodel {
+
+// Serial tag for datatools::i_serializable interface :
+DATATOOLS_SERIALIZATION_SERIAL_TAG_IMPLEMENTATION(angle_measurement,
+                                                  "snemo::datamodel::angle_measurement")
+
+angle_measurement::angle_measurement() {
+  datatools::invalidate(_angle_);
+  return;
+}
+
+angle_measurement::~angle_measurement() { return; }
+
+bool angle_measurement::has_angle() const { return datatools::is_valid(_angle_); }
+
+void angle_measurement::set_angle(double angle_) {
+  _angle_ = angle_;
+  return;
+}
+
+const double& angle_measurement::get_angle() const { return _angle_; }
+
+double& angle_measurement::grab_angle() { return _angle_; }
+
+void angle_measurement::tree_dump(std::ostream& out_, const std::string& title_,
+                                  const std::string& indent_, bool inherit_) const {
+  std::string indent;
+  if (!indent_.empty()) indent = indent_;
+  base_topology_measurement::tree_dump(out_, title_, indent_, true);
+
+  out_ << indent << datatools::i_tree_dumpable::inherit_tag(inherit_) << "Angle: ";
+  if (has_angle()) {
+    out_ << _angle_ / CLHEP::degree << "°" << std::endl;
+  } else {
+    out_ << "<no value>" << std::endl;
+  }
+  return;
+}
+
+}  // end of namespace datamodel
+
+}  // end of namespace snemo
+
+/*
+** Local Variables: --
+** mode: c++ --
+** c-file-style: "gnu" --
+** tab-width: 2 --
+** End: --
+*/

--- a/source/falaise/snemo/datamodels/angle_measurement.h
+++ b/source/falaise/snemo/datamodels/angle_measurement.h
@@ -1,0 +1,65 @@
+/// \file falaise/snemo/datamodels/angle_measurement.h
+/* Author(s) :    Steven Calvez <calvez@lal.in2p3.fr>
+ * Creation date: 2015-10-24
+ * Last modified: 2015-10-24
+ *
+ * Description: The class for angle measurement
+ */
+
+#ifndef FALAISE_SNEMO_DATAMODEL_ANGLE_MEASUREMENT_H
+#define FALAISE_SNEMO_DATAMODEL_ANGLE_MEASUREMENT_H 1
+
+// This project:
+#include <falaise/snemo/datamodels/base_topology_measurement.h>
+
+namespace snemo {
+
+namespace datamodel {
+
+/// \brief The angle measurement
+class angle_measurement : public base_topology_measurement {
+ public:
+  /// Constructor
+  angle_measurement();
+
+  /// Destructor
+  ~angle_measurement();
+
+  /// Check angle validity
+  bool has_angle() const;
+
+  /// Set angle value
+  void set_angle(double angle_);
+
+  /// Get a non-mutable reference to angle
+  const double& get_angle() const;
+
+  /// Get a mutable reference to angle
+  double& grab_angle();
+
+  /// Smart print
+  virtual void tree_dump(std::ostream& out_ = std::clog, const std::string& title_ = "",
+                         const std::string& indent_ = "", bool inherit_ = false) const;
+
+ private:
+  double _angle_;  //!< The angle value
+
+  DATATOOLS_SERIALIZATION_DECLARATION()
+};
+
+}  // end of namespace datamodel
+
+}  // end of namespace snemo
+
+#include <boost/serialization/export.hpp>
+BOOST_CLASS_EXPORT_KEY2(snemo::datamodel::angle_measurement, "snemo::datamodel::angle_measurement")
+
+#endif  // FALAISE_SNEMO_DATAMODEL_ANGLE_MEASUREMENT_H
+
+/*
+** Local Variables: --
+** mode: c++ --
+** c-file-style: "gnu" --
+** tab-width: 2 --
+** End: --
+*/

--- a/source/falaise/snemo/datamodels/angle_measurement.ipp
+++ b/source/falaise/snemo/datamodels/angle_measurement.ipp
@@ -1,0 +1,37 @@
+// -*- mode: c++ ; -*-
+/// \file falaise/snemo/datamodels/angle_measurement.ipp
+
+#ifndef FALAISE_SNEMO_DATAMODEL_ANGLE_MEASUREMENT_IPP
+#define FALAISE_SNEMO_DATAMODEL_ANGLE_MEASUREMENT_IPP 1
+
+// Ourselves:
+#include <falaise/snemo/datamodels/angle_measurement.h>
+
+// Third party:
+// - Boost:
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/nvp.hpp>
+#include <boost/serialization/string.hpp>
+// - Bayeux/datatools:
+#include <datatools/i_serializable.ipp>
+
+// This project:
+#include <falaise/snemo/datamodels/base_topology_measurement.ipp>
+
+namespace snemo {
+
+namespace datamodel {
+
+/// Serialization method
+template <class Archive>
+void angle_measurement::serialize(Archive& ar_, const unsigned int /* version_ */) {
+  ar_& BOOST_SERIALIZATION_BASE_OBJECT_NVP(base_topology_measurement);
+  ar_& boost::serialization::make_nvp("angle", _angle_);
+  return;
+}
+
+}  // end of namespace datamodel
+
+}  // end of namespace snemo
+
+#endif  // FALAISE_SNEMO_DATAMODEL_ANGLE_MEASUREMENT_IPP

--- a/source/falaise/snemo/datamodels/base_topology_measurement.cc
+++ b/source/falaise/snemo/datamodels/base_topology_measurement.cc
@@ -1,0 +1,60 @@
+/** \file falaise/snemo/datamodels/base_topology_measurement.cc
+ */
+
+// Ourselves:
+#include <falaise/snemo/datamodels/base_topology_measurement.h>
+
+namespace snemo {
+
+namespace datamodel {
+
+// Serial tag for datatools::i_serializable interface :
+DATATOOLS_SERIALIZATION_SERIAL_TAG_IMPLEMENTATION(base_topology_measurement,
+                                                  "snemo::datamodel::base_topology_measurement")
+
+base_topology_measurement::base_topology_measurement() { return; }
+
+base_topology_measurement::~base_topology_measurement() { return; }
+
+const datatools::properties& base_topology_measurement::get_auxiliaries() const {
+  return _auxiliaries_;
+}
+
+datatools::properties& base_topology_measurement::grab_auxiliaries() { return _auxiliaries_; }
+
+void base_topology_measurement::tree_dump(std::ostream& out_, const std::string& title_,
+                                          const std::string& indent_, bool inherit_) const {
+  std::string indent;
+  if (!indent_.empty()) {
+    indent = indent_;
+  }
+  if (!title_.empty()) {
+    out_ << indent << title_ << std::endl;
+  }
+
+  out_ << indent << datatools::i_tree_dumpable::inherit_tag(inherit_) << "Auxiliaries : ";
+  if (_auxiliaries_.empty()) {
+    out_ << "<empty>";
+  }
+  out_ << std::endl;
+  {
+    std::ostringstream indent_oss;
+    indent_oss << indent;
+    indent_oss << datatools::i_tree_dumpable::inherit_skip_tag(inherit_);
+    _auxiliaries_.tree_dump(out_, "", indent_oss.str());
+  }
+
+  return;
+}
+
+}  // end of namespace datamodel
+
+}  // end of namespace snemo
+
+/*
+** Local Variables: --
+** mode: c++ --
+** c-file-style: "gnu" --
+** tab-width: 2 --
+** End: --
+*/

--- a/source/falaise/snemo/datamodels/base_topology_measurement.cc
+++ b/source/falaise/snemo/datamodels/base_topology_measurement.cc
@@ -16,32 +16,14 @@ base_topology_measurement::base_topology_measurement() { return; }
 
 base_topology_measurement::~base_topology_measurement() { return; }
 
-const datatools::properties& base_topology_measurement::get_auxiliaries() const {
-  return _auxiliaries_;
-}
-
-datatools::properties& base_topology_measurement::grab_auxiliaries() { return _auxiliaries_; }
-
 void base_topology_measurement::tree_dump(std::ostream& out_, const std::string& title_,
-                                          const std::string& indent_, bool inherit_) const {
+                                          const std::string& indent_, bool /*inherit_*/) const {
   std::string indent;
   if (!indent_.empty()) {
     indent = indent_;
   }
   if (!title_.empty()) {
     out_ << indent << title_ << std::endl;
-  }
-
-  out_ << indent << datatools::i_tree_dumpable::inherit_tag(inherit_) << "Auxiliaries : ";
-  if (_auxiliaries_.empty()) {
-    out_ << "<empty>";
-  }
-  out_ << std::endl;
-  {
-    std::ostringstream indent_oss;
-    indent_oss << indent;
-    indent_oss << datatools::i_tree_dumpable::inherit_skip_tag(inherit_);
-    _auxiliaries_.tree_dump(out_, "", indent_oss.str());
   }
 
   return;

--- a/source/falaise/snemo/datamodels/base_topology_measurement.h
+++ b/source/falaise/snemo/datamodels/base_topology_measurement.h
@@ -1,0 +1,63 @@
+/// \file falaise/snemo/datamodels/base_topology_measurement.h
+/* Author(s) :    François Mauger <mauger@lpccaen.in2p3.fr>
+ * Creation date: 2012-03-19
+ * Last modified: 2014-01-27
+ *
+ * Description: The base class of topology measurement
+ */
+
+#ifndef FALAISE_SNEMO_DATAMODEL_BASE_TOPOLOGY_MEASUREMENT_H
+#define FALAISE_SNEMO_DATAMODEL_BASE_TOPOLOGY_MEASUREMENT_H 1
+
+// Standard library:
+#include <string>
+
+// Third party:
+// - Bayeux/datatools:
+#include <bayeux/datatools/i_serializable.h>
+#include <bayeux/datatools/i_tree_dump.h>
+#include <bayeux/datatools/properties.h>
+
+namespace snemo {
+
+namespace datamodel {
+
+/// \brief The base class of reconstructed topology
+class base_topology_measurement : public datatools::i_serializable,
+                                  public datatools::i_tree_dumpable {
+ public:
+  /// Constructor
+  base_topology_measurement();
+
+  /// Destructor
+  virtual ~base_topology_measurement();
+
+  /// Return the const container of auxiliaries
+  const datatools::properties& get_auxiliaries() const;
+
+  /// Return the mutable container of auxiliaries
+  datatools::properties& grab_auxiliaries();
+
+  /// Smart print
+  virtual void tree_dump(std::ostream& out_ = std::clog, const std::string& title_ = "",
+                         const std::string& indent_ = "", bool inherit_ = false) const;
+
+ private:
+  datatools::properties _auxiliaries_;  //!< Auxiliary properties
+
+  DATATOOLS_SERIALIZATION_DECLARATION()
+};
+
+}  // end of namespace datamodel
+
+}  // end of namespace snemo
+
+#endif  // FALAISE_SNEMO_DATAMODEL_BASE_TOPOLOGY_MEASUREMENT_H
+
+/*
+** Local Variables: --
+** mode: c++ --
+** c-file-style: "gnu" --
+** tab-width: 2 --
+** End: --
+*/

--- a/source/falaise/snemo/datamodels/base_topology_measurement.h
+++ b/source/falaise/snemo/datamodels/base_topology_measurement.h
@@ -16,7 +16,6 @@
 // - Bayeux/datatools:
 #include <bayeux/datatools/i_serializable.h>
 #include <bayeux/datatools/i_tree_dump.h>
-#include <bayeux/datatools/properties.h>
 
 namespace snemo {
 
@@ -32,18 +31,11 @@ class base_topology_measurement : public datatools::i_serializable,
   /// Destructor
   virtual ~base_topology_measurement();
 
-  /// Return the const container of auxiliaries
-  const datatools::properties& get_auxiliaries() const;
-
-  /// Return the mutable container of auxiliaries
-  datatools::properties& grab_auxiliaries();
-
   /// Smart print
   virtual void tree_dump(std::ostream& out_ = std::clog, const std::string& title_ = "",
                          const std::string& indent_ = "", bool inherit_ = false) const;
 
  private:
-  datatools::properties _auxiliaries_;  //!< Auxiliary properties
 
   DATATOOLS_SERIALIZATION_DECLARATION()
 };

--- a/source/falaise/snemo/datamodels/base_topology_measurement.ipp
+++ b/source/falaise/snemo/datamodels/base_topology_measurement.ipp
@@ -1,0 +1,34 @@
+// -*- mode: c++ ; -*-
+/// \file falaise/snemo/datamodels/base_topology_measurement.ipp
+
+#ifndef FALAISE_SNEMO_DATAMODEL_BASE_TOPOLOGY_MEASUREMENT_IPP
+#define FALAISE_SNEMO_DATAMODEL_BASE_TOPOLOGY_MEASUREMENT_IPP 1
+
+// Ourselves:
+#include <falaise/snemo/datamodels/base_topology_measurement.h>
+
+// Third party:
+// - Boost:
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/nvp.hpp>
+#include <boost/serialization/string.hpp>
+// - Bayeux/datatools:
+#include <datatools/i_serializable.ipp>
+
+namespace snemo {
+
+namespace datamodel {
+
+/// Serialization method
+template <class Archive>
+void base_topology_measurement::serialize(Archive& ar_, const unsigned int /* version_ */) {
+  ar_& DATATOOLS_SERIALIZATION_I_SERIALIZABLE_BASE_OBJECT_NVP;
+  ar_& boost::serialization::make_nvp("auxiliaries", _auxiliaries_);
+  return;
+}
+
+}  // end of namespace datamodel
+
+}  // end of namespace snemo
+
+#endif  // FALAISE_SNEMO_DATAMODEL_BASE_TOPOLOGY_MEASUREMENT_IPP

--- a/source/falaise/snemo/datamodels/base_topology_measurement.ipp
+++ b/source/falaise/snemo/datamodels/base_topology_measurement.ipp
@@ -23,7 +23,6 @@ namespace datamodel {
 template <class Archive>
 void base_topology_measurement::serialize(Archive& ar_, const unsigned int /* version_ */) {
   ar_& DATATOOLS_SERIALIZATION_I_SERIALIZABLE_BASE_OBJECT_NVP;
-  ar_& boost::serialization::make_nvp("auxiliaries", _auxiliaries_);
   return;
 }
 

--- a/source/falaise/snemo/datamodels/base_topology_pattern.cc
+++ b/source/falaise/snemo/datamodels/base_topology_pattern.cc
@@ -1,0 +1,150 @@
+/** \file falaise/snemo/datamodels/base_topology_pattern.cc
+ */
+
+// Ourselves:
+#include <falaise/snemo/datamodels/base_topology_pattern.h>
+
+// Standard library:
+#include <regex>
+
+namespace snemo {
+
+namespace datamodel {
+
+// Serial tag for datatools::i_serializable interface :
+DATATOOLS_SERIALIZATION_SERIAL_TAG_IMPLEMENTATION(base_topology_pattern,
+                                                  "snemo::datamodel::base_topology_pattern")
+
+base_topology_pattern::base_topology_pattern() { return; }
+
+base_topology_pattern::~base_topology_pattern() { return; }
+
+snemo::datamodel::base_topology_pattern::particle_track_dict_type&
+base_topology_pattern::grab_particle_track_dictionary() {
+  return _tracks_;
+}
+
+const snemo::datamodel::base_topology_pattern::particle_track_dict_type&
+base_topology_pattern::get_particle_track_dictionary() const {
+  return _tracks_;
+}
+
+bool base_topology_pattern::has_particle_track(const std::string& key_) const {
+  return _tracks_.find(key_) != _tracks_.end();
+}
+
+const snemo::datamodel::particle_track& base_topology_pattern::get_particle_track(
+    const std::string& key_) const {
+  return _tracks_.at(key_).get();
+}
+
+bool base_topology_pattern::has_measurement(const std::string& key_) const {
+  // Use key as regular expression and match over it
+  auto it = std::find_if(_meas_.begin(), _meas_.end(),
+                         [key_](const std::pair<std::string, handle_measurement>& t) -> bool {
+                           return std::regex_match(t.first, std::regex(key_));
+                         });
+  return it != _meas_.end();
+}
+
+const snemo::datamodel::base_topology_measurement& base_topology_pattern::get_measurement(
+    const std::string& key_) const {
+  return _meas_.at(key_).get();
+}
+
+snemo::datamodel::base_topology_pattern::measurement_dict_type&
+base_topology_pattern::grab_measurement_dictionary() {
+  return _meas_;
+}
+
+const snemo::datamodel::base_topology_pattern::measurement_dict_type&
+base_topology_pattern::get_measurement_dictionary() const {
+  return _meas_;
+}
+
+void base_topology_pattern::tree_dump(std::ostream& out_, const std::string& title_,
+                                      const std::string& indent_, bool inherit_) const {
+  std::string indent;
+  if (!indent_.empty()) {
+    indent = indent_;
+  }
+  if (!title_.empty()) {
+    out_ << indent << title_ << std::endl;
+  }
+
+  out_ << indent << datatools::i_tree_dumpable::tag << "Pattern ID : "
+       << "'" << get_pattern_id() << "'" << std::endl;
+
+  {
+    out_ << indent << datatools::i_tree_dumpable::tag << "Associated particle tracks : ";
+    if (_tracks_.empty()) {
+      out_ << "<none>";
+    } else {
+      out_ << _tracks_.size();
+    }
+    out_ << std::endl;
+    for (snemo::datamodel::base_topology_pattern::particle_track_dict_type::const_iterator i =
+             _tracks_.begin();
+         i != _tracks_.end(); ++i) {
+      const std::string& a_name = i->first;
+      const snemo::datamodel::particle_track& a_track = i->second.get();
+      out_ << indent << datatools::i_tree_dumpable::skip_tag;
+      snemo::datamodel::base_topology_pattern::particle_track_dict_type::const_iterator j = i;
+      std::ostringstream indent2;
+      indent2 << indent << datatools::i_tree_dumpable::skip_tag;
+      if (++j == _tracks_.end()) {
+        out_ << datatools::i_tree_dumpable::last_tag;
+        indent2 << datatools::i_tree_dumpable::last_skip_tag;
+      } else {
+        out_ << datatools::i_tree_dumpable::tag;
+        indent2 << datatools::i_tree_dumpable::skip_tag;
+      }
+      out_ << "Particle '" << a_name << "' :" << std::endl;
+      a_track.tree_dump(out_, "", indent2.str());
+    }
+  }
+
+  {
+    out_ << indent << datatools::i_tree_dumpable::inherit_tag(inherit_)
+         << "Associated measurements : ";
+    if (_meas_.empty()) {
+      out_ << "<none>";
+    } else {
+      out_ << _meas_.size();
+    }
+    out_ << std::endl;
+    for (snemo::datamodel::base_topology_pattern::measurement_dict_type::const_iterator i =
+             _meas_.begin();
+         i != _meas_.end(); ++i) {
+      const std::string& a_name = i->first;
+      const snemo::datamodel::base_topology_measurement& a_meas = i->second.get();
+      out_ << indent << datatools::i_tree_dumpable::inherit_skip_tag(inherit_);
+      snemo::datamodel::base_topology_pattern::measurement_dict_type::const_iterator j = i;
+      std::ostringstream indent2;
+      indent2 << indent << datatools::i_tree_dumpable::inherit_skip_tag(inherit_);
+      if (++j == _meas_.end()) {
+        out_ << datatools::i_tree_dumpable::inherit_tag(inherit_);
+        indent2 << datatools::i_tree_dumpable::inherit_skip_tag(inherit_);
+      } else {
+        out_ << datatools::i_tree_dumpable::tag;
+        indent2 << datatools::i_tree_dumpable::skip_tag;
+      }
+      out_ << "Measurement '" << a_name << "' :" << std::endl;
+      a_meas.tree_dump(out_, "", indent2.str());
+    }
+  }
+
+  return;
+}
+
+}  // end of namespace datamodel
+
+}  // end of namespace snemo
+
+/*
+** Local Variables: --
+** mode: c++ --
+** c-file-style: "gnu" --
+** tab-width: 2 --
+** End: --
+*/

--- a/source/falaise/snemo/datamodels/base_topology_pattern.h
+++ b/source/falaise/snemo/datamodels/base_topology_pattern.h
@@ -1,0 +1,119 @@
+/// \file falaise/snemo/datamodels/base_topology_pattern.h
+/* Author(s) :    Steven Calvez <calvez@lal.in2p3.fr>
+ * Creation date: 2015-09-19
+ * Last modified: 2015-11-11
+ *
+ * Description: The base class of topology patterns
+ */
+
+#ifndef FALAISE_SNEMO_DATAMODEL_BASE_TOPOLOGY_PATTERN_H
+#define FALAISE_SNEMO_DATAMODEL_BASE_TOPOLOGY_PATTERN_H 1
+
+// Standard library:
+#include <map>
+#include <string>
+
+// Third party:
+// - Bayeux/datatools:
+#include <bayeux/datatools/i_serializable.h>
+#include <bayeux/datatools/i_tree_dump.h>
+
+// This project:
+#include <falaise/snemo/datamodels/base_topology_measurement.h>
+#include <falaise/snemo/datamodels/particle_track.h>
+
+namespace snemo {
+
+namespace datamodel {
+
+/// \brief The base class of reconstructed topology
+class base_topology_pattern : public datatools::i_serializable, public datatools::i_tree_dumpable {
+ public:
+  /// Return topology pattern id
+  virtual std::string get_pattern_id() const = 0;
+
+  /// Typedef to particle track dictionary
+  typedef std::map<std::string, snemo::datamodel::particle_track::handle_type>
+      particle_track_dict_type;
+
+  /// Typedef to base topology pattern handle
+  typedef datatools::handle<snemo::datamodel::base_topology_pattern> handle_type;
+
+  /// Typedef to measurement handle
+  typedef datatools::handle<base_topology_measurement> handle_measurement;
+
+  /// Typedef to measurement dictionary
+  typedef std::map<std::string, handle_measurement> measurement_dict_type;
+
+  /// Constructor
+  base_topology_pattern();
+
+  /// Destructor
+  virtual ~base_topology_pattern();
+
+  /// Get a mutable reference to particle track dictionary
+  particle_track_dict_type &grab_particle_track_dictionary();
+
+  /// Get a non-mutable reference to particle track dictionary
+  const particle_track_dict_type &get_particle_track_dictionary() const;
+
+  /// Check if a particle track exists
+  bool has_particle_track(const std::string &) const;
+
+  /// Get a given particle track
+  const snemo::datamodel::particle_track &get_particle_track(const std::string &) const;
+
+  /// Check if a measurement is available
+  bool has_measurement(const std::string &) const;
+
+  /// Get a given measurement
+  const snemo::datamodel::base_topology_measurement &get_measurement(const std::string &) const;
+
+  /// Check measurement data type
+  template <class T>
+  bool has_measurement_as(const std::string &label_) const {
+    DT_THROW_IF(!has_measurement(label_), std::logic_error,
+                "Topology pattern does not hold any '" << label_ << "' measurement !");
+    const std::type_info &ti = typeid(T);
+    const std::type_info &tf = typeid(get_measurement(label_));
+    return ti == tf;
+  }
+
+  /// Get a non-mutable measurement of a given type
+  template <class T>
+  const T &get_measurement_as(const std::string &label_) const {
+    DT_THROW_IF(!has_measurement_as<T>(label_), std::logic_error,
+                "Invalid request on measurement data type !");
+    return dynamic_cast<const T &>(get_measurement(label_));
+  }
+
+  /// Get a mutable reference to measurement dictionary
+  measurement_dict_type &grab_measurement_dictionary();
+
+  /// Get a non-mutable reference to measurement dictionary
+  const measurement_dict_type &get_measurement_dictionary() const;
+
+  /// Smart print
+  virtual void tree_dump(std::ostream &out_ = std::clog, const std::string &title_ = "",
+                         const std::string &indent_ = "", bool inherit_ = false) const;
+
+ private:
+  particle_track_dict_type _tracks_;  //!< Particle track dictionary
+  measurement_dict_type _meas_;       //!< Measurement dictionary
+
+  DATATOOLS_SERIALIZATION_DECLARATION()
+};
+
+}  // end of namespace datamodel
+
+}  // end of namespace snemo
+
+#endif  // FALAISE_SNEMO_DATAMODEL_BASE_TOPOLOGY_PATTERN_H
+
+/*
+** Local Variables: --
+** mode: c++ --
+** c-file-style: "gnu" --
+** tab-width: 2 --
+** End: --
+*/

--- a/source/falaise/snemo/datamodels/base_topology_pattern.ipp
+++ b/source/falaise/snemo/datamodels/base_topology_pattern.ipp
@@ -1,0 +1,35 @@
+// -*- mode: c++ ; -*-
+/// \file falaise/snemo/datamodels/base_topology_pattern.ipp
+
+#ifndef FALAISE_SNEMO_DATAMODEL_BASE_TOPOLOGY_PATTERN_IPP
+#define FALAISE_SNEMO_DATAMODEL_BASE_TOPOLOGY_PATTERN_IPP 1
+
+// Ourselves:
+#include <falaise/snemo/datamodels/base_topology_pattern.h>
+
+// Third party:
+// - Boost:
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/nvp.hpp>
+#include <boost/serialization/string.hpp>
+// - Bayeux/datatools:
+#include <datatools/i_serializable.ipp>
+
+namespace snemo {
+
+namespace datamodel {
+
+/// Serialization method
+template <class Archive>
+void base_topology_pattern::serialize(Archive& ar_, const unsigned int /* version_ */) {
+  ar_& DATATOOLS_SERIALIZATION_I_SERIALIZABLE_BASE_OBJECT_NVP;
+  ar_& boost::serialization::make_nvp("particle_tracks", _tracks_);
+  ar_& boost::serialization::make_nvp("measurements", _meas_);
+  return;
+}
+
+}  // end of namespace datamodel
+
+}  // end of namespace snemo
+
+#endif  // FALAISE_SNEMO_DATAMODEL_BASE_TOPOLOGY_PATTERN_IPP

--- a/source/falaise/snemo/datamodels/energy_measurement.cc
+++ b/source/falaise/snemo/datamodels/energy_measurement.cc
@@ -1,0 +1,62 @@
+/** \file falaise/snemo/datamodels/energy_measurement.cc
+ */
+
+// Ourselves:
+#include <falaise/snemo/datamodels/energy_measurement.h>
+
+// Third party:
+// - Bayeux/datatools:
+#include <bayeux/datatools/clhep_units.h>
+
+namespace snemo {
+
+namespace datamodel {
+
+// Serial tag for datatools::i_serializable interface :
+DATATOOLS_SERIALIZATION_SERIAL_TAG_IMPLEMENTATION(energy_measurement,
+                                                  "snemo::datamodel::energy_measurement")
+
+energy_measurement::energy_measurement() {
+  datatools::invalidate(_energy_);
+  return;
+}
+
+energy_measurement::~energy_measurement() { return; }
+
+bool energy_measurement::has_energy() const { return datatools::is_valid(_energy_); }
+
+void energy_measurement::set_energy(double energy_) {
+  _energy_ = energy_;
+  return;
+}
+
+const double& energy_measurement::get_energy() const { return _energy_; }
+
+double& energy_measurement::grab_energy() { return _energy_; }
+
+void energy_measurement::tree_dump(std::ostream& out_, const std::string& title_,
+                                   const std::string& indent_, bool inherit_) const {
+  std::string indent;
+  if (!indent_.empty()) indent = indent_;
+  base_topology_measurement::tree_dump(out_, title_, indent_, true);
+
+  out_ << indent << datatools::i_tree_dumpable::inherit_tag(inherit_) << "Energy: ";
+  if (has_energy()) {
+    out_ << _energy_ / CLHEP::keV << " keV" << std::endl;
+  } else {
+    out_ << "<no value>" << std::endl;
+  }
+  return;
+}
+
+}  // end of namespace datamodel
+
+}  // end of namespace snemo
+
+/*
+** Local Variables: --
+** mode: c++ --
+** c-file-style: "gnu" --
+** tab-width: 2 --
+** End: --
+*/

--- a/source/falaise/snemo/datamodels/energy_measurement.h
+++ b/source/falaise/snemo/datamodels/energy_measurement.h
@@ -1,0 +1,66 @@
+/// \file falaise/snemo/datamodels/energy_measurement.h
+/* Author(s) :    Steven Calvez <calvez@lal.in2p3.fr>
+ * Creation date: 2015-10-24
+ * Last modified: 2015-10-24
+ *
+ * Description: The class for energy measurement
+ */
+
+#ifndef FALAISE_SNEMO_DATAMODEL_ENERGY_MEASUREMENT_H
+#define FALAISE_SNEMO_DATAMODEL_ENERGY_MEASUREMENT_H 1
+
+// This project:
+#include <falaise/snemo/datamodels/base_topology_measurement.h>
+
+namespace snemo {
+
+namespace datamodel {
+
+/// \brief The energy measurement
+class energy_measurement : public base_topology_measurement {
+ public:
+  /// Constructor
+  energy_measurement();
+
+  /// Destructor
+  ~energy_measurement();
+
+  /// Check energy validity
+  bool has_energy() const;
+
+  /// Set energy value
+  void set_energy(double energy_);
+
+  /// Get a non-mutable reference to energy
+  const double& get_energy() const;
+
+  /// Get a mutable reference to energy
+  double& grab_energy();
+
+  /// Smart print
+  virtual void tree_dump(std::ostream& out_ = std::clog, const std::string& title_ = "",
+                         const std::string& indent_ = "", bool inherit_ = false) const;
+
+ private:
+  double _energy_;  //!< The energy value
+
+  DATATOOLS_SERIALIZATION_DECLARATION()
+};
+
+}  // end of namespace datamodel
+
+}  // end of namespace snemo
+
+#include <boost/serialization/export.hpp>
+BOOST_CLASS_EXPORT_KEY2(snemo::datamodel::energy_measurement,
+                        "snemo::datamodel::energy_measurement")
+
+#endif  // FALAISE_SNEMO_DATAMODEL_ENERGY_MEASUREMENT_H
+
+/*
+** Local Variables: --
+** mode: c++ --
+** c-file-style: "gnu" --
+** tab-width: 2 --
+** End: --
+*/

--- a/source/falaise/snemo/datamodels/energy_measurement.ipp
+++ b/source/falaise/snemo/datamodels/energy_measurement.ipp
@@ -1,0 +1,37 @@
+// -*- mode: c++ ; -*-
+/// \file falaise/snemo/datamodels/energy_measurement.ipp
+
+#ifndef FALAISE_SNEMO_DATAMODEL_ENERGY_MEASUREMENT_IPP
+#define FALAISE_SNEMO_DATAMODEL_ENERGY_MEASUREMENT_IPP 1
+
+// Ourselves:
+#include <falaise/snemo/datamodels/energy_measurement.h>
+
+// Third party:
+// - Boost:
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/nvp.hpp>
+#include <boost/serialization/string.hpp>
+// - Bayeux/datatools:
+#include <datatools/i_serializable.ipp>
+
+// This project:
+#include <falaise/snemo/datamodels/base_topology_measurement.ipp>
+
+namespace snemo {
+
+namespace datamodel {
+
+/// Serialization method
+template <class Archive>
+void energy_measurement::serialize(Archive& ar_, const unsigned int /* version_ */) {
+  ar_& BOOST_SERIALIZATION_BASE_OBJECT_NVP(base_topology_measurement);
+  ar_& boost::serialization::make_nvp("energy", _energy_);
+  return;
+}
+
+}  // end of namespace datamodel
+
+}  // end of namespace snemo
+
+#endif  // FALAISE_SNEMO_DATAMODEL_ENERGY_MEASUREMENT_IPP

--- a/source/falaise/snemo/datamodels/the_serializable.h
+++ b/source/falaise/snemo/datamodels/the_serializable.h
@@ -150,6 +150,57 @@ DATATOOLS_SERIALIZATION_CLASS_SERIALIZE_INSTANTIATE_ALL(snemo::datamodel::partic
 DATATOOLS_SERIALIZATION_CLASS_SERIALIZE_INSTANTIATE_ALL(snemo::datamodel::particle_track_data)
 BOOST_CLASS_EXPORT_IMPLEMENT(snemo::datamodel::particle_track_data)
 
+/******************************************
+ * snemo::datamodel::topology_measurement *
+ ******************************************/
+#include <falaise/snemo/datamodels/base_topology_measurement.ipp>
+#include <falaise/snemo/datamodels/energy_measurement.ipp>
+DATATOOLS_SERIALIZATION_CLASS_SERIALIZE_INSTANTIATE_ALL(snemo::datamodel::energy_measurement)
+BOOST_CLASS_EXPORT_IMPLEMENT(snemo::datamodel::energy_measurement)
+#include <falaise/snemo/datamodels/angle_measurement.ipp>
+DATATOOLS_SERIALIZATION_CLASS_SERIALIZE_INSTANTIATE_ALL(snemo::datamodel::angle_measurement)
+BOOST_CLASS_EXPORT_IMPLEMENT(snemo::datamodel::angle_measurement)
+#include <falaise/snemo/datamodels/vertex_measurement.ipp>
+DATATOOLS_SERIALIZATION_CLASS_SERIALIZE_INSTANTIATE_ALL(snemo::datamodel::vertex_measurement)
+BOOST_CLASS_EXPORT_IMPLEMENT(snemo::datamodel::vertex_measurement)
+#include <falaise/snemo/datamodels/tof_measurement.ipp>
+DATATOOLS_SERIALIZATION_CLASS_SERIALIZE_INSTANTIATE_ALL(snemo::datamodel::tof_measurement)
+BOOST_CLASS_EXPORT_IMPLEMENT(snemo::datamodel::tof_measurement)
+
+
+/**************************************
+ * snemo::datamodel::topology_pattern *
+ **************************************/
+
+#include <falaise/snemo/datamodels/base_topology_pattern.ipp>
+#include <falaise/snemo/datamodels/topology_1e_pattern.ipp>
+DATATOOLS_SERIALIZATION_CLASS_SERIALIZE_INSTANTIATE_ALL(snemo::datamodel::topology_1e_pattern)
+BOOST_CLASS_EXPORT_IMPLEMENT(snemo::datamodel::topology_1e_pattern)
+
+#include <falaise/snemo/datamodels/topology_1e1a_pattern.ipp>
+DATATOOLS_SERIALIZATION_CLASS_SERIALIZE_INSTANTIATE_ALL(snemo::datamodel::topology_1e1a_pattern)
+BOOST_CLASS_EXPORT_IMPLEMENT(snemo::datamodel::topology_1e1a_pattern)
+
+#include <falaise/snemo/datamodels/topology_1eNg_pattern.ipp>
+DATATOOLS_SERIALIZATION_CLASS_SERIALIZE_INSTANTIATE_ALL(snemo::datamodel::topology_1eNg_pattern)
+BOOST_CLASS_EXPORT_IMPLEMENT(snemo::datamodel::topology_1eNg_pattern)
+
+#include <falaise/snemo/datamodels/topology_2e_pattern.ipp>
+DATATOOLS_SERIALIZATION_CLASS_SERIALIZE_INSTANTIATE_ALL(snemo::datamodel::topology_2e_pattern)
+BOOST_CLASS_EXPORT_IMPLEMENT(snemo::datamodel::topology_2e_pattern)
+
+#include <falaise/snemo/datamodels/topology_2eNg_pattern.ipp>
+DATATOOLS_SERIALIZATION_CLASS_SERIALIZE_INSTANTIATE_ALL(snemo::datamodel::topology_2eNg_pattern)
+BOOST_CLASS_EXPORT_IMPLEMENT(snemo::datamodel::topology_2eNg_pattern)
+
+/***********************************
+ * snemo::datamodel::topology_data *
+ ***********************************/
+
+#include <falaise/snemo/datamodels/topology_data.ipp>
+DATATOOLS_SERIALIZATION_CLASS_SERIALIZE_INSTANTIATE_ALL(snemo::datamodel::topology_data)
+BOOST_CLASS_EXPORT_IMPLEMENT(snemo::datamodel::topology_data)
+
 /***********************************
  * snemo::datamodel::sim_digi_data *
  ***********************************/

--- a/source/falaise/snemo/datamodels/the_serializable.ipp
+++ b/source/falaise/snemo/datamodels/the_serializable.ipp
@@ -32,6 +32,15 @@
 #include <falaise/snemo/datamodels/particle_track.ipp>
 #include <falaise/snemo/datamodels/particle_track_data.ipp>
 
+#include <falaise/snemo/datamodels/base_topology_pattern.ipp>
+#include <falaise/snemo/datamodels/base_topology_measurement.ipp>
+#include <falaise/snemo/datamodels/topology_1e_pattern.ipp>
+#include <falaise/snemo/datamodels/topology_2e_pattern.ipp>
+#include <falaise/snemo/datamodels/topology_1eNg_pattern.ipp>
+#include <falaise/snemo/datamodels/topology_2eNg_pattern.ipp>
+#include <falaise/snemo/datamodels/topology_1e1a_pattern.ipp>
+#include <falaise/snemo/datamodels/topology_data.ipp>
+
 //#include <snemo/datamodels/sim_signal_data.ipp>
 #include <snemo/datamodels/sim_calo_digi_hit.ipp>
 #include <snemo/datamodels/sim_digi_data.ipp>

--- a/source/falaise/snemo/datamodels/tof_measurement.cc
+++ b/source/falaise/snemo/datamodels/tof_measurement.cc
@@ -1,0 +1,100 @@
+/** \file falaise/snemo/datamodels/tof_measurement.cc
+ */
+
+// Ourselves:
+#include <falaise/snemo/datamodels/tof_measurement.h>
+
+// Third party:
+// - Bayeux/datatools:
+#include <bayeux/datatools/clhep_units.h>
+
+namespace snemo {
+
+namespace datamodel {
+
+// Serial tag for datatools::i_serializable interface :
+DATATOOLS_SERIALIZATION_SERIAL_TAG_IMPLEMENTATION(tof_measurement,
+                                                  "snemo::datamodel::tof_measurement")
+
+tof_measurement::tof_measurement() { return; }
+
+tof_measurement::~tof_measurement() { return; }
+
+bool tof_measurement::has_internal_probabilities() const {
+  return !_internal_probabilities_.empty();
+}
+
+const tof_measurement::probability_type& tof_measurement::get_internal_probabilities() const {
+  return _internal_probabilities_;
+}
+
+tof_measurement::probability_type& tof_measurement::grab_internal_probabilities() {
+  return _internal_probabilities_;
+}
+
+bool tof_measurement::has_external_probabilities() const {
+  return !_external_probabilities_.empty();
+}
+
+const tof_measurement::probability_type& tof_measurement::get_external_probabilities() const {
+  return _external_probabilities_;
+}
+
+tof_measurement::probability_type& tof_measurement::grab_external_probabilities() {
+  return _external_probabilities_;
+}
+
+void tof_measurement::tree_dump(std::ostream& out_, const std::string& title_,
+                                const std::string& indent_, bool inherit_) const {
+  std::string indent;
+  if (!indent_.empty()) indent = indent_;
+  base_topology_measurement::tree_dump(out_, title_, indent_, true);
+
+  out_ << indent << datatools::i_tree_dumpable::tag << "Internal probabilities: ";
+  if (has_internal_probabilities()) {
+    out_ << _internal_probabilities_.size() << std::endl;
+  } else {
+    out_ << "<no value>" << std::endl;
+  }
+  for (size_t i = 0; i < _internal_probabilities_.size(); i++) {
+    const double pint = _internal_probabilities_.at(i);
+    out_ << indent << datatools::i_tree_dumpable::skip_tag;
+    if (i + 1 == _internal_probabilities_.size()) {
+      out_ << datatools::i_tree_dumpable::last_tag;
+    } else {
+      out_ << datatools::i_tree_dumpable::tag;
+    }
+    out_ << "Value #" << i << " = " << pint / CLHEP::perCent << "%" << std::endl;
+  }
+
+  out_ << indent << datatools::i_tree_dumpable::inherit_tag(inherit_) << "External probabilities: ";
+  if (has_external_probabilities()) {
+    out_ << _external_probabilities_.size() << std::endl;
+  } else {
+    out_ << "<no value>" << std::endl;
+  }
+  for (size_t i = 0; i < _external_probabilities_.size(); i++) {
+    const double pext = _external_probabilities_.at(i);
+    out_ << indent << datatools::i_tree_dumpable::inherit_skip_tag(inherit_);
+    if (i + 1 == _external_probabilities_.size()) {
+      out_ << datatools::i_tree_dumpable::last_tag;
+    } else {
+      out_ << datatools::i_tree_dumpable::tag;
+    }
+    out_ << "Value #" << i << " = " << pext / CLHEP::perCent << "%" << std::endl;
+  }
+
+  return;
+}
+
+}  // end of namespace datamodel
+
+}  // end of namespace snemo
+
+/*
+** Local Variables: --
+** mode: c++ --
+** c-file-style: "gnu" --
+** tab-width: 2 --
+** End: --
+*/

--- a/source/falaise/snemo/datamodels/tof_measurement.h
+++ b/source/falaise/snemo/datamodels/tof_measurement.h
@@ -1,0 +1,74 @@
+/// \file falaise/snemo/datamodels/tof_measurement.h
+/* Author(s) :    Steven Calvez <calvez@lal.in2p3.fr>
+ * Creation date: 2014-01-27
+ * Last modified: 2015-10-20
+ *
+ * Description: The Time-Of-Flight measurement
+ */
+
+#ifndef FALAISE_SNEMO_DATAMODEL_TOF_MEASUREMENT_H
+#define FALAISE_SNEMO_DATAMODEL_TOF_MEASUREMENT_H 1
+
+// This project:
+#include <falaise/snemo/datamodels/base_topology_measurement.h>
+
+namespace snemo {
+
+namespace datamodel {
+
+/// \brief The Time Of Flight measurement
+class tof_measurement : public base_topology_measurement {
+ public:
+  /// Typedef for probability type
+  typedef std::vector<double> probability_type;
+
+  /// Constructor
+  tof_measurement();
+
+  /// Destructor
+  ~tof_measurement();
+
+  /// Check if current measure has internal probabilities
+  bool has_internal_probabilities() const;
+
+  /// Get a non-mutable reference to internal probabilities
+  const probability_type& get_internal_probabilities() const;
+
+  /// Get a mutable reference to internal probabilities
+  probability_type& grab_internal_probabilities();
+
+  /// Check if current measure has external probabilities
+  bool has_external_probabilities() const;
+
+  /// Get a non-mutable reference to external probabilities
+  const probability_type& get_external_probabilities() const;
+
+  /// Get a mutable reference to external probabilities
+  probability_type& grab_external_probabilities();
+
+  /// Smart print
+  virtual void tree_dump(std::ostream& out_ = std::clog, const std::string& title_ = "",
+                         const std::string& indent_ = "", bool inherit_ = false) const;
+
+ private:
+  probability_type _internal_probabilities_;  //!< TOF internal probabilities
+  probability_type _external_probabilities_;  //!< TOF external probabilities
+
+  DATATOOLS_SERIALIZATION_DECLARATION()
+};
+
+}  // end of namespace datamodel
+
+}  // end of namespace snemo
+#include <boost/serialization/export.hpp>
+BOOST_CLASS_EXPORT_KEY2(snemo::datamodel::tof_measurement, "snemo::datamodel::tof_measurement")
+
+#endif  // FALAISE_SNEMO_DATAMODEL_TOF_MEASUREMENT_H
+
+/*
+** Local Variables: --
+** mode: c++ --
+** c-file-style: "gnu" --
+** tab-width: 2 --
+** End: --
+*/

--- a/source/falaise/snemo/datamodels/tof_measurement.ipp
+++ b/source/falaise/snemo/datamodels/tof_measurement.ipp
@@ -1,0 +1,38 @@
+// -*- mode: c++ ; -*-
+/// \file falaise/snemo/datamodels/tof_measurement.ipp
+
+#ifndef FALAISE_SNEMO_DATAMODEL_TOF_MEASUREMENT_IPP
+#define FALAISE_SNEMO_DATAMODEL_TOF_MEASUREMENT_IPP 1
+
+// Ourselves:
+#include <falaise/snemo/datamodels/tof_measurement.h>
+
+// Third party:
+// - Boost:
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/nvp.hpp>
+#include <boost/serialization/string.hpp>
+// - Bayeux/datatools:
+#include <datatools/i_serializable.ipp>
+
+// This project:
+#include <falaise/snemo/datamodels/base_topology_measurement.ipp>
+
+namespace snemo {
+
+namespace datamodel {
+
+/// Serialization method
+template <class Archive>
+void tof_measurement::serialize(Archive& ar_, const unsigned int /* version_ */) {
+  ar_& BOOST_SERIALIZATION_BASE_OBJECT_NVP(base_topology_measurement);
+  ar_& boost::serialization::make_nvp("internal_probabilities", _internal_probabilities_);
+  ar_& boost::serialization::make_nvp("external_probabilities", _external_probabilities_);
+  return;
+}
+
+}  // end of namespace datamodel
+
+}  // end of namespace snemo
+
+#endif  // FALAISE_SNEMO_DATAMODEL_TOF_MEASUREMENT_IPP

--- a/source/falaise/snemo/datamodels/topology_1e1a_pattern.cc
+++ b/source/falaise/snemo/datamodels/topology_1e1a_pattern.cc
@@ -1,0 +1,165 @@
+/** \file falaise/snemo/datamodels/topology_1e1a_pattern.cc
+ */
+
+// Ourselves:
+#include <falaise/snemo/datamodels/angle_measurement.h>
+#include <falaise/snemo/datamodels/topology_1e1a_pattern.h>
+#include <falaise/snemo/datamodels/vertex_measurement.h>
+
+namespace snemo {
+
+namespace datamodel {
+
+// Serial tag for datatools::i_serializable interface :
+DATATOOLS_SERIALIZATION_SERIAL_TAG_IMPLEMENTATION(topology_1e1a_pattern,
+                                                  "snemo::datamodel::topology_1e1a_pattern")
+
+// static
+const std::string& topology_1e1a_pattern::pattern_id() {
+  static const std::string _id("1e1a");
+  return _id;
+}
+
+std::string topology_1e1a_pattern::get_pattern_id() const {
+  return topology_1e1a_pattern::pattern_id();
+}
+
+topology_1e1a_pattern::topology_1e1a_pattern() : topology_1e_pattern() { return; }
+
+topology_1e1a_pattern::~topology_1e1a_pattern() { return; }
+
+bool topology_1e1a_pattern::has_alpha_track() const { return has_particle_track("a1"); }
+
+const snemo::datamodel::particle_track& topology_1e1a_pattern::get_alpha_track() const {
+  return get_particle_track("a1");
+}
+
+bool topology_1e1a_pattern::has_alpha_angle() const {
+  return has_measurement_as<snemo::datamodel::angle_measurement>("angle_a1");
+}
+
+double topology_1e1a_pattern::get_alpha_angle() const {
+  DT_THROW_IF(!has_alpha_angle(), std::logic_error, "No alpha angle measurement stored !");
+  return get_measurement_as<snemo::datamodel::angle_measurement>("angle_a1").get_angle();
+}
+
+bool topology_1e1a_pattern::has_electron_alpha_angle() const {
+  return has_measurement_as<snemo::datamodel::angle_measurement>("angle_e1_a1");
+}
+
+double topology_1e1a_pattern::get_electron_alpha_angle() const {
+  DT_THROW_IF(!has_electron_alpha_angle(), std::logic_error,
+              "No electron-alpha angle measurement stored !");
+  return get_measurement_as<snemo::datamodel::angle_measurement>("angle_e1_a1").get_angle();
+}
+
+bool topology_1e1a_pattern::has_electron_alpha_vertices_probability() const {
+  return has_measurement_as<snemo::datamodel::vertex_measurement>("vertex_e1_a1");
+}
+
+double topology_1e1a_pattern::get_electron_alpha_vertices_probability() const {
+  DT_THROW_IF(!has_electron_alpha_vertices_probability(), std::logic_error,
+              "No common electron-alpha vertices measurement stored !");
+  return get_measurement_as<snemo::datamodel::vertex_measurement>("vertex_e1_a1").get_probability();
+}
+
+bool topology_1e1a_pattern::has_electron_alpha_vertices_distance() const {
+  return has_measurement_as<snemo::datamodel::vertex_measurement>("vertex_e1_a1");
+}
+
+double topology_1e1a_pattern::get_electron_alpha_vertices_distance_x() const {
+  DT_THROW_IF(!has_electron_alpha_vertices_distance(), std::logic_error,
+              "No common electron-alpha vertices measurement stored !");
+  return get_measurement_as<snemo::datamodel::vertex_measurement>("vertex_e1_a1")
+      .get_vertices_distance_x();
+}
+
+double topology_1e1a_pattern::get_electron_alpha_vertices_distance_y() const {
+  DT_THROW_IF(!has_electron_alpha_vertices_distance(), std::logic_error,
+              "No common electron-alpha vertices measurement stored !");
+  return get_measurement_as<snemo::datamodel::vertex_measurement>("vertex_e1_a1")
+      .get_vertices_distance_y();
+}
+
+double topology_1e1a_pattern::get_electron_alpha_vertices_distance_z() const {
+  DT_THROW_IF(!has_electron_alpha_vertices_distance(), std::logic_error,
+              "No common electron-alpha vertices measurement stored !");
+  return get_measurement_as<snemo::datamodel::vertex_measurement>("vertex_e1_a1")
+      .get_vertices_distance_z();
+}
+
+bool topology_1e1a_pattern::has_electron_alpha_vertex_location() const {
+  return has_measurement_as<snemo::datamodel::vertex_measurement>("vertex_e1_a1");
+}
+
+std::string topology_1e1a_pattern::get_electron_alpha_vertex_location() const {
+  DT_THROW_IF(!has_electron_alpha_vertex_location(), std::logic_error,
+              "No common electron-alpha vertices measurement stored !");
+  return dynamic_cast<const snemo::datamodel::vertex_measurement&>(get_measurement("vertex_e1_a1"))
+      .get_location();
+}
+
+bool topology_1e1a_pattern::has_electron_alpha_vertex_position() const {
+  return has_measurement_as<snemo::datamodel::vertex_measurement>("vertex_e1_a1");
+}
+
+double topology_1e1a_pattern::get_electron_alpha_vertex_position_x() const {
+  DT_THROW_IF(!has_electron_alpha_vertex_position(), std::logic_error,
+              "No common electron-alpha vertices measurement stored !");
+  return dynamic_cast<const snemo::datamodel::vertex_measurement&>(get_measurement("vertex_e1_a1"))
+      .get_vertex_position_x();
+}
+
+double topology_1e1a_pattern::get_electron_alpha_vertex_position_y() const {
+  DT_THROW_IF(!has_electron_alpha_vertex_position(), std::logic_error,
+              "No common electron-alpha vertices measurement stored !");
+  return dynamic_cast<const snemo::datamodel::vertex_measurement&>(get_measurement("vertex_e1_a1"))
+      .get_vertex_position_y();
+}
+
+double topology_1e1a_pattern::get_electron_alpha_vertex_position_z() const {
+  DT_THROW_IF(!has_electron_alpha_vertex_position(), std::logic_error,
+              "No common electron-alpha vertices measurement stored !");
+  return dynamic_cast<const snemo::datamodel::vertex_measurement&>(get_measurement("vertex_e1_a1"))
+      .get_vertex_position_z();
+}
+
+double topology_1e1a_pattern::get_alpha_delayed_time() const {
+  double time = datatools::invalid_real();
+  if (has_alpha_track()) {
+    const snemo::datamodel::particle_track& the_alpha = get_alpha_track();
+    if (the_alpha.has_trajectory()) {
+      const snemo::datamodel::tracker_trajectory& a_trajectory = the_alpha.get_trajectory();
+      const datatools::properties& aux = a_trajectory.get_auxiliaries();
+      if (aux.has_key("t0")) {
+        time = aux.fetch_real("t0");
+      }
+    }
+  }
+  return time;
+}
+
+double topology_1e1a_pattern::get_alpha_track_length() const {
+  double length = datatools::invalid_real();
+  if (has_alpha_track()) {
+    const snemo::datamodel::particle_track& the_alpha = get_alpha_track();
+    if (the_alpha.has_trajectory()) {
+      const snemo::datamodel::tracker_trajectory& a_trajectory = the_alpha.get_trajectory();
+      const snemo::datamodel::base_trajectory_pattern& a_track_pattern = a_trajectory.get_pattern();
+      length = a_track_pattern.get_shape().get_length();
+    }
+  }
+  return length;
+}
+
+}  // end of namespace datamodel
+
+}  // end of namespace snemo
+
+/*
+** Local Variables: --
+** mode: c++ --
+** c-file-style: "gnu" --
+** tab-width: 2 --
+** End: --
+*/

--- a/source/falaise/snemo/datamodels/topology_1e1a_pattern.h
+++ b/source/falaise/snemo/datamodels/topology_1e1a_pattern.h
@@ -1,0 +1,117 @@
+/// \file falaise/snemo/datamodels/topology_1e1a_pattern.h
+/* Author(s) :    François Mauger <mauger@lpccaen.in2p3.fr>
+ * Creation date: 2012-03-19
+ * Last modified: 2014-01-27
+ *
+ * Description: The 1e1a class of trajectory patterns
+ */
+
+#ifndef FALAISE_SNEMO_DATAMODEL_TOPOLOGY_1E1A_PATTERN_H
+#define FALAISE_SNEMO_DATAMODEL_TOPOLOGY_1E1A_PATTERN_H 1
+
+// Standard library:
+#include <string>
+
+// This project:
+#include <falaise/snemo/datamodels/topology_1e_pattern.h>
+
+namespace snemo {
+
+namespace datamodel {
+
+/// \brief The 1 electron - 1 alpha class of reconstructed topology
+class topology_1e1a_pattern : public topology_1e_pattern {
+ public:
+  /// Static function to return pattern identifier of the pattern
+  static const std::string& pattern_id();
+
+  /// Return pattern identifier of the pattern
+  virtual std::string get_pattern_id() const;
+
+  /// Constructor
+  topology_1e1a_pattern();
+
+  /// Destructor
+  virtual ~topology_1e1a_pattern();
+
+  /// Check alpha track availability
+  bool has_alpha_track() const;
+
+  /// Return alpha track
+  const snemo::datamodel::particle_track& get_alpha_track() const;
+
+  /// Check angle measurement availability
+  bool has_alpha_angle() const;
+
+  /// Return alpha angle
+  double get_alpha_angle() const;
+
+  /// Check angle measurement availability
+  bool has_electron_alpha_angle() const;
+
+  /// Return electron-alpha angle
+  double get_electron_alpha_angle() const;
+
+  /// Check common vertices probability between electron and alpha validity
+  bool has_electron_alpha_vertices_probability() const;
+
+  /// Get common vertices probability between electrons
+  double get_electron_alpha_vertices_probability() const;
+
+  /// Check common vertices distance between electron and alpha validity
+  bool has_electron_alpha_vertices_distance() const;
+
+  /// Get common vertices distance in X between electron and alpha
+  double get_electron_alpha_vertices_distance_x() const;
+
+  /// Get common vertices distance in Y between electron and alpha
+  double get_electron_alpha_vertices_distance_y() const;
+
+  /// Get common vertices distance in Z between electron and alpha
+  double get_electron_alpha_vertices_distance_z() const;
+
+  /// Check common vertices location between electron and alpha
+  bool has_electron_alpha_vertex_location() const;
+
+  /// Get common vertices location between electrons
+  std::string get_electron_alpha_vertex_location() const;
+
+  /// Check common vertices position
+  bool has_electron_alpha_vertex_position() const;
+
+  /// Get common vertices position between electrons
+  double get_electron_alpha_vertex_position_x() const;
+
+  /// Get common vertices position between electrons
+  double get_electron_alpha_vertex_position_y() const;
+
+  /// Get common vertices position between electrons
+  double get_electron_alpha_vertex_position_z() const;
+
+  /// Get alpha delayed time
+  double get_alpha_delayed_time() const;
+
+  /// Get alpha track length
+  double get_alpha_track_length() const;
+
+ private:
+  DATATOOLS_SERIALIZATION_DECLARATION()
+};
+
+}  // end of namespace datamodel
+
+}  // end of namespace snemo
+
+#include <boost/serialization/export.hpp>
+BOOST_CLASS_EXPORT_KEY2(snemo::datamodel::topology_1e1a_pattern,
+                        "snemo::datamodel::topology_1e1a_pattern")
+
+#endif  // FALAISE_SNEMO_DATAMODEL_TOPOLOGY_1E1A_PATTERN_H
+
+/*
+** Local Variables: --
+** mode: c++ --
+** c-file-style: "gnu" --
+** tab-width: 2 --
+** End: --
+*/

--- a/source/falaise/snemo/datamodels/topology_1e1a_pattern.ipp
+++ b/source/falaise/snemo/datamodels/topology_1e1a_pattern.ipp
@@ -1,0 +1,33 @@
+// -*- mode: c++ ; -*-
+/// \file falaise/snemo/datamodels/topology_1e1a_pattern.ipp
+
+#ifndef FALAISE_SNEMO_DATAMODEL_TOPOLOGY_1E1A_PATTERN_IPP
+#define FALAISE_SNEMO_DATAMODEL_TOPOLOGY_1E1A_PATTERN_IPP 1
+
+// Ourselves:
+#include <falaise/snemo/datamodels/topology_1e1a_pattern.h>
+
+// Third party:
+// - Boost:
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/nvp.hpp>
+
+// This project:
+#include <falaise/snemo/datamodels/topology_1e_pattern.ipp>
+
+namespace snemo {
+
+namespace datamodel {
+
+/// Serialization method
+template <class Archive>
+void topology_1e1a_pattern::serialize(Archive& ar_, const unsigned int /* version_ */) {
+  ar_& BOOST_SERIALIZATION_BASE_OBJECT_NVP(topology_1e_pattern);
+  return;
+}
+
+}  // end of namespace datamodel
+
+}  // end of namespace snemo
+
+#endif  // FALAISE_SNEMO_DATAMODEL_TOPOLOGY_1E1A_PATTERN_IPP

--- a/source/falaise/snemo/datamodels/topology_1eNg_pattern.cc
+++ b/source/falaise/snemo/datamodels/topology_1eNg_pattern.cc
@@ -1,0 +1,107 @@
+/** \file falaise/snemo/datamodels/topology_1eNg_pattern.cc
+ */
+
+// Ourselves:
+#include <falaise/snemo/datamodels/topology_1eNg_pattern.h>
+
+#include <falaise/snemo/datamodels/energy_measurement.h>
+namespace snemo {
+
+namespace datamodel {
+
+// Serial tag for datatools::i_serializable interface :
+DATATOOLS_SERIALIZATION_SERIAL_TAG_IMPLEMENTATION(topology_1eNg_pattern,
+                                                  "snemo::datamodel::topology_1eNg_pattern")
+
+// static
+const std::string& topology_1eNg_pattern::pattern_id() {
+  static const std::string _id("1eNg");
+  return _id;
+}
+
+std::string topology_1eNg_pattern::get_pattern_id() const {
+  return topology_1eNg_pattern::pattern_id();
+}
+
+topology_1eNg_pattern::topology_1eNg_pattern() : topology_1e_pattern() {
+  _number_of_gammas_ = 0;
+  return;
+}
+
+topology_1eNg_pattern::~topology_1eNg_pattern() { return; }
+
+bool topology_1eNg_pattern::has_number_of_gammas() const { return _number_of_gammas_ != 0; }
+
+void topology_1eNg_pattern::set_number_of_gammas(const size_t ngammas_) {
+  _number_of_gammas_ = ngammas_;
+  return;
+}
+
+size_t topology_1eNg_pattern::get_number_of_gammas() const { return _number_of_gammas_; }
+
+bool topology_1eNg_pattern::has_gammas_energies() const {
+  return has_measurement("energy_g[0-9]+");
+}
+
+void topology_1eNg_pattern::fetch_gammas_energies(
+    topology_1eNg_pattern::energy_collection_type& energies_) const {
+  DT_THROW_IF(!has_gammas_energies(), std::logic_error, "No gammas energy measurement stored !");
+  for (size_t ig = 1; ig <= get_number_of_gammas(); ig++) {
+    std::ostringstream oss;
+    oss << "energy_g" << ig;
+    DT_THROW_IF(!has_measurement_as<snemo::datamodel::energy_measurement>(oss.str()),
+                std::logic_error, "Missing '" << oss.str() << "' energy measurement !");
+    const snemo::datamodel::energy_measurement& a_energy_meas =
+        get_measurement_as<snemo::datamodel::energy_measurement>(oss.str());
+    energies_.push_back(a_energy_meas.get_energy());
+  }
+  return;
+}
+
+bool topology_1eNg_pattern::has_electron_gammas_tof_probabilities() const {
+  return has_measurement("tof_e1_g[0-9]+");
+}
+
+void topology_1eNg_pattern::fetch_electron_gammas_internal_probabilities(
+    topology_1eNg_pattern::tof_collection_type& eg_pint_) const {
+  DT_THROW_IF(!has_electron_gammas_tof_probabilities(), std::logic_error,
+              "No electron-gammas TOF measurement stored !");
+  for (size_t ig = 1; ig <= get_number_of_gammas(); ig++) {
+    std::ostringstream oss;
+    oss << "tof_e1_g" << ig;
+    DT_THROW_IF(!has_measurement_as<snemo::datamodel::tof_measurement>(oss.str()), std::logic_error,
+                "Missing '" << oss.str() << "' TOF measurement !");
+    const snemo::datamodel::tof_measurement& a_tof_meas =
+        get_measurement_as<snemo::datamodel::tof_measurement>(oss.str());
+    eg_pint_.push_back(a_tof_meas.get_internal_probabilities());
+  }
+  return;
+}
+
+void topology_1eNg_pattern::fetch_electron_gammas_external_probabilities(
+    topology_1eNg_pattern::tof_collection_type& eg_pext_) const {
+  DT_THROW_IF(!has_electron_gammas_tof_probabilities(), std::logic_error,
+              "No electron-gammas TOF measurement stored !");
+  for (size_t ig = 1; ig <= get_number_of_gammas(); ++ig) {
+    std::ostringstream oss;
+    oss << "tof_e1_g" << ig;
+    DT_THROW_IF(!has_measurement_as<snemo::datamodel::tof_measurement>(oss.str()), std::logic_error,
+                "Missing '" << oss.str() << "' TOF measurement !");
+    const snemo::datamodel::tof_measurement& a_tof_meas =
+        get_measurement_as<snemo::datamodel::tof_measurement>(oss.str());
+    eg_pext_.push_back(a_tof_meas.get_external_probabilities());
+  }
+  return;
+}
+
+}  // end of namespace datamodel
+
+}  // end of namespace snemo
+
+/*
+** Local Variables: --
+** mode: c++ --
+** c-file-style: "gnu" --
+** tab-width: 2 --
+** End: --
+*/

--- a/source/falaise/snemo/datamodels/topology_1eNg_pattern.h
+++ b/source/falaise/snemo/datamodels/topology_1eNg_pattern.h
@@ -1,0 +1,88 @@
+/// \file falaise/snemo/datamodels/topology_1e1Ng_pattern.h
+/* Author(s) :    Steven Calvez <calvez@lal.in2p3.fr>
+ * Creation date: 2015-10-24
+ * Last modified: 2015-10-24
+ *
+ * Description: The 1e1Ng class of trajectory pattern
+ */
+
+#ifndef FALAISE_SNEMO_DATAMODEL_TOPOLOGY_1ENG_PATTERN_H
+#define FALAISE_SNEMO_DATAMODEL_TOPOLOGY_1ENG_PATTERN_H 1
+
+// This project:
+#include <falaise/snemo/datamodels/energy_measurement.h>
+#include <falaise/snemo/datamodels/tof_measurement.h>
+#include <falaise/snemo/datamodels/topology_1e_pattern.h>
+
+namespace snemo {
+
+namespace datamodel {
+
+/// \brief The 1e1Ng class of reconstructed topology
+class topology_1eNg_pattern : public topology_1e_pattern {
+ public:
+  /// Typedef for TOF collection
+  typedef std::vector<snemo::datamodel::tof_measurement::probability_type> tof_collection_type;
+
+  /// Typedef for energy measurement collection
+  typedef std::vector<double> energy_collection_type;
+
+  /// Static function to return pattern identifier of the pattern
+  static const std::string& pattern_id();
+
+  /// Return pattern identifier of the pattern
+  virtual std::string get_pattern_id() const;
+
+  /// Constructor
+  topology_1eNg_pattern();
+
+  /// Destructor
+  virtual ~topology_1eNg_pattern();
+
+  /// Check number of gammas validity
+  bool has_number_of_gammas() const;
+
+  /// Set number of gammas
+  void set_number_of_gammas(const size_t ngammas_);
+
+  /// Return the number of gammas
+  size_t get_number_of_gammas() const;
+
+  /// Check gammas energy existence
+  bool has_gammas_energies() const;
+
+  /// Fetch gammas energies
+  void fetch_gammas_energies(energy_collection_type& energies_) const;
+
+  /// Check electron-gammas TOF probabilities existence
+  bool has_electron_gammas_tof_probabilities() const;
+
+  /// Fetch the electron-gammas internal TOF probability
+  void fetch_electron_gammas_internal_probabilities(tof_collection_type& eg_pint_) const;
+
+  /// Fetch the electron-gammas external TOF probability
+  void fetch_electron_gammas_external_probabilities(tof_collection_type& eg_pext_) const;
+
+ private:
+  size_t _number_of_gammas_;  //!< Number of gamma in the topology
+
+  DATATOOLS_SERIALIZATION_DECLARATION()
+};
+
+}  // end of namespace datamodel
+
+}  // end of namespace snemo
+
+#include <boost/serialization/export.hpp>
+BOOST_CLASS_EXPORT_KEY2(snemo::datamodel::topology_1eNg_pattern,
+                        "snemo::datamodel::topology_1eNg_pattern")
+
+#endif  // FALAISE_SNEMO_DATAMODEL_TOPOLOGY_1ENG_PATTERN_H
+
+/*
+** Local Variables: --
+** mode: c++ --
+** c-file-style: "gnu" --
+** tab-width: 2 --
+** End: --
+*/

--- a/source/falaise/snemo/datamodels/topology_1eNg_pattern.ipp
+++ b/source/falaise/snemo/datamodels/topology_1eNg_pattern.ipp
@@ -1,0 +1,34 @@
+// -*- mode: c++ ; -*-
+/// \file falaise/snemo/datamodels/topology_1eNg_pattern.ipp
+
+#ifndef FALAISE_SNEMO_DATAMODEL_TOPOLOGY_1ENG_PATTERN_IPP
+#define FALAISE_SNEMO_DATAMODEL_TOPOLOGY_1ENG_PATTERN_IPP 1
+
+// Ourselves:
+#include <falaise/snemo/datamodels/topology_1eNg_pattern.h>
+
+// Third party:
+// - Boost:
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/nvp.hpp>
+
+// This project:
+#include <falaise/snemo/datamodels/base_topology_pattern.ipp>
+
+namespace snemo {
+
+namespace datamodel {
+
+/// Serialization method
+template <class Archive>
+void topology_1eNg_pattern::serialize(Archive& ar_, const unsigned int /* version_ */) {
+  ar_& BOOST_SERIALIZATION_BASE_OBJECT_NVP(topology_1e_pattern);
+  ar_& boost::serialization::make_nvp("number_of_gammas", _number_of_gammas_);
+  return;
+}
+
+}  // end of namespace datamodel
+
+}  // end of namespace snemo
+
+#endif  // FALAISE_SNEMO_DATAMODEL_TOPOLOGY_1ENG_PATTERN_IPP

--- a/source/falaise/snemo/datamodels/topology_1e_pattern.cc
+++ b/source/falaise/snemo/datamodels/topology_1e_pattern.cc
@@ -1,0 +1,114 @@
+/** \file falaise/snemo/datamodels/topology_1e_pattern.cc
+ */
+
+// Ourselves:
+#include <falaise/snemo/datamodels/angle_measurement.h>
+#include <falaise/snemo/datamodels/energy_measurement.h>
+#include <falaise/snemo/datamodels/topology_1e_pattern.h>
+#include <falaise/snemo/datamodels/vertex_measurement.h>
+
+namespace snemo {
+
+namespace datamodel {
+
+// Serial tag for datatools::i_serializable interface :
+DATATOOLS_SERIALIZATION_SERIAL_TAG_IMPLEMENTATION(topology_1e_pattern,
+                                                  "snemo::datamodel::topology_1e_pattern")
+
+// static
+const std::string& topology_1e_pattern::pattern_id() {
+  static const std::string _id("1e");
+  return _id;
+}
+
+std::string topology_1e_pattern::get_pattern_id() const {
+  return topology_1e_pattern::pattern_id();
+}
+
+topology_1e_pattern::topology_1e_pattern() : base_topology_pattern() { return; }
+
+topology_1e_pattern::~topology_1e_pattern() { return; }
+
+bool topology_1e_pattern::has_electron_track() const { return has_particle_track("e1"); }
+
+const snemo::datamodel::particle_track& topology_1e_pattern::get_electron_track() const {
+  return get_particle_track("e1");
+}
+
+bool topology_1e_pattern::has_electron_angle() const {
+  return has_measurement_as<snemo::datamodel::angle_measurement>("angle_e1");
+}
+
+double topology_1e_pattern::get_electron_angle() const {
+  DT_THROW_IF(!has_electron_angle(), std::logic_error, "No electron angle measurement stored !");
+  return get_measurement_as<snemo::datamodel::angle_measurement>("angle_e1").get_angle();
+}
+
+bool topology_1e_pattern::has_electron_energy() const {
+  return has_measurement_as<snemo::datamodel::energy_measurement>("energy_e1");
+}
+
+double topology_1e_pattern::get_electron_energy() const {
+  DT_THROW_IF(!has_electron_energy(), std::logic_error, "No electron energy measurement stored !");
+  return get_measurement_as<snemo::datamodel::energy_measurement>("energy_e1").get_energy();
+}
+
+double topology_1e_pattern::get_electron_track_length() const {
+  double length = datatools::invalid_real();
+  if (has_electron_track()) {
+    const snemo::datamodel::particle_track& the_electron = get_electron_track();
+    if (the_electron.has_trajectory()) {
+      const snemo::datamodel::tracker_trajectory& a_trajectory = the_electron.get_trajectory();
+      const snemo::datamodel::base_trajectory_pattern& a_track_pattern = a_trajectory.get_pattern();
+      length = a_track_pattern.get_shape().get_length();
+    }
+  }
+  return length;
+}
+
+bool topology_1e_pattern::has_electron_vertex_location() const {
+  return has_measurement_as<snemo::datamodel::vertex_measurement>("vertex_e1");
+}
+
+std::string topology_1e_pattern::get_electron_vertex_location() const {
+  DT_THROW_IF(!has_electron_vertex_location(), std::logic_error,
+              "No electron vertex measurement stored !");
+  return get_measurement_as<snemo::datamodel::vertex_measurement>("vertex_e1").get_location();
+}
+
+bool topology_1e_pattern::has_electron_vertex_position() const {
+  return has_measurement_as<snemo::datamodel::vertex_measurement>("vertex_e1");
+}
+
+double topology_1e_pattern::get_electron_vertex_position_x() const {
+  DT_THROW_IF(!has_electron_vertex_position(), std::logic_error,
+              "No electron vertex measurement stored !");
+  return get_measurement_as<snemo::datamodel::vertex_measurement>("vertex_e1")
+      .get_vertex_position_x();
+}
+
+double topology_1e_pattern::get_electron_vertex_position_y() const {
+  DT_THROW_IF(!has_electron_vertex_position(), std::logic_error,
+              "No electron vertex measurement stored !");
+  return get_measurement_as<snemo::datamodel::vertex_measurement>("vertex_e1")
+      .get_vertex_position_y();
+}
+
+double topology_1e_pattern::get_electron_vertex_position_z() const {
+  DT_THROW_IF(!has_electron_vertex_position(), std::logic_error,
+              "No electron vertex measurement stored !");
+  return get_measurement_as<snemo::datamodel::vertex_measurement>("vertex_e1")
+      .get_vertex_position_z();
+}
+
+}  // end of namespace datamodel
+
+}  // end of namespace snemo
+
+/*
+** Local Variables: --
+** mode: c++ --
+** c-file-style: "gnu" --
+** tab-width: 2 --
+** End: --
+*/

--- a/source/falaise/snemo/datamodels/topology_1e_pattern.h
+++ b/source/falaise/snemo/datamodels/topology_1e_pattern.h
@@ -1,0 +1,93 @@
+/// \file falaise/snemo/datamodels/topology_1e_pattern.h
+/* Author(s) :    Steven Calvez <calvez@lal.in2p3.fr>
+ * Creation date: 2015-11-09
+ * Last modified: 2015-11-09
+ *
+ * Description: The 1 electron topology pattern class
+ */
+
+#ifndef FALAISE_SNEMO_DATAMODEL_TOPOLOGY_1E_PATTERN_H
+#define FALAISE_SNEMO_DATAMODEL_TOPOLOGY_1E_PATTERN_H 1
+
+// This project:
+#include <falaise/snemo/datamodels/base_topology_pattern.h>
+
+namespace snemo {
+
+namespace datamodel {
+
+/// \brief The 1e class of reconstructed topology
+class topology_1e_pattern : public base_topology_pattern {
+ public:
+  /// Static function to return pattern identifier of the pattern
+  static const std::string& pattern_id();
+
+  /// Return pattern identifier of the pattern
+  virtual std::string get_pattern_id() const;
+
+  /// Constructor
+  topology_1e_pattern();
+
+  /// Destructor
+  virtual ~topology_1e_pattern();
+
+  /// Check electron track availability
+  bool has_electron_track() const;
+
+  /// Return electron track
+  const snemo::datamodel::particle_track& get_electron_track() const;
+
+  /// Check angle measurement availability
+  bool has_electron_angle() const;
+
+  /// Return electron angle
+  double get_electron_angle() const;
+
+  /// Check electron energy validity
+  bool has_electron_energy() const;
+
+  /// Return electron energy
+  double get_electron_energy() const;
+
+  /// Get electron track length
+  double get_electron_track_length() const;
+
+  /// Check electron vertex location validity
+  bool has_electron_vertex_location() const;
+
+  /// Return electron vertex location
+  std::string get_electron_vertex_location() const;
+
+  /// Check electron vertex position validity
+  bool has_electron_vertex_position() const;
+
+  /// Return electron vertex position in X
+  double get_electron_vertex_position_x() const;
+
+  /// Return electron vertex position in Y
+  double get_electron_vertex_position_y() const;
+
+  /// Return electron vertex position in Z
+  double get_electron_vertex_position_z() const;
+
+ private:
+  DATATOOLS_SERIALIZATION_DECLARATION()
+};
+
+}  // end of namespace datamodel
+
+}  // end of namespace snemo
+
+#include <boost/serialization/export.hpp>
+BOOST_CLASS_EXPORT_KEY2(snemo::datamodel::topology_1e_pattern,
+                        "snemo::datamodel::topology_1e_pattern")
+
+#endif  // FALAISE_SNEMO_DATAMODEL_TOPOLOGY_1E_PATTERN_H
+
+/*
+** Local Variables: --
+** mode: c++ --
+** c-file-style: "gnu" --
+** tab-width: 2 --
+** End: --
+*/

--- a/source/falaise/snemo/datamodels/topology_1e_pattern.ipp
+++ b/source/falaise/snemo/datamodels/topology_1e_pattern.ipp
@@ -1,0 +1,33 @@
+// -*- mode: c++ ; -*-
+/// \file falaise/snemo/datamodels/topology_1e_pattern.ipp
+
+#ifndef FALAISE_SNEMO_DATAMODEL_TOPOLOGY_1E_PATTERN_IPP
+#define FALAISE_SNEMO_DATAMODEL_TOPOLOGY_1E_PATTERN_IPP 1
+
+// Ourselves:
+#include <falaise/snemo/datamodels/topology_1e_pattern.h>
+
+// Third party:
+// - Boost:
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/nvp.hpp>
+
+// This project:
+#include <falaise/snemo/datamodels/base_topology_pattern.ipp>
+
+namespace snemo {
+
+namespace datamodel {
+
+/// Serialization method
+template <class Archive>
+void topology_1e_pattern::serialize(Archive& ar_, const unsigned int /* version */) {
+  ar_& BOOST_SERIALIZATION_BASE_OBJECT_NVP(base_topology_pattern);
+  return;
+}
+
+}  // end of namespace datamodel
+
+}  // end of namespace snemo
+
+#endif  // FALAISE_SNEMO_DATAMODEL_TOPOLOGY_1E_PATTERN_IPP

--- a/source/falaise/snemo/datamodels/topology_2eNg_pattern.cc
+++ b/source/falaise/snemo/datamodels/topology_2eNg_pattern.cc
@@ -1,0 +1,192 @@
+/** \file falaise/snemo/datamodels/topology_2eNg_pattern.cc
+ */
+
+// Ourselves:
+#include <falaise/snemo/datamodels/topology_2eNg_pattern.h>
+
+namespace snemo {
+
+namespace datamodel {
+
+// Serial tag for datatools::i_serializable interface :
+DATATOOLS_SERIALIZATION_SERIAL_TAG_IMPLEMENTATION(topology_2eNg_pattern,
+                                                  "snemo::datamodel::topology_2eNg_pattern")
+
+// static
+const std::string& topology_2eNg_pattern::pattern_id() {
+  static const std::string _id("2eNg");
+  return _id;
+}
+
+std::string topology_2eNg_pattern::get_pattern_id() const {
+  return topology_2eNg_pattern::pattern_id();
+}
+
+topology_2eNg_pattern::topology_2eNg_pattern() : topology_2e_pattern() {
+  _number_of_gammas_ = 0;
+  return;
+}
+
+topology_2eNg_pattern::~topology_2eNg_pattern() { return; }
+
+bool topology_2eNg_pattern::has_number_of_gammas() const { return _number_of_gammas_ != 0; }
+
+void topology_2eNg_pattern::set_number_of_gammas(const size_t ngammas_) {
+  _number_of_gammas_ = ngammas_;
+  return;
+}
+
+size_t topology_2eNg_pattern::get_number_of_gammas() const { return _number_of_gammas_; }
+
+bool topology_2eNg_pattern::has_gammas_energies() const {
+  return has_measurement("energy_g[0-9]+");
+}
+
+void topology_2eNg_pattern::fetch_gammas_energies(
+    topology_2eNg_pattern::energy_collection_type& g_energies_) const {
+  DT_THROW_IF(!has_gammas_energies(), std::logic_error, "No gamma energy measurement stored !");
+  for (size_t ig = 1; ig <= get_number_of_gammas(); ig++) {
+    std::ostringstream oss;
+    oss << "energy_g" << ig;
+    DT_THROW_IF(!has_measurement_as<snemo::datamodel::energy_measurement>(oss.str()),
+                std::logic_error, "Missing '" << oss.str() << "' energy measurement !");
+    const snemo::datamodel::energy_measurement& a_energy_meas =
+        get_measurement_as<snemo::datamodel::energy_measurement>(oss.str());
+    g_energies_.push_back(a_energy_meas.get_energy());
+  }
+  return;
+}
+
+bool topology_2eNg_pattern::has_electrons_gammas_tof_probabilities() const {
+  return has_measurement("tof_e[0-9]+_g[0-9]+");
+}
+
+void topology_2eNg_pattern::fetch_electrons_gammas_internal_probabilities(
+    topology_2eNg_pattern::tof_collection_type& eg_pint_) const {
+  DT_THROW_IF(!has_electrons_gammas_tof_probabilities(), std::logic_error,
+              "No electrons-gammas TOF measurement stored !");
+  for (size_t ig = 1; ig <= get_number_of_gammas(); ig++) {
+    for (size_t ie = 1; ie <= 2; ie++) {
+      std::ostringstream oss;
+      oss << "tof_e" << ie << "_g" << ig;
+      DT_THROW_IF(!has_measurement_as<snemo::datamodel::tof_measurement>(oss.str()),
+                  std::logic_error, "Missing '" << oss.str() << "' TOF measurement !");
+      const snemo::datamodel::tof_measurement& a_tof_meas =
+          get_measurement_as<snemo::datamodel::tof_measurement>(oss.str());
+      eg_pint_.push_back(a_tof_meas.get_internal_probabilities());
+    }
+  }
+  return;
+}
+
+void topology_2eNg_pattern::fetch_electrons_gammas_external_probabilities(
+    topology_2eNg_pattern::tof_collection_type& eg_pext_) const {
+  DT_THROW_IF(!has_electrons_gammas_tof_probabilities(), std::logic_error,
+              "No electrons-gammas TOF measurement stored !");
+  for (size_t ig = 1; ig <= get_number_of_gammas(); ig++) {
+    for (size_t ie = 1; ie <= 2; ie++) {
+      std::ostringstream oss;
+      oss << "tof_e" << ie << "_g" << ig;
+      DT_THROW_IF(!has_measurement_as<snemo::datamodel::tof_measurement>(oss.str()),
+                  std::logic_error, "Missing '" << oss.str() << "' TOF measurement !");
+      const snemo::datamodel::tof_measurement& a_tof_meas =
+          get_measurement_as<snemo::datamodel::tof_measurement>(oss.str());
+      eg_pext_.push_back(a_tof_meas.get_external_probabilities());
+    }
+  }
+  return;
+}
+
+bool topology_2eNg_pattern::has_electron_min_gammas_tof_probabilities() const {
+  if (get_minimal_energy_electron_name() == "e1")
+    return has_measurement("tof_e1_g[0-9]+");
+  else
+    return has_measurement("tof_e2_g[0-9]+");
+}
+
+void topology_2eNg_pattern::fetch_electron_min_gammas_internal_probabilities(
+    topology_2eNg_pattern::tof_collection_type& eg_pint_) const {
+  DT_THROW_IF(!has_electron_min_gammas_tof_probabilities(), std::logic_error,
+              "No electron_min-gammas TOF measurement stored !");
+  std::string e_min = get_minimal_energy_electron_name();
+  for (size_t ig = 1; ig <= get_number_of_gammas(); ig++) {
+    std::ostringstream oss;
+    oss << "tof_" << e_min << "_g" << ig;
+    DT_THROW_IF(!has_measurement_as<snemo::datamodel::tof_measurement>(oss.str()), std::logic_error,
+                "Missing '" << oss.str() << "' TOF measurement !");
+    const snemo::datamodel::tof_measurement& a_tof_meas =
+        get_measurement_as<snemo::datamodel::tof_measurement>(oss.str());
+    eg_pint_.push_back(a_tof_meas.get_internal_probabilities());
+  }
+  return;
+}
+
+void topology_2eNg_pattern::fetch_electron_min_gammas_external_probabilities(
+    topology_2eNg_pattern::tof_collection_type& eg_pext_) const {
+  DT_THROW_IF(!has_electron_min_gammas_tof_probabilities(), std::logic_error,
+              "No electron_min-gammas TOF measurement stored !");
+  std::string e_min = get_minimal_energy_electron_name();
+  for (size_t ig = 1; ig <= get_number_of_gammas(); ig++) {
+    std::ostringstream oss;
+    oss << "tof_" << e_min << "_g" << ig;
+    DT_THROW_IF(!has_measurement_as<snemo::datamodel::tof_measurement>(oss.str()), std::logic_error,
+                "Missing '" << oss.str() << "' TOF measurement !");
+    const snemo::datamodel::tof_measurement& a_tof_meas =
+        get_measurement_as<snemo::datamodel::tof_measurement>(oss.str());
+    eg_pext_.push_back(a_tof_meas.get_external_probabilities());
+  }
+  return;
+}
+
+bool topology_2eNg_pattern::has_electron_max_gammas_tof_probabilities() const {
+  if (get_maximal_energy_electron_name() == "e1")
+    return has_measurement("tof_e1_g[0-9]+");
+  else
+    return has_measurement("tof_e2_g[0-9]+");
+}
+
+void topology_2eNg_pattern::fetch_electron_max_gammas_internal_probabilities(
+    topology_2eNg_pattern::tof_collection_type& eg_pint_) const {
+  DT_THROW_IF(!has_electron_max_gammas_tof_probabilities(), std::logic_error,
+              "No electron_max-gammas TOF measurement stored !");
+  std::string e_max = get_maximal_energy_electron_name();
+  for (size_t ig = 1; ig <= get_number_of_gammas(); ig++) {
+    std::ostringstream oss;
+    oss << "tof_" << e_max << "_g" << ig;
+    DT_THROW_IF(!has_measurement_as<snemo::datamodel::tof_measurement>(oss.str()), std::logic_error,
+                "Missing '" << oss.str() << "' TOF measurement !");
+    const snemo::datamodel::tof_measurement& a_tof_meas =
+        get_measurement_as<snemo::datamodel::tof_measurement>(oss.str());
+    eg_pint_.push_back(a_tof_meas.get_internal_probabilities());
+  }
+  return;
+}
+
+void topology_2eNg_pattern::fetch_electron_max_gammas_external_probabilities(
+    topology_2eNg_pattern::tof_collection_type& eg_pext_) const {
+  DT_THROW_IF(!has_electron_max_gammas_tof_probabilities(), std::logic_error,
+              "No electron_max-gammas TOF measurement stored !");
+  std::string e_max = get_maximal_energy_electron_name();
+  for (size_t ig = 1; ig <= get_number_of_gammas(); ig++) {
+    std::ostringstream oss;
+    oss << "tof_" << e_max << "_g" << ig;
+    DT_THROW_IF(!has_measurement_as<snemo::datamodel::tof_measurement>(oss.str()), std::logic_error,
+                "Missing '" << oss.str() << "' TOF measurement !");
+    const snemo::datamodel::tof_measurement& a_tof_meas =
+        get_measurement_as<snemo::datamodel::tof_measurement>(oss.str());
+    eg_pext_.push_back(a_tof_meas.get_external_probabilities());
+  }
+  return;
+}
+
+}  // end of namespace datamodel
+
+}  // end of namespace snemo
+
+/*
+** Local Variables: --
+** mode: c++ --
+** c-file-style: "gnu" --
+** tab-width: 2 --
+** End: --
+*/

--- a/source/falaise/snemo/datamodels/topology_2eNg_pattern.h
+++ b/source/falaise/snemo/datamodels/topology_2eNg_pattern.h
@@ -1,0 +1,106 @@
+/// \file falaise/snemo/datamodels/topology_2eNg_pattern.h
+/* Author(s) :    François Mauger <mauger@lpccaen.in2p3.fr>
+ * Creation date: 2012-03-19
+ * Last modified: 2014-01-27
+ *
+ * Description: The 2eNg class of trajectory patterns
+ */
+
+#ifndef FALAISE_SNEMO_DATAMODEL_TOPOLOGY_2ENG_PATTERN_H
+#define FALAISE_SNEMO_DATAMODEL_TOPOLOGY_2ENG_PATTERN_H 1
+
+// This project:
+#include <falaise/snemo/datamodels/energy_measurement.h>
+#include <falaise/snemo/datamodels/tof_measurement.h>
+#include <falaise/snemo/datamodels/topology_2e_pattern.h>
+
+namespace snemo {
+
+namespace datamodel {
+
+/// \brief The 2 electron - N gammas class of reconstructed topology
+class topology_2eNg_pattern : public topology_2e_pattern {
+ public:
+  /// Typedef for TOF dictionnary
+  typedef std::vector<snemo::datamodel::tof_measurement::probability_type> tof_collection_type;
+
+  /// Typedef for energy dictionnary
+  typedef std::vector<double> energy_collection_type;
+
+  /// Static function to return pattern identifier of the pattern
+  static const std::string& pattern_id();
+
+  /// Return pattern identifier of the pattern
+  virtual std::string get_pattern_id() const;
+
+  /// Constructor
+  topology_2eNg_pattern();
+
+  /// Destructor
+  virtual ~topology_2eNg_pattern();
+
+  /// Check number of gammas validity
+  bool has_number_of_gammas() const;
+
+  /// Set number of gammas
+  void set_number_of_gammas(const size_t ngammas_);
+
+  /// Return internal probability
+  size_t get_number_of_gammas() const;
+
+  /// Check gammas energies existence
+  bool has_gammas_energies() const;
+
+  /// Fetch the gammas energies
+  void fetch_gammas_energies(energy_collection_type& g_energies_) const;
+
+  /// Check electrons-gammas TOF probabilities existence
+  bool has_electrons_gammas_tof_probabilities() const;
+
+  /// Fetch the electrons-gammas internal TOF probability
+  void fetch_electrons_gammas_internal_probabilities(tof_collection_type& eg_pint_) const;
+
+  /// Fetch the electrons-gammas external TOF probability
+  void fetch_electrons_gammas_external_probabilities(tof_collection_type& eg_pext_) const;
+
+  /// Check electron_min-gammas TOF probabilities existence
+  bool has_electron_min_gammas_tof_probabilities() const;
+
+  /// Fetch the electron_min-gammas internal TOF probability
+  void fetch_electron_min_gammas_internal_probabilities(tof_collection_type& eg_pint_) const;
+
+  /// Fetch the electron_min-gammas external TOF probability
+  void fetch_electron_min_gammas_external_probabilities(tof_collection_type& eg_pext_) const;
+
+  /// Check electron_max-gammas TOF probabilities existence
+  bool has_electron_max_gammas_tof_probabilities() const;
+
+  /// Fetch the electron_max-gammas internal TOF probability
+  void fetch_electron_max_gammas_internal_probabilities(tof_collection_type& eg_pint_) const;
+
+  /// Fetch the electron_max-gammas external TOF probability
+  void fetch_electron_max_gammas_external_probabilities(tof_collection_type& eg_pext_) const;
+
+ private:
+  size_t _number_of_gammas_;  //!< Number of gamma in the topology
+
+  DATATOOLS_SERIALIZATION_DECLARATION()
+};
+
+}  // end of namespace datamodel
+
+}  // end of namespace snemo
+
+#include <boost/serialization/export.hpp>
+BOOST_CLASS_EXPORT_KEY2(snemo::datamodel::topology_2eNg_pattern,
+                        "snemo::datamodel::topology_2eNg_pattern")
+
+#endif  // FALAISE_SNEMO_DATAMODEL_TOPOLOGY_2ENG_PATTERN_H
+
+/*
+** Local Variables: --
+** mode: c++ --
+** c-file-style: "gnu" --
+** tab-width: 2 --
+** End: --
+*/

--- a/source/falaise/snemo/datamodels/topology_2eNg_pattern.ipp
+++ b/source/falaise/snemo/datamodels/topology_2eNg_pattern.ipp
@@ -1,0 +1,34 @@
+// -*- mode: c++ ; -*-
+/// \file falaise/snemo/datamodels/topology_2eNg_pattern.ipp
+
+#ifndef FALAISE_SNEMO_DATAMODEL_TOPOLOGY_2ENG_PATTERN_IPP
+#define FALAISE_SNEMO_DATAMODEL_TOPOLOGY_2ENG_PATTERN_IPP 1
+
+// Ourselves:
+#include <falaise/snemo/datamodels/topology_2eNg_pattern.h>
+
+// Third party:
+// - Boost:
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/nvp.hpp>
+
+// This project:
+#include <falaise/snemo/datamodels/base_topology_pattern.ipp>
+
+namespace snemo {
+
+namespace datamodel {
+
+/// Serialization method
+template <class Archive>
+void topology_2eNg_pattern::serialize(Archive& ar_, const unsigned int /* version_ */) {
+  ar_& BOOST_SERIALIZATION_BASE_OBJECT_NVP(topology_2e_pattern);
+  ar_& boost::serialization::make_nvp("number_of_gammas", _number_of_gammas_);
+  return;
+}
+
+}  // end of namespace datamodel
+
+}  // end of namespace snemo
+
+#endif  // FALAISE_SNEMO_DATAMODEL_TOPOLOGY_2ENG_PATTERN_IPP

--- a/source/falaise/snemo/datamodels/topology_2e_pattern.cc
+++ b/source/falaise/snemo/datamodels/topology_2e_pattern.cc
@@ -1,0 +1,200 @@
+/** \file falaise/snemo/datamodels/topology_2e_pattern.cc
+ */
+
+// Ourselves:
+#include <falaise/snemo/datamodels/angle_measurement.h>
+#include <falaise/snemo/datamodels/energy_measurement.h>
+#include <falaise/snemo/datamodels/particle_track.h>
+#include <falaise/snemo/datamodels/tof_measurement.h>
+#include <falaise/snemo/datamodels/topology_2e_pattern.h>
+#include <falaise/snemo/datamodels/vertex_measurement.h>
+
+namespace snemo {
+
+namespace datamodel {
+
+// Serial tag for datatools::i_serializable interface :
+DATATOOLS_SERIALIZATION_SERIAL_TAG_IMPLEMENTATION(topology_2e_pattern,
+                                                  "snemo::datamodel::topology_2e_pattern")
+
+// static
+const std::string& topology_2e_pattern::pattern_id() {
+  static const std::string _id("2e");
+  return _id;
+}
+
+std::string topology_2e_pattern::get_pattern_id() const {
+  return topology_2e_pattern::pattern_id();
+}
+
+topology_2e_pattern::topology_2e_pattern() : base_topology_pattern() { return; }
+
+topology_2e_pattern::~topology_2e_pattern() { return; }
+
+bool topology_2e_pattern::has_electrons_energy() const {
+  return has_measurement_as<snemo::datamodel::energy_measurement>("energy_e1") &&
+         has_measurement_as<snemo::datamodel::energy_measurement>("energy_e2");
+}
+
+bool topology_2e_pattern::has_electron_minimal_energy() const { return has_electrons_energy(); }
+
+double topology_2e_pattern::get_electron_minimal_energy() const {
+  DT_THROW_IF(!has_electron_minimal_energy(), std::logic_error,
+              "No electron minimal energy measurement stored !");
+  return std::min(
+      get_measurement_as<snemo::datamodel::energy_measurement>("energy_e1").get_energy(),
+      get_measurement_as<snemo::datamodel::energy_measurement>("energy_e2").get_energy());
+}
+
+bool topology_2e_pattern::has_electron_maximal_energy() const { return has_electrons_energy(); }
+
+double topology_2e_pattern::get_electron_maximal_energy() const {
+  DT_THROW_IF(!has_electron_maximal_energy(), std::logic_error,
+              "No electron maximal energy measurement stored !");
+  return std::max(
+      get_measurement_as<snemo::datamodel::energy_measurement>("energy_e1").get_energy(),
+      get_measurement_as<snemo::datamodel::energy_measurement>("energy_e2").get_energy());
+}
+
+double topology_2e_pattern::get_electrons_energy_sum() const {
+  DT_THROW_IF(!has_electrons_energy(), std::logic_error, "No electron energy measurement stored !");
+  return get_electron_minimal_energy() + get_electron_maximal_energy();
+}
+
+double topology_2e_pattern::get_electrons_energy_difference() const {
+  DT_THROW_IF(!has_electrons_energy(), std::logic_error, "No electron energy measurement stored !");
+  return get_electron_maximal_energy() - get_electron_minimal_energy();
+}
+
+std::string topology_2e_pattern::get_minimal_energy_electron_name() const {
+  if (get_measurement_as<snemo::datamodel::energy_measurement>("energy_e1").get_energy() <
+      get_measurement_as<snemo::datamodel::energy_measurement>("energy_e2").get_energy())
+    return "e1";
+  else
+    return "e2";
+}
+
+std::string topology_2e_pattern::get_maximal_energy_electron_name() const {
+  if (get_measurement_as<snemo::datamodel::energy_measurement>("energy_e1").get_energy() <
+      get_measurement_as<snemo::datamodel::energy_measurement>("energy_e2").get_energy())
+    return "e2";
+  else
+    return "e1";
+}
+
+bool topology_2e_pattern::has_electrons_internal_probability() const {
+  return has_measurement_as<snemo::datamodel::tof_measurement>("tof_e1_e2");
+}
+
+double topology_2e_pattern::get_electrons_internal_probability() const {
+  DT_THROW_IF(!has_electrons_internal_probability(), std::logic_error,
+              "No electrons TOF measurement stored !");
+  return get_measurement_as<snemo::datamodel::tof_measurement>("tof_e1_e2")
+      .get_internal_probabilities()
+      .front();
+}
+
+bool topology_2e_pattern::has_electrons_external_probability() const {
+  return has_measurement_as<snemo::datamodel::tof_measurement>("tof_e1_e2");
+}
+
+double topology_2e_pattern::get_electrons_external_probability() const {
+  DT_THROW_IF(!has_electrons_external_probability(), std::logic_error,
+              "No electrons TOF measurement stored !");
+  return get_measurement_as<snemo::datamodel::tof_measurement>("tof_e1_e2")
+      .get_external_probabilities()
+      .front();
+}
+
+bool topology_2e_pattern::has_electrons_angle() const {
+  return has_measurement_as<snemo::datamodel::angle_measurement>("angle_e1_e2");
+}
+
+double topology_2e_pattern::get_electrons_angle() const {
+  DT_THROW_IF(!has_electrons_external_probability(), std::logic_error,
+              "No electrons angle measurement stored !");
+  return get_measurement_as<snemo::datamodel::angle_measurement>("angle_e1_e2").get_angle();
+}
+
+bool topology_2e_pattern::has_electrons_vertices_probability() const {
+  return has_measurement_as<snemo::datamodel::vertex_measurement>("vertex_e1_e2");
+}
+
+double topology_2e_pattern::get_electrons_vertices_probability() const {
+  DT_THROW_IF(!has_electrons_vertices_probability(), std::logic_error,
+              "No common electrons vertices measurement stored !");
+  return get_measurement_as<snemo::datamodel::vertex_measurement>("vertex_e1_e2").get_probability();
+}
+
+bool topology_2e_pattern::has_electrons_vertices_distance() const {
+  return has_measurement_as<snemo::datamodel::vertex_measurement>("vertex_e1_e2");
+}
+
+double topology_2e_pattern::get_electrons_vertices_distance_x() const {
+  DT_THROW_IF(!has_electrons_vertices_distance(), std::logic_error,
+              "No common electrons vertices measurement stored !");
+  return get_measurement_as<snemo::datamodel::vertex_measurement>("vertex_e1_e2")
+      .get_vertices_distance_x();
+}
+
+double topology_2e_pattern::get_electrons_vertices_distance_y() const {
+  DT_THROW_IF(!has_electrons_vertices_distance(), std::logic_error,
+              "No common electrons vertices measurement stored !");
+  return get_measurement_as<snemo::datamodel::vertex_measurement>("vertex_e1_e2")
+      .get_vertices_distance_y();
+}
+
+double topology_2e_pattern::get_electrons_vertices_distance_z() const {
+  DT_THROW_IF(!has_electrons_vertices_distance(), std::logic_error,
+              "No common electrons vertices measurement stored !");
+  return get_measurement_as<snemo::datamodel::vertex_measurement>("vertex_e1_e2")
+      .get_vertices_distance_z();
+}
+
+bool topology_2e_pattern::has_electrons_vertex_location() const {
+  return has_measurement_as<snemo::datamodel::vertex_measurement>("vertex_e1_e2");
+}
+
+std::string topology_2e_pattern::get_electrons_vertex_location() const {
+  DT_THROW_IF(!has_electrons_vertex_location(), std::logic_error,
+              "No common electrons vertices measurement stored !");
+  return dynamic_cast<const snemo::datamodel::vertex_measurement&>(get_measurement("vertex_e1_e2"))
+      .get_location();
+}
+
+bool topology_2e_pattern::has_electrons_vertex_position() const {
+  return has_measurement_as<snemo::datamodel::vertex_measurement>("vertex_e1_e2");
+}
+
+double topology_2e_pattern::get_electrons_vertex_position_x() const {
+  DT_THROW_IF(!has_electrons_vertex_position(), std::logic_error,
+              "No electrons vertex measurement stored !");
+  return get_measurement_as<snemo::datamodel::vertex_measurement>("vertex_e1_e2")
+      .get_vertex_position_x();
+}
+
+double topology_2e_pattern::get_electrons_vertex_position_y() const {
+  DT_THROW_IF(!has_electrons_vertex_position(), std::logic_error,
+              "No electrons vertex measurement stored !");
+  return get_measurement_as<snemo::datamodel::vertex_measurement>("vertex_e1_e2")
+      .get_vertex_position_y();
+}
+
+double topology_2e_pattern::get_electrons_vertex_position_z() const {
+  DT_THROW_IF(!has_electrons_vertex_position(), std::logic_error,
+              "No electrons vertex measurement stored !");
+  return get_measurement_as<snemo::datamodel::vertex_measurement>("vertex_e1_e2")
+      .get_vertex_position_z();
+}
+
+}  // end of namespace datamodel
+
+}  // end of namespace snemo
+
+/*
+** Local Variables: --
+** mode: c++ --
+** c-file-style: "gnu" --
+** tab-width: 2 --
+** End: --
+*/

--- a/source/falaise/snemo/datamodels/topology_2e_pattern.h
+++ b/source/falaise/snemo/datamodels/topology_2e_pattern.h
@@ -1,0 +1,135 @@
+/// \file falaise/snemo/datamodels/topology_2e_pattern.h
+/* Author(s) :    Steven Calvez <calvez@lal.in2p3.fr>
+ * Creation date: 2015-05-19
+ * Last modified: 2015-10-16
+ *
+ * Description: The 2 electrons topology pattern class
+ */
+
+#ifndef FALAISE_SNEMO_DATAMODEL_TOPOLOGY_2E_PATTERN_H
+#define FALAISE_SNEMO_DATAMODEL_TOPOLOGY_2E_PATTERN_H 1
+
+// This project:
+#include <falaise/snemo/datamodels/base_topology_pattern.h>
+
+namespace snemo {
+
+namespace datamodel {
+
+/// \brief The 2 electrons class of reconstructed topology
+class topology_2e_pattern : public base_topology_pattern {
+ public:
+  /// Static function to return pattern identifier of the pattern
+  static const std::string& pattern_id();
+
+  /// Return pattern identifier of the pattern
+  virtual std::string get_pattern_id() const;
+
+  /// Constructor
+  topology_2e_pattern();
+
+  /// Destructor
+  virtual ~topology_2e_pattern();
+
+  /// Check electron minimal energy validity
+  bool has_electron_minimal_energy() const;
+
+  /// Get electron minimal energy
+  double get_electron_minimal_energy() const;
+
+  /// Check electron maximal energy validity
+  bool has_electron_maximal_energy() const;
+
+  /// Get electron maximal energy
+  double get_electron_maximal_energy() const;
+
+  /// Check electrons energy
+  bool has_electrons_energy() const;
+
+  /// Get electrons energy sum
+  double get_electrons_energy_sum() const;
+
+  /// Get electrons energy difference
+  double get_electrons_energy_difference() const;
+
+  /// Get the name of the minimal energy electron
+  std::string get_minimal_energy_electron_name() const;
+
+  /// Get the name of the maximal energy electron
+  std::string get_maximal_energy_electron_name() const;
+
+  /// Check electrons TOF internal probability validity
+  bool has_electrons_internal_probability() const;
+
+  /// Get electrons TOF internal probability
+  double get_electrons_internal_probability() const;
+
+  /// Check electrons TOF external probability validity
+  bool has_electrons_external_probability() const;
+
+  /// Get electrons TOF external probability
+  double get_electrons_external_probability() const;
+
+  /// Check angle between electrons validity
+  bool has_electrons_angle() const;
+
+  /// Get angle between electrons
+  double get_electrons_angle() const;
+
+  /// Check common vertices probability between electrons validity
+  bool has_electrons_vertices_probability() const;
+
+  /// Get common vertices probability between electrons
+  double get_electrons_vertices_probability() const;
+
+  /// Check common vertices distance between electrons validity
+  bool has_electrons_vertices_distance() const;
+
+  /// Get common vertices distance in X between electrons
+  double get_electrons_vertices_distance_x() const;
+
+  /// Get common vertices distance in Y between electrons
+  double get_electrons_vertices_distance_y() const;
+
+  /// Get common vertices distance in Z between electrons
+  double get_electrons_vertices_distance_z() const;
+
+  /// Check common vertices location between electrons
+  bool has_electrons_vertex_location() const;
+
+  /// Get common vertices location between electrons
+  std::string get_electrons_vertex_location() const;
+
+  /// Check electrons vertex position validity
+  bool has_electrons_vertex_position() const;
+
+  /// Return electrons vertex position in X
+  double get_electrons_vertex_position_x() const;
+
+  /// Return electrons vertex position in Y
+  double get_electrons_vertex_position_y() const;
+
+  /// Return electrons vertex position in Z
+  double get_electrons_vertex_position_z() const;
+
+ private:
+  DATATOOLS_SERIALIZATION_DECLARATION()
+};
+
+}  // end of namespace datamodel
+
+}  // end of namespace snemo
+
+#include <boost/serialization/export.hpp>
+BOOST_CLASS_EXPORT_KEY2(snemo::datamodel::topology_2e_pattern,
+                        "snemo::datamodel::topology_2e_pattern")
+
+#endif  // FALAISE_SNEMO_DATAMODEL_TOPOLOGY_2E_PATTERN_H
+
+/*
+** Local Variables: --
+** mode: c++ --
+** c-file-style: "gnu" --
+** tab-width: 2 --
+** End: --
+*/

--- a/source/falaise/snemo/datamodels/topology_2e_pattern.ipp
+++ b/source/falaise/snemo/datamodels/topology_2e_pattern.ipp
@@ -1,0 +1,33 @@
+// -*- mode: c++ ; -*-
+/// \file falaise/snemo/datamodels/topology_2e_pattern.ipp
+
+#ifndef FALAISE_SNEMO_DATAMODEL_TOPOLOGY_2E_PATTERN_IPP
+#define FALAISE_SNEMO_DATAMODEL_TOPOLOGY_2E_PATTERN_IPP 1
+
+// Ourselves:
+#include <falaise/snemo/datamodels/topology_2e_pattern.h>
+
+// Third party:
+// - Boost:
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/nvp.hpp>
+
+// This project:
+#include <falaise/snemo/datamodels/base_topology_pattern.ipp>
+
+namespace snemo {
+
+namespace datamodel {
+
+/// Serialization method
+template <class Archive>
+void topology_2e_pattern::serialize(Archive& ar_, const unsigned int /* version */) {
+  ar_& BOOST_SERIALIZATION_BASE_OBJECT_NVP(base_topology_pattern);
+  return;
+}
+
+}  // end of namespace datamodel
+
+}  // end of namespace snemo
+
+#endif  // FALAISE_SNEMO_DATAMODEL_TOPOLOGY_2E_PATTERN_IPP

--- a/source/falaise/snemo/datamodels/topology_data.cc
+++ b/source/falaise/snemo/datamodels/topology_data.cc
@@ -1,0 +1,91 @@
+// topology_data.cc
+
+// Ourselves:
+#include <falaise/snemo/datamodels/topology_data.h>
+
+namespace snemo {
+
+namespace datamodel {
+
+bool topology_data::has_pattern() const { return _pattern_.has_data(); }
+
+void topology_data::set_pattern_handle(const handle_pattern& pattern_handle_) {
+  _pattern_ = pattern_handle_;
+  return;
+}
+
+void topology_data::detach_pattern() {
+  _pattern_.reset();
+  return;
+}
+
+topology_data::handle_pattern& topology_data::grab_pattern_handle() { return _pattern_; }
+
+const topology_data::handle_pattern& topology_data::get_pattern_handle() const { return _pattern_; }
+
+base_topology_pattern& topology_data::grab_pattern() { return _pattern_.grab(); }
+
+const base_topology_pattern& topology_data::get_pattern() const { return _pattern_.get(); }
+
+datatools::properties& topology_data::grab_auxiliaries() { return _auxiliaries_; }
+
+const datatools::properties& topology_data::get_auxiliaries() const { return _auxiliaries_; }
+
+topology_data::topology_data() { return; }
+
+topology_data::~topology_data() {
+  this->reset();
+  return;
+}
+
+void topology_data::reset() {
+  this->clear();
+  return;
+}
+
+void topology_data::clear() {
+  detach_pattern();
+  _auxiliaries_.clear();
+  return;
+}
+
+void topology_data::tree_dump(std::ostream& out_, const std::string& title_,
+                              const std::string& indent_, bool inherit_) const {
+  std::string indent;
+  if (!indent_.empty()) {
+    indent = indent_;
+  }
+  if (!title_.empty()) {
+    out_ << indent << title_ << std::endl;
+  }
+
+  out_ << indent << datatools::i_tree_dumpable::tag
+       << "Pattern : " << (has_pattern() ? "Yes" : "No") << std::endl;
+  if (has_pattern()) {
+    std::ostringstream indent_oss;
+    indent_oss << indent;
+    indent_oss << datatools::i_tree_dumpable::skip_tag;
+    get_pattern().tree_dump(out_, "", indent_oss.str());
+  }
+
+  out_ << indent << datatools::i_tree_dumpable::inherit_tag(inherit_) << "Auxiliaries : ";
+  if (_auxiliaries_.empty()) {
+    out_ << "<empty>";
+  }
+  out_ << std::endl;
+  {
+    std::ostringstream indent_oss;
+    indent_oss << indent;
+    indent_oss << datatools::i_tree_dumpable::inherit_skip_tag(inherit_);
+    _auxiliaries_.tree_dump(out_, "", indent_oss.str());
+  }
+
+  return;
+}
+
+// serial tag for datatools::serialization::i_serializable interface :
+DATATOOLS_SERIALIZATION_SERIAL_TAG_IMPLEMENTATION(topology_data, "snemo::datamodel::topology_data")
+
+}  // namespace datamodel
+
+}  // end of namespace snemo

--- a/source/falaise/snemo/datamodels/topology_data.h
+++ b/source/falaise/snemo/datamodels/topology_data.h
@@ -1,0 +1,130 @@
+/// \file falaise/snemo/datamodels/topology_data.h
+/* Author (s) : Steven Calvez  <calvez@lal.in2p3.fr>
+ *              Xavier Garrido <garrido@lal.in2p3.fr>
+ * Creation date: 2015-03-31
+ * Last modified: 2015-03-31
+ *
+ * Description:  SuperNEMO Topology data model
+ *
+ * History:
+ *
+ */
+
+#ifndef FALAISE_SNEMO_DATAMODELS_TOPOLOGY_DATA_H
+#define FALAISE_SNEMO_DATAMODELS_TOPOLOGY_DATA_H 1
+
+// Third party:
+// - Bayeux/datatools:
+#include <bayeux/datatools/handle.h>
+#include <bayeux/datatools/i_clear.h>
+#include <bayeux/datatools/i_serializable.h>
+#include <bayeux/datatools/i_tree_dump.h>
+#include <bayeux/datatools/properties.h>
+
+// This project:
+#include <falaise/snemo/datamodels/base_topology_pattern.h>
+
+namespace snemo {
+
+namespace datamodel {
+
+/// \brief SuperNEMO topology data model
+class topology_data : public datatools::i_serializable,
+                      public datatools::i_tree_dumpable,
+                      public datatools::i_clear {
+ public:
+  /// Handle on topology pattern
+  typedef datatools::handle<base_topology_pattern> handle_pattern;
+
+  /// Default constructor
+  topology_data();
+
+  /// Destructor
+  virtual ~topology_data();
+
+  /// Check if the pattern is present
+  bool has_pattern() const;
+
+  /// Detach the pattern
+  void detach_pattern();
+
+  /// Attach a pattern by handle
+  void set_pattern_handle(const handle_pattern& pattern_handle_);
+
+  /// Return a mutable reference on the pattern handle
+  handle_pattern& grab_pattern_handle();
+
+  /// Return a non mutable reference on the pattern handle
+  const handle_pattern& get_pattern_handle() const;
+
+  /// Return a mutable reference on the pattern
+  base_topology_pattern& grab_pattern();
+
+  /// Return a non mutable reference on the pattern
+  const base_topology_pattern& get_pattern() const;
+
+  /// Check pattern data type
+  template <class T>
+  bool has_pattern_as() const {
+    DT_THROW_IF(!has_pattern(), std::logic_error,
+                "Topology data does not hold any topology pattern !");
+    const std::type_info& ti = typeid(T);
+    const std::type_info& tf = typeid(get_pattern());
+    return ti == tf;
+  }
+
+  /// Get a non-mutable topology pattern of a given type
+  template <class T>
+  const T& get_pattern_as() const {
+    DT_THROW_IF(!has_pattern_as<T>(), std::logic_error,
+                "Invalid request on topology pattern type !");
+    return dynamic_cast<const T&>(get_pattern());
+  }
+
+  /// Get a mutable topology pattern of a given type
+  template <class T>
+  T& grab_pattern_as() {
+    DT_THROW_IF(!has_pattern_as<T>(), std::logic_error,
+                "Invalid request on topology pattern type !");
+    return dynamic_cast<T&>(grab_pattern());
+  }
+
+  /// Return a mutable reference on the container of auxiliary properties
+  const datatools::properties& get_auxiliaries() const;
+
+  /// Return a non mutable reference on the container of auxiliary properties
+  datatools::properties& grab_auxiliaries();
+
+  /// Reset the internals
+  void reset();
+
+  /// Clear the object
+  virtual void clear();
+
+  /// Smart print
+  virtual void tree_dump(std::ostream& out_ = std::clog, const std::string& title_ = "",
+                         const std::string& indent_ = "", bool inherit_ = false) const;
+
+ private:
+  handle_pattern _pattern_;             //!< Handle to a topology pattern
+  datatools::properties _auxiliaries_;  //!< Auxiliary properties
+
+  DATATOOLS_SERIALIZATION_DECLARATION()
+};
+
+}  // end of namespace datamodel
+
+}  // end of namespace snemo
+
+#include <boost/serialization/export.hpp>
+BOOST_CLASS_EXPORT_KEY2(snemo::datamodel::topology_data, "snemo::datamodel::topology_data")
+
+#endif  // FALAISE_SNEMO_DATAMODELS_TOPOLOGY_DATA_H
+
+/*
+** Local Variables: --
+** mode: c++ --
+** c-file-style: "gnu" --
+** tab-width: 2 --
+** End: --
+*/

--- a/source/falaise/snemo/datamodels/topology_data.ipp
+++ b/source/falaise/snemo/datamodels/topology_data.ipp
@@ -1,0 +1,37 @@
+// -*- mode: c++ ; -*-
+/// \file falaise/snemo/datamodels/topology_data.ipp
+
+#ifndef FALAISE_SNEMO_DATAMODEL_TOPOLOGY_DATA_IPP
+#define FALAISE_SNEMO_DATAMODEL_TOPOLOGY_DATA_IPP 1
+
+// Ourselves:
+#include <falaise/snemo/datamodels/topology_data.h>
+
+// Third party:
+// - Boost:
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/nvp.hpp>
+#include <boost/serialization/vector.hpp>
+// - Bayeux/datatools:
+#include <datatools/properties.ipp>
+
+// This project:
+#include <falaise/snemo/datamodels/base_topology_pattern.ipp>
+
+namespace snemo {
+
+namespace datamodel {
+
+template <class Archive>
+void topology_data::serialize(Archive& ar_, const unsigned int /*version_*/) {
+  ar_& DATATOOLS_SERIALIZATION_I_SERIALIZABLE_BASE_OBJECT_NVP;
+  ar_& boost::serialization::make_nvp("pattern", _pattern_);
+  ar_& boost::serialization::make_nvp("auxiliaries", _auxiliaries_);
+  return;
+}
+
+}  // end of namespace datamodel
+
+}  // end of namespace snemo
+
+#endif  // FALAISE_SNEMO_DATAMODEL_TOPOLOGY_DATA_IPP

--- a/source/falaise/snemo/datamodels/vertex_measurement.cc
+++ b/source/falaise/snemo/datamodels/vertex_measurement.cc
@@ -1,0 +1,142 @@
+/** \file falaise/snemo/datamodels/vertex_measurement.cc
+ */
+
+// Ourselves:
+#include <falaise/snemo/datamodels/particle_track.h>
+#include <falaise/snemo/datamodels/vertex_measurement.h>
+
+namespace snemo {
+
+namespace datamodel {
+
+// Serial tag for datatools::i_serializable interface :
+DATATOOLS_SERIALIZATION_SERIAL_TAG_IMPLEMENTATION(vertex_measurement,
+                                                  "snemo::datamodel::vertex_measurement")
+
+vertex_measurement::vertex_measurement() {
+  _vertex_.invalidate();
+  datatools::invalidate(_probability_);
+  return;
+}
+
+vertex_measurement::~vertex_measurement() { return; }
+
+bool vertex_measurement::has_vertex() const {
+  // Only test if placement is valid (blur_spot validation implies a valid
+  // base_hit i.e. valid geom_id + valid errors...)
+  // return _vertex_.get_placement().is_valid();
+  return has_probability();
+}
+
+const geomtools::blur_spot& vertex_measurement::get_vertex() const { return _vertex_; }
+
+geomtools::blur_spot& vertex_measurement::grab_vertex() { return _vertex_; }
+
+bool vertex_measurement::has_probability() const { return datatools::is_valid(_probability_); }
+
+double vertex_measurement::get_probability() const { return _probability_; }
+
+void vertex_measurement::set_probability(const double probability_) {
+  _probability_ = probability_;
+  return;
+}
+
+bool vertex_measurement::has_vertices_distance() const {
+  return (datatools::is_valid(_vertex_.get_x_error()) &&
+          datatools::is_valid(_vertex_.get_y_error()) &&
+          datatools::is_valid(_vertex_.get_z_error()));
+  // return (datatools::is_valid(_vertex_.get_y_error()) &&
+  //         datatools::is_valid(_vertex_.get_z_error()));
+}
+
+double vertex_measurement::get_vertices_distance_x() const { return _vertex_.get_x_error(); }
+
+double vertex_measurement::get_vertices_distance_y() const { return _vertex_.get_y_error(); }
+
+double vertex_measurement::get_vertices_distance_z() const { return _vertex_.get_z_error(); }
+
+bool vertex_measurement::has_vertex_position() const {
+  return (datatools::is_valid(_vertex_.get_position().x()) &&
+          datatools::is_valid(_vertex_.get_position().y()) &&
+          datatools::is_valid(_vertex_.get_position().z()));
+}
+
+double vertex_measurement::get_vertex_position_x() const { return _vertex_.get_position().x(); }
+
+double vertex_measurement::get_vertex_position_y() const { return _vertex_.get_position().y(); }
+
+double vertex_measurement::get_vertex_position_z() const { return _vertex_.get_position().z(); }
+
+bool vertex_measurement::has_location() const {
+  std::string location;
+  _vertex_.get_auxiliaries().fetch("vertex.type", location);
+
+  return location != snemo::datamodel::particle_track::vertex_none_label();
+}
+
+std::string vertex_measurement::get_location() const {
+  std::string location;
+  _vertex_.get_auxiliaries().fetch("vertex.type", location);
+  return location;
+}
+
+void vertex_measurement::tree_dump(std::ostream& out_, const std::string& title_,
+                                   const std::string& indent_, bool inherit_) const {
+  std::string indent;
+  if (!indent_.empty()) indent = indent_;
+  base_topology_measurement::tree_dump(out_, title_, indent_, true);
+
+  out_ << indent << datatools::i_tree_dumpable::tag << "Probability: ";
+  if (!has_probability()) {
+    out_ << "<no value>" << std::endl;
+  } else {
+    out_ << _probability_ / CLHEP::perCent << "%" << std::endl;
+  }
+
+  out_ << indent << datatools::i_tree_dumpable::tag << "Distance: " << std::endl;
+  if (!has_vertices_distance()) {
+    out_ << "<no value>" << std::endl;
+  } else {
+    out_ << indent << datatools::i_tree_dumpable::tag << "X "
+         << get_vertices_distance_x() / CLHEP::mm << " mm" << std::endl;
+    out_ << indent << datatools::i_tree_dumpable::tag << "Y "
+         << get_vertices_distance_y() / CLHEP::mm << " mm" << std::endl;
+    out_ << indent << datatools::i_tree_dumpable::tag << "Z "
+         << get_vertices_distance_z() / CLHEP::mm << " mm" << std::endl;
+  }
+
+  out_ << indent << datatools::i_tree_dumpable::tag << "Position: " << std::endl;
+  if (!has_vertex_position()) {
+    out_ << "<no value>" << std::endl;
+  } else {
+    out_ << indent << datatools::i_tree_dumpable::tag << "X " << get_vertex_position_x() / CLHEP::mm
+         << " mm" << std::endl;
+    out_ << indent << datatools::i_tree_dumpable::tag << "Y " << get_vertex_position_y() / CLHEP::mm
+         << " mm" << std::endl;
+    out_ << indent << datatools::i_tree_dumpable::tag << "Z " << get_vertex_position_z() / CLHEP::mm
+         << " mm" << std::endl;
+  }
+
+  out_ << indent << datatools::i_tree_dumpable::inherit_tag(inherit_) << "Vertex: ";
+  if (!has_vertex()) {
+    out_ << "<no value>" << std::endl;
+  } else {
+    out_ << std::endl;
+    std::ostringstream indent_oss;
+    indent_oss << indent_ << datatools::i_tree_dumpable::inherit_skip_tag(inherit_);
+    _vertex_.tree_dump(out_, "", indent_oss.str(), true);
+  }
+  return;
+}
+
+}  // end of namespace datamodel
+
+}  // end of namespace snemo
+
+/*
+** Local Variables: --
+** mode: c++ --
+** c-file-style: "gnu" --
+** tab-width: 2 --
+** End: --
+*/

--- a/source/falaise/snemo/datamodels/vertex_measurement.h
+++ b/source/falaise/snemo/datamodels/vertex_measurement.h
@@ -1,0 +1,107 @@
+/// \file falaise/snemo/datamodels/vertex_measurement.h
+/* Author(s) :    Steven Calvez <calvez@lal.in2p3.fr>
+ * Creation date: 2015-10-24
+ * Last modified: 2015-10-24
+ *
+ * Description: The class for vertex measurement
+ */
+
+#ifndef FALAISE_SNEMO_DATAMODEL_VERTEX_MEASUREMENT_H
+#define FALAISE_SNEMO_DATAMODEL_VERTEX_MEASUREMENT_H 1
+
+// This project
+#include <falaise/snemo/datamodels/base_topology_measurement.h>
+
+// Third party:
+// - Bayeux/geomtools:
+#include <bayeux/geomtools/blur_spot.h>
+
+namespace snemo {
+
+namespace datamodel {
+
+/// \brief The vertex measurement
+class vertex_measurement : public base_topology_measurement {
+ public:
+  /// Constructor
+  vertex_measurement();
+
+  /// Destructor
+  ~vertex_measurement();
+
+  /// Check vertex validity
+  bool has_vertex() const;
+
+  /// Get a non-mutable reference to vertex location
+  const geomtools::blur_spot& get_vertex() const;
+
+  /// Get a mutable reference to vertex location
+  geomtools::blur_spot& grab_vertex();
+
+  /// Check probability validity
+  bool has_probability() const;
+
+  /// Return vertex probability
+  double get_probability() const;
+
+  /// Set probability value
+  void set_probability(const double probability_);
+
+  /// Check vertices distance validity
+  bool has_vertices_distance() const;
+
+  /// Return vertices distance in X
+  double get_vertices_distance_x() const;
+
+  /// Return vertices distance in Y
+  double get_vertices_distance_y() const;
+
+  /// Return vertices distance in Z
+  double get_vertices_distance_z() const;
+
+  /// Check vertex position validity
+  bool has_vertex_position() const;
+
+  /// Return vertex position in X
+  double get_vertex_position_x() const;
+
+  /// Return vertex position in Y
+  double get_vertex_position_y() const;
+
+  /// Return vertex position in Z
+  double get_vertex_position_z() const;
+
+  /// Check location validity
+  bool has_location() const;
+
+  /// Return vertex location
+  std::string get_location() const;
+
+  /// Smart print
+  virtual void tree_dump(std::ostream& out_ = std::clog, const std::string& title_ = "",
+                         const std::string& indent_ = "", bool inherit_ = false) const;
+
+ private:
+  double _probability_;           //!< Chi2 probability of the vertex
+  geomtools::blur_spot _vertex_;  //!< 3D position and associated errors
+
+  DATATOOLS_SERIALIZATION_DECLARATION()
+};
+
+}  // end of namespace datamodel
+
+}  // end of namespace snemo
+
+#include <boost/serialization/export.hpp>
+BOOST_CLASS_EXPORT_KEY2(snemo::datamodel::vertex_measurement,
+                        "snemo::datamodel::vertex_measurement")
+
+#endif  // FALAISE_SNEMO_DATAMODEL_VERTEX_MEASUREMENT_H
+
+/*
+** Local Variables: --
+** mode: c++ --
+** c-file-style: "gnu" --
+** tab-width: 2 --
+** End: --
+*/

--- a/source/falaise/snemo/datamodels/vertex_measurement.ipp
+++ b/source/falaise/snemo/datamodels/vertex_measurement.ipp
@@ -1,0 +1,38 @@
+// -*- mode: c++ ; -*-
+/// \file falaise/snemo/datamodels/vertex_measurement.ipp
+
+#ifndef FALAISE_SNEMO_DATAMODEL_VERTEX_MEASUREMENT_IPP
+#define FALAISE_SNEMO_DATAMODEL_VERTEX_MEASUREMENT_IPP 1
+
+// Ourselves:
+#include <falaise/snemo/datamodels/vertex_measurement.h>
+
+// Third party:
+// - Boost:
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/nvp.hpp>
+#include <boost/serialization/string.hpp>
+// - Bayeux/datatools:
+#include <datatools/i_serializable.ipp>
+
+// This project:
+#include <falaise/snemo/datamodels/base_topology_measurement.ipp>
+
+namespace snemo {
+
+namespace datamodel {
+
+/// Serialization method
+template <class Archive>
+void vertex_measurement::serialize(Archive& ar_, const unsigned int /* version_ */) {
+  ar_& BOOST_SERIALIZATION_BASE_OBJECT_NVP(base_topology_measurement);
+  ar_& boost::serialization::make_nvp("probability", _probability_);
+  ar_& boost::serialization::make_nvp("vertex", _vertex_);
+  return;
+}
+
+}  // end of namespace datamodel
+
+}  // end of namespace snemo
+
+#endif  // FALAISE_SNEMO_DATAMODEL_VERTEX_MEASUREMENT_IPP

--- a/source/falaise/snemo/testing/test_snemo_datamodel_base_topology_pattern.cxx
+++ b/source/falaise/snemo/testing/test_snemo_datamodel_base_topology_pattern.cxx
@@ -1,0 +1,63 @@
+// test_base_topology_pattern.cxx
+
+// Standard library:
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <exception>
+
+// This project:
+#include <falaise/snemo/datamodels/topology_2e_pattern.h>
+#include <falaise/snemo/datamodels/tof_measurement.h>
+
+int main()
+{
+  int error_code = EXIT_SUCCESS;
+  try {
+    std::clog << "Test program for the 'base_topology_pattern' class." << std::endl;
+
+    // Create a fake topology pattern :
+    snemo::datamodel::base_topology_pattern::handle_type hTP0;
+    hTP0.reset(new snemo::datamodel::topology_2e_pattern);
+    snemo::datamodel::base_topology_pattern & a_pattern = hTP0.grab();
+
+    // Add associated measurement :
+    snemo::datamodel::base_topology_pattern::measurement_dict_type & meas_dict
+      = a_pattern.grab_measurement_dictionary();
+    // Add fake TOF measurements
+    meas_dict.insert(std::make_pair("fake_tof_1", new snemo::datamodel::tof_measurement));
+    meas_dict.insert(std::make_pair("fake_tof_2", new snemo::datamodel::tof_measurement));
+    meas_dict.insert(std::make_pair("fake_tof_3", new snemo::datamodel::tof_measurement));
+    meas_dict.insert(std::make_pair("fake_tof_10", new snemo::datamodel::tof_measurement));
+
+    a_pattern.tree_dump();
+
+    // Check measurement existence (through regular expression)
+    std::vector<std::string> keys = {
+      "fake_tof",
+      "fake_tof_.?",
+      "fake_tof_[0-9]+",
+      "fake_tof_[0-9]{2}",
+      "fake_tof_[0-9]{3}",
+      ".*",
+      ".*_(1|10)",
+      ".*_(100|1000)"
+    };
+    for (size_t i = 0; i < keys.size(); i++) {
+      const std::string & a_key = keys.at(i);
+      std::clog << "Topology pattern has ";
+      if (! a_pattern.has_measurement(a_key)) {
+        std::clog << "no ";
+      }
+      std::clog << "'" << a_key << "' measurement" << std::endl;
+    }
+
+  } catch (std::exception & x) {
+    std::cerr << "error: " << x.what() << std::endl;
+    error_code = EXIT_FAILURE;
+  } catch (...) {
+    std::cerr << "error: " << "unexpected error !" << std::endl;
+    error_code = EXIT_FAILURE;
+  }
+  return (error_code);
+}

--- a/source/falaise/snemo/testing/test_snemo_datamodel_tof_measurement.cxx
+++ b/source/falaise/snemo/testing/test_snemo_datamodel_tof_measurement.cxx
@@ -1,0 +1,41 @@
+// test_tof_measurement.cxx
+
+// Standard library:
+#include <iostream>
+#include <exception>
+
+// Third party:
+// - Bayeux/datatools:
+#include <bayeux/datatools/clhep_units.h>
+
+// This project:
+#include <falaise/snemo/datamodels/tof_measurement.h>
+
+int main()
+{
+  int error_code = EXIT_SUCCESS;
+  try {
+    std::clog << "Test program for the 'tof_measurement' class." << std::endl;
+    // Fake TOF measurement
+    snemo::datamodel::tof_measurement TM;
+    snemo::datamodel::tof_measurement::probability_type & int_probs
+      = TM.grab_internal_probabilities();
+    int_probs.push_back(10 * CLHEP::perCent);
+    int_probs.push_back(30 * CLHEP::perCent);
+    int_probs.push_back(40 * CLHEP::perCent);
+    snemo::datamodel::tof_measurement::probability_type & ext_probs
+      = TM.grab_external_probabilities();
+    ext_probs.push_back(1e-1 * CLHEP::perCent);
+    ext_probs.push_back(1e-4 * CLHEP::perCent);
+    ext_probs.push_back(1e-5 * CLHEP::perCent);
+    TM.tree_dump(std::cout, "TOF measurement dump:", "[notice]: ");
+
+  } catch (std::exception & x) {
+    std::cerr << "error: " << x.what() << std::endl;
+    error_code = EXIT_FAILURE;
+  } catch (...) {
+    std::cerr << "error: " << "unexpected error !" << std::endl;
+    error_code = EXIT_FAILURE;
+  }
+  return error_code;
+}

--- a/source/falaise/snemo/testing/test_snemo_datamodel_topology_data.cxx
+++ b/source/falaise/snemo/testing/test_snemo_datamodel_topology_data.cxx
@@ -1,0 +1,75 @@
+// test_topology_data.cxx
+
+// Standard library:
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <exception>
+
+// This project:
+#include <falaise/snemo/datamodels/topology_data.h>
+#include <falaise/snemo/datamodels/topology_1e_pattern.h>
+#include <falaise/snemo/datamodels/topology_2e_pattern.h>
+#include <falaise/snemo/datamodels/tof_measurement.h>
+
+int main()
+{
+  int error_code = EXIT_SUCCESS;
+  try {
+    std::clog << "Test program for the 'topology_data' class." << std::endl;
+
+    // Create a topology pattern :
+    snemo::datamodel::topology_data::handle_pattern hP0;
+    hP0.reset(new snemo::datamodel::topology_2e_pattern);
+    // Add associated particle tracks :
+    snemo::datamodel::base_topology_pattern::particle_track_dict_type & pt_dict
+      = hP0.grab().grab_particle_track_dictionary();
+    // Create 2 fake electrons :
+    pt_dict.insert(std::make_pair("fake_electron0", new snemo::datamodel::particle_track));
+    pt_dict.insert(std::make_pair("fake_electron1", new snemo::datamodel::particle_track));
+
+    // Add associated measurement :
+    snemo::datamodel::base_topology_pattern::measurement_dict_type & meas_dict
+      = hP0.grab().grab_measurement_dictionary();
+    // Add a fake TOF measurement
+    meas_dict.insert(std::make_pair("fake_tof", new snemo::datamodel::tof_measurement));
+
+    // Topology data bank :
+    snemo::datamodel::topology_data TD;
+    TD.set_pattern_handle(hP0);
+    TD.grab_auxiliaries().store_flag("test_td");
+    TD.tree_dump(std::clog, "Topology data:");
+
+    // Get pattern handle
+    if (TD.has_pattern()) {
+      const snemo::datamodel::base_topology_pattern & a_btp
+        = TD.get_pattern();
+      std::cout << "Pattern id " << a_btp.get_pattern_id() << std::endl;
+    }
+
+    // Check existence of 2e pattern
+    if (TD.has_pattern_as<snemo::datamodel::topology_2e_pattern>()) {
+      std::cout << "TD has " << snemo::datamodel::topology_2e_pattern::pattern_id()
+                << " pattern" << std::endl;
+      const snemo::datamodel::topology_2e_pattern & t2ep
+        = TD.get_pattern_as<snemo::datamodel::topology_2e_pattern>();
+      t2ep.tree_dump(std::clog, "2e topology pattern:");
+    }
+
+    // Check non existence of 1e pattern
+    try {
+      const snemo::datamodel::topology_1e_pattern & t1ep
+        = TD.get_pattern_as<snemo::datamodel::topology_1e_pattern>();
+      t1ep.tree_dump();
+    } catch (...) {
+      std::cerr << "No 1e pattern stored!" << std::endl;
+    }
+  } catch (std::exception & x) {
+    std::cerr << "error: " << x.what() << std::endl;
+    error_code = EXIT_FAILURE;
+  } catch (...) {
+    std::cerr << "error: " << "unexpected error !" << std::endl;
+    error_code = EXIT_FAILURE;
+  }
+  return (error_code);
+}

--- a/source/falaise/snemo/testing/test_snemo_datamodel_vertex_measurement.cxx
+++ b/source/falaise/snemo/testing/test_snemo_datamodel_vertex_measurement.cxx
@@ -1,0 +1,33 @@
+// test_vertex_measurement.cxx
+
+// Standard library:
+#include <iostream>
+#include <exception>
+
+// Third party:
+// - Bayeux/datatools:
+#include <bayeux/datatools/clhep_units.h>
+
+// This project:
+#include <falaise/snemo/datamodels/vertex_measurement.h>
+
+int main()
+{
+  int error_code = EXIT_SUCCESS;
+  try {
+    std::clog << "Test program for the 'vertex_measurement' class." << std::endl;
+    // Fake vertex measurement
+    snemo::datamodel::vertex_measurement VM;
+    geomtools::blur_spot & a_vertex = VM.grab_vertex();
+    geomtools::placement::from_string("10 -15 20 (mm)", a_vertex.grab_placement());
+    VM.tree_dump(std::cout, "Vertex measurement dump:", "[notice]: ");
+
+  } catch (std::exception & x) {
+    std::cerr << "error: " << x.what() << std::endl;
+    error_code = EXIT_FAILURE;
+  } catch (...) {
+    std::cerr << "error: " << "unexpected error !" << std::endl;
+    error_code = EXIT_FAILURE;
+  }
+  return error_code;
+}


### PR DESCRIPTION
Please fill in the following details as appropriate for your pull request.
You can leave any entries that aren't relevant blank.

Changes proposed in this pull request:
- Add new data bank named `topology_data`
- Add basic topology pattern needed by `topology_data`
- Add unit tests
- Update documentation

Additional comments or information
----------------------------------
The `topology_data` bank is currently hosted by the `ParticleIdentification` module. It might be the last reconstructed data bank before data analysis since topological information such as Time-Of-Flight calculation can be stored within this new data bank. 

Modules should only provide algorithms and do not host "general" data model. For instance, it is quite complicated for the `EventBrowser` module to use and to add topological informations from `topology_data` bank unless  the `EventBrowser` module explicitely set a dependency to `ParticleIdentification` module. Dependency between modules must be avoided.   