### PR TITLE
Update inc paths for ROOT 6.12

### DIFF
--- a/modules/EventBrowser/source/CMakeLists.txt
+++ b/modules/EventBrowser/source/CMakeLists.txt
@@ -122,6 +122,8 @@ else()
     set(CMAKE_INSTALL_LIBDIR_OLD "${CMAKE_INSTALL_LIBDIR}")
     set(CMAKE_INSTALL_LIBDIR "${CMAKE_INSTALL_LIBDIR_OLD}/Falaise/modules")
   endif()
+  # Root 6.12 requires additional include path
+  include_directories("${CMAKE_CURRENT_SOURCE_DIR}")
   root_generate_dictionary(event_browser_dict
     "${FalaiseEventBrowserPlugin_DICT_HEADERS}"
     ${__EVENTBROWSER_MODULE_ARG}


### PR DESCRIPTION
Latest versions of ROOT require additional include paths to be set before
calling root_generate_dictionary.

Please fill in the following details as appropriate for your pull request.
You can leave any entries that aren't relevant blank. If you think the pull request
will need further commits before being ready for review/merge, prepend "WIP:" to
the title.

Changes proprosed in this pull request:
- Update include_directories to point ROOT to our dictionary headers

Does this pull request fix any reported issues?
- Fixes #.

Additional comments or information
----------------------------------
Needed to support macOS High Sierra, which requires use of ROOT 6.12

