### PR TITLE
Remove default units for parameters with dimension

### DIFF
--- a/source/falaise/snemo/cuts/calibrated_data_cut.cc
+++ b/source/falaise/snemo/cuts/calibrated_data_cut.cc
@@ -223,10 +223,8 @@ void calibrated_data_cut::initialize(const datatools::properties& configuration_
     if (is_mode_tracker_hit_is_delayed()) {
       DT_LOG_DEBUG(get_logging_priority(), "Using TRACKER_HIT_IS_DELAYED mode...");
       if (configuration_.has_key("tracker_hit_is_delayed.delay_time")) {
-        _tracker_hit_delay_time_ = configuration_.fetch_real("tracker_hit_is_delayed.delay_time");
-        if (!configuration_.has_explicit_unit("tracker_hit_is_delayed.delay_time")) {
-          _tracker_hit_delay_time_ *= CLHEP::microsecond;
-        }
+        _tracker_hit_delay_time_ =
+          configuration_.fetch_real_with_explicit_dimension("tracker_hit_is_delayed.delay_time", "time");
       }
     }  // end of is_mode_tracker_hit_is_delayed
   }

--- a/source/falaise/snemo/cuts/tracker_trajectory_data_cut.cc
+++ b/source/falaise/snemo/cuts/tracker_trajectory_data_cut.cc
@@ -161,20 +161,14 @@ void tracker_trajectory_data_cut::initialize(const datatools::properties& config
       DT_LOG_DEBUG(get_logging_priority(), "Using RANGE_PVALUE mode...");
       int count = 0;
       if (configuration_.has_key("range_pvalue.min")) {
-        double pmin = configuration_.fetch_real("range_pvalue.min");
-        if (!configuration_.has_explicit_unit("range_pvalue.min")) {
-          pmin *= CLHEP::perCent;
-        }
+        const double pmin = configuration_.fetch_real_with_explicit_dimension("range_pvalue.min", "fraction");
         DT_THROW_IF(pmin < 0.0 * CLHEP::perCent || pmin > 100.0 * CLHEP::perCent, std::range_error,
                     "Invalid min value of p-value (" << pmin << ") !");
         _pvalue_range_min_ = pmin;
         count++;
       }
       if (configuration_.has_key("range_pvalue.max")) {
-        double pmax = configuration_.fetch_real("range_pvalue.max");
-        if (!configuration_.has_explicit_unit("range_pvalue.max")) {
-          pmax *= CLHEP::perCent;
-        }
+        const double pmax = configuration_.fetch_real_with_explicit_dimension("range_pvalue.max", "fraction");
         DT_THROW_IF(pmax < 0.0 * CLHEP::perCent || pmax > 100.0 * CLHEP::perCent, std::range_error,
                     "Invalid max value of p-value (" << pmax << ") !");
         _pvalue_range_max_ = pmax;

--- a/source/falaise/snemo/processing/base_gamma_builder.cc
+++ b/source/falaise/snemo/processing/base_gamma_builder.cc
@@ -119,10 +119,7 @@ void base_gamma_builder::_initialize(const datatools::properties& setup_) {
   if (_add_foil_vertex_extrapolation_) {
     if (bgb_setup.has_key("add_foil_vertex_extrapolation.minimal_probability")) {
       _add_foil_vertex_minimal_probability_ =
-          bgb_setup.fetch_real("add_foil_vertex_extrapolation.minimal_probability");
-      if (!bgb_setup.has_explicit_unit("add_foil_vertex_extrapolation.minimal_probability")) {
-        _add_foil_vertex_minimal_probability_ *= CLHEP::perCent;
-      }
+        bgb_setup.fetch_real_with_explicit_dimension("add_foil_vertex_extrapolation.minimal_probability", "fraction");
     }
   }
 
@@ -134,10 +131,7 @@ void base_gamma_builder::_initialize(const datatools::properties& setup_) {
   if (_add_gamma_from_annihilation_) {
     if (bgb_setup.has_key("add_gamma_from_annihilation.minimal_probability")) {
       _add_gamma_from_annihilation_minimal_probability_ =
-          bgb_setup.fetch_real("add_gamma_from_annihilation.minimal_probability");
-      if (!bgb_setup.has_explicit_unit("add_gamma_from_annihilation.minimal_probability")) {
-        _add_gamma_from_annihilation_minimal_probability_ *= CLHEP::perCent;
-      }
+        bgb_setup.fetch_real_with_explicit_dimension("add_gamma_from_annihilation.minimal_probability", "fraction");
     }
   }
   return;

--- a/source/falaise/snemo/processing/base_tracker_clusterizer.cc
+++ b/source/falaise/snemo/processing/base_tracker_clusterizer.cc
@@ -121,14 +121,10 @@ void base_tracker_clusterizer::_initialize(const datatools::properties &setup_) 
   _tpc_setup_data_.processing_delayed_hits = true;
   _tpc_setup_data_.split_chamber = false;
 
-  double default_time_unit = CLHEP::microsecond;
-
   // Delayed hit minimum time :
   if (setup_.has_key("TPC.delayed_hit_cluster_time")) {
-    double delayed_hit_cluster_time = setup_.fetch_real("TPC.delayed_hit_cluster_time");
-    if (!setup_.has_explicit_unit("TPC.delayed_hit_cluster_time")) {
-      delayed_hit_cluster_time *= default_time_unit;
-    }
+    const double delayed_hit_cluster_time =
+      setup_.fetch_real_with_explicit_dimension("TPC.delayed_hit_cluster_time", "time");
     _tpc_setup_data_.delayed_hit_cluster_time = delayed_hit_cluster_time;
   }
 

--- a/source/falaise/snemo/processing/calorimeter_regime.cc
+++ b/source/falaise/snemo/processing/calorimeter_regime.cc
@@ -54,60 +54,30 @@ calorimeter_regime::calorimeter_regime() {
 void calorimeter_regime::initialize(const datatools::properties& config_) {
   DT_THROW_IF(is_initialized(), std::logic_error, "Calorimeter regime is already initialized !");
 
-  const double energy_unit = CLHEP::keV;
-  const double time_unit = CLHEP::ns;
-
-  // Energy resolution
-  {
-    const std::string key_name = "energy.resolution";
-    if (config_.has_key(key_name)) {
-      _resolution_ = config_.fetch_real(key_name);
-      if (!config_.has_explicit_unit(key_name)) {
-        _resolution_ *= CLHEP::perCent;
-      }
-    }
+  if (config_.has_key("energy.resolution")) {
+    _resolution_ = config_.fetch_real_with_explicit_dimension("energy.resolution", "fraction");
   }
 
-  // Trigger thresholds
-  {
-    const std::string key_name = "energy.high_threshold";
-    if (config_.has_key(key_name)) {
-      _high_threshold_ = config_.fetch_real(key_name);
-      if (!config_.has_explicit_unit(key_name)) {
-        _high_threshold_ *= energy_unit;
-      }
-    }
+  if (config_.has_key("energy.high_threshold")) {
+    _high_threshold_ = config_.fetch_real_with_explicit_dimension("energy.high_threshold", "energy");
   }
 
-  {
-    const std::string key_name = "energy.low_threshold";
-    if (config_.has_key(key_name)) {
-      _low_threshold_ = config_.fetch_real(key_name);
-      if (!config_.has_explicit_unit(key_name)) {
-        _low_threshold_ *= energy_unit;
-      }
-    }
+  if (config_.has_key("energy.low_threshold")) {
+    _low_threshold_ = config_.fetch_real_with_explicit_dimension("energy.low_threshold", "energy");
   }
 
   // Alpha quenching fit parameters
-  {
-    const std::string key_name = "alpha_quenching_parameters";
-    if (config_.has_key(key_name)) {
-      _alpha_quenching_0_ = config_.fetch_real_vector(key_name, 0);
-      _alpha_quenching_1_ = config_.fetch_real_vector(key_name, 1);
-      _alpha_quenching_2_ = config_.fetch_real_vector(key_name, 2);
-    }
+  const std::string key_name = "alpha_quenching_parameters";
+  if (config_.has_key(key_name)) {
+    _alpha_quenching_0_ = config_.fetch_real_vector(key_name, 0);
+    _alpha_quenching_1_ = config_.fetch_real_vector(key_name, 1);
+    _alpha_quenching_2_ = config_.fetch_real_vector(key_name, 2);
   }
 
   // Scintillator relaxation time for time resolution
-  {
-    const std::string key_name = "scintillator_relaxation_time";
-    if (config_.has_key(key_name)) {
-      _scintillator_relaxation_time_ = config_.fetch_real(key_name);
-      if (!config_.has_explicit_unit(key_name)) {
-        _scintillator_relaxation_time_ *= time_unit;
-      }
-    }
+  if (config_.has_key("scintillator_relaxation_time")) {
+    _scintillator_relaxation_time_
+      = config_.fetch_real_with_explicit_dimension("scintillator_relaxation_time", "time");
   }
 
   _initialized_ = true;

--- a/source/falaise/snemo/processing/geiger_regime.cc
+++ b/source/falaise/snemo/processing/geiger_regime.cc
@@ -33,43 +33,24 @@ void geiger_regime::reset() {
 void geiger_regime::initialize(const datatools::properties& config_) {
   DT_THROW_IF(is_initialized(), std::logic_error, "Already initialized !");
 
-  double length_unit = CLHEP::mm;
-  double time_unit = CLHEP::microsecond;
-  double drift_speed_unit = (CLHEP::cm / CLHEP::microsecond);
-
   if (config_.has_key("cell_diameter")) {
-    _cell_diameter_ = config_.fetch_real("cell_diameter");
-    if (!config_.has_explicit_unit("cell_diameter")) {
-      _cell_diameter_ *= length_unit;
-    }
+    _cell_diameter_ = config_.fetch_real_with_explicit_dimension("cell_diameter", "length");
   }
 
   if (config_.has_key("cell_length")) {
-    _cell_length_ = config_.fetch_real("cell_length");
-    if (!config_.has_explicit_unit("cell_length")) {
-      _cell_length_ *= length_unit;
-    }
+    _cell_length_ = config_.fetch_real_with_explicit_dimension("cell_length", "length");
   }
 
   if (config_.has_key("tcut")) {
-    _tcut_ = config_.fetch_real("tcut");
-    if (!config_.has_explicit_unit("tcut")) {
-      _tcut_ *= time_unit;
-    }
+    _tcut_ = config_.fetch_real_with_explicit_dimension("tcut", "time");
   }
 
   if (config_.has_key("sigma_anode_time")) {
-    _sigma_anode_time_ = config_.fetch_real("sigma_anode_time");
-    if (!config_.has_explicit_unit("sigma_anode_time")) {
-      _sigma_anode_time_ *= time_unit;
-    }
+    _sigma_anode_time_ = config_.fetch_real_with_explicit_dimension("sigma_anode_time", "time");
   }
 
   if (config_.has_key("sigma_cathode_time")) {
-    _sigma_cathode_time_ = config_.fetch_real("sigma_cathode_time");
-    if (!config_.has_explicit_unit("sigma_cathode_time")) {
-      _sigma_cathode_time_ *= time_unit;
-    }
+    _sigma_cathode_time_ = config_.fetch_real_with_explicit_dimension("sigma_cathode_time", "time");
   }
 
   if (config_.has_key("base_anode_efficiency")) {
@@ -81,38 +62,26 @@ void geiger_regime::initialize(const datatools::properties& config_) {
   }
 
   if (config_.has_key("plasma_longitudinal_speed")) {
-    _plasma_longitudinal_speed_ = config_.fetch_real("plasma_longitudinal_speed");
-    if (!config_.has_explicit_unit("plasma_longitudinal_speed")) {
-      _plasma_longitudinal_speed_ *= drift_speed_unit;
-    }
+    _plasma_longitudinal_speed_
+      = config_.fetch_real_with_explicit_dimension("plasma_longitudinal_speed", "velocity");
   }
 
   if (config_.has_key("sigma_plasma_longitudinal_speed")) {
-    _sigma_plasma_longitudinal_speed_ = config_.fetch_real("sigma_plasma_longitudinal_speed");
-    if (!config_.has_explicit_unit("sigma_plasma_longitudinal_speed")) {
-      _sigma_plasma_longitudinal_speed_ *= drift_speed_unit;
-    }
+    _sigma_plasma_longitudinal_speed_
+      = config_.fetch_real_with_explicit_dimension("sigma_plasma_longitudinal_speed", "velocity");
   }
 
   if (config_.has_key("sigma_z")) {
-    _sigma_z_ = config_.fetch_real("sigma_z");
-    if (!config_.has_explicit_unit("sigma_z")) {
-      _sigma_z_ *= length_unit;
-    }
+    _sigma_z_ = config_.fetch_real_with_explicit_dimension("sigma_z", "length");
   }
 
   if (config_.has_key("sigma_z_missing_cathode")) {
-    _sigma_z_missing_cathode_ = config_.fetch_real("sigma_z_missing_cathode");
-    if (!config_.has_explicit_unit("sigma_z_missing_cathode")) {
-      _sigma_z_missing_cathode_ *= length_unit;
-    }
+    _sigma_z_missing_cathode_
+      = config_.fetch_real_with_explicit_dimension("sigma_z_missing_cathode", "length");
   }
 
   if (config_.has_key("sigma_r_a")) {
-    _sigma_r_a_ = config_.fetch_real("sigma_r_a");
-    if (!config_.has_explicit_unit("sigma_r_a")) {
-      _sigma_r_a_ *= length_unit;
-    }
+    _sigma_r_a_ = config_.fetch_real_with_explicit_dimension("sigma_r_a", "length");
   }
 
   if (config_.has_key("sigma_r_b")) {
@@ -120,20 +89,17 @@ void geiger_regime::initialize(const datatools::properties& config_) {
   }
 
   if (config_.has_key("sigma_r_r0")) {
-    _sigma_r_r0_ = config_.fetch_real("sigma_r_r0");
-    if (!config_.has_explicit_unit("sigma_r_r0")) {
-      _sigma_r_r0_ *= length_unit;
-    }
+    _sigma_r_r0_ = config_.fetch_real_with_explicit_dimension("sigma_r_r0", "length");
   }
 
-  DT_THROW_IF(_tcut_ < 8 * time_unit, std::range_error,
-              "Cut drift time is too short (" << _tcut_ / time_unit << " us < 8 us) !");
+  DT_THROW_IF(_tcut_ < 8 * CLHEP::microsecond, std::range_error,
+              "Cut drift time is too short (" << _tcut_ / CLHEP::microsecond << " us < 8 us) !");
 
   const double r_cell = 0.5 * _cell_diameter_;
   // 2011-05-12 FM : Compute a valid t0 before :
-  double step_drift_time1 = 0.050 * time_unit;
+  double step_drift_time1 = 0.050 * CLHEP::microsecond;
   bool tune = false;
-  for (double drift_time = 0.0 * time_unit; drift_time < (_tcut_ + 0.5 * step_drift_time1);
+  for (double drift_time = 0.0 * CLHEP::microsecond; drift_time < (_tcut_ + 0.5 * step_drift_time1);
        drift_time += step_drift_time1) {
     const double drift_radius = base_t_2_r(drift_time, 1);
     if (drift_radius > r_cell) {
@@ -148,8 +114,8 @@ void geiger_regime::initialize(const datatools::properties& config_) {
     }
   }
 
-  const double step_drift_time = 0.2 * time_unit;
-  for (double drift_time = 0.0 * time_unit; drift_time < (_tcut_ + 0.5 * step_drift_time);
+  const double step_drift_time = 0.2 * CLHEP::microsecond;
+  for (double drift_time = 0.0 * CLHEP::microsecond; drift_time < (_tcut_ + 0.5 * step_drift_time);
        drift_time += step_drift_time) {
     const double drift_radius = base_t_2_r(drift_time);
     _base_rt_.add_point(drift_radius, drift_time, false);

--- a/source/falaise/snemo/processing/mock_calorimeter_s2c_module.cc
+++ b/source/falaise/snemo/processing/mock_calorimeter_s2c_module.cc
@@ -158,16 +158,8 @@ void mock_calorimeter_s2c_module::initialize(const datatools::properties& setup_
   }
 
   // Setup trigger time
-  if (!datatools::is_valid(_cluster_time_width_)) {
-    if (setup_.has_key("cluster_time_width")) {
-      _cluster_time_width_ = setup_.fetch_real("cluster_time_width");
-      if (!setup_.has_explicit_unit("cluster_time_width")) {
-        _cluster_time_width_ *= CLHEP::ns;
-      }
-    }
-  }
-  if (!datatools::is_valid(_cluster_time_width_)) {
-    _cluster_time_width_ = 100 * CLHEP::ns;
+  if (setup_.has_key("cluster_time_width")) {
+    _cluster_time_width_ = setup_.fetch_real_with_explicit_dimension("cluster_time_width", "time");
   }
 
   // 2012-09-17 FM : support reference to the MC true hit ID
@@ -212,7 +204,7 @@ void mock_calorimeter_s2c_module::_set_defaults() {
   _SD_label_.clear();
   _CD_label_.clear();
   _Geo_label_.clear();
-  datatools::invalidate(_cluster_time_width_);
+  _cluster_time_width_ = 100 * CLHEP::ns;
   _alpha_quenching_ = true;
   _store_mc_hit_id_ = false;
   return;

--- a/source/falaise/snemo/processing/mock_tracker_s2c_module.cc
+++ b/source/falaise/snemo/processing/mock_tracker_s2c_module.cc
@@ -159,37 +159,31 @@ void mock_tracker_s2c_module::initialize(const datatools::properties& setup_,
   // Initialize the Geiger regime utility:
   _geiger_.initialize(setup_);
 
-  const double time_unit = CLHEP::microsecond;
-
   // Set minimum drift time for peripheral hits:
   if (setup_.has_key("peripheral_drift_time_threshold")) {
-    _peripheral_drift_time_threshold_ = setup_.fetch_real("peripheral_drift_time_threshold");
-    if (!setup_.has_explicit_unit("peripheral_drift_time_threshold")) {
-      _peripheral_drift_time_threshold_ *= time_unit;
-    }
+    _peripheral_drift_time_threshold_
+      = setup_.fetch_real_with_explicit_dimension("peripheral_drift_time_threshold", "time");
   }
   // Default value:
   if (!datatools::is_valid(_peripheral_drift_time_threshold_)) {
     _peripheral_drift_time_threshold_ = _geiger_.get_t0();
   }
   DT_LOG_DEBUG(get_logging_priority(), "peripheral_drift_time_threshold = "
-                                           << _peripheral_drift_time_threshold_ / CLHEP::microsecond
-                                           << " us");
+               << _peripheral_drift_time_threshold_ / CLHEP::microsecond
+               << " us");
 
   // Set minium drift time for delayed hits:
   if (setup_.has_key("delayed_drift_time_threshold")) {
-    _delayed_drift_time_threshold_ = setup_.fetch_real("delayed_drift_time_threshold");
-    if (!setup_.has_explicit_unit("delayed_drift_time_threshold")) {
-      _delayed_drift_time_threshold_ *= time_unit;
-    }
+    _delayed_drift_time_threshold_
+      = setup_.fetch_real_with_explicit_dimension("delayed_drift_time_threshold", "time");
   }
   // Default value:
   if (!datatools::is_valid(_delayed_drift_time_threshold_)) {
     _delayed_drift_time_threshold_ = _geiger_.get_tcut();
   }
   DT_LOG_DEBUG(get_logging_priority(), "delayed_drift_time_threshold = "
-                                           << _delayed_drift_time_threshold_ / CLHEP::microsecond
-                                           << " us");
+               << _delayed_drift_time_threshold_ / CLHEP::microsecond
+               << " us");
 
   // 2012-07-26 FM : support reference to the MC true hit ID
   if (setup_.has_flag("store_mc_hit_id")) {

--- a/source/falaise/snemo/simulation/cosmic_muon_generator.cc
+++ b/source/falaise/snemo/simulation/cosmic_muon_generator.cc
@@ -203,19 +203,6 @@ void cosmic_muon_generator::initialize(const datatools::properties& config_,
                 "Missing 'mode' property for particle generator '" << get_name() << "' !");
   }
 
-  double energy_unit = CLHEP::GeV;
-  double angle_unit = CLHEP::degree;
-
-  if (config_.has_key("energy_unit")) {
-    std::string unit_str = config_.fetch_string("energy_unit");
-    energy_unit = datatools::units::get_energy_unit_from(unit_str);
-  }
-
-  if (config_.has_key("angle_unit")) {
-    std::string unit_str = config_.fetch_string("angle_unit");
-    angle_unit = datatools::units::get_angle_unit_from(unit_str);
-  }
-
   if (_mode_ == MODE_SEA_LEVEL) {
     DT_THROW_IF(
         !config_.has_key("sea_level.mode"), std::logic_error,
@@ -233,28 +220,20 @@ void cosmic_muon_generator::initialize(const datatools::properties& config_,
 
     if (_sea_level_mode_ == SEA_LEVEL_TOY) {
       if (config_.has_key("sea_level_toy.energy_mean")) {
-        _sea_level_toy_setup_.energy_mean = config_.fetch_real("sea_level_toy.energy_mean");
-        if (!config_.has_explicit_unit("sea_level_toy.energy_mean")) {
-          _sea_level_toy_setup_.energy_mean *= energy_unit;
-        }
+        _sea_level_toy_setup_.energy_mean
+          = config_.fetch_real_with_explicit_dimension("sea_level_toy.energy_mean", "energy");
       }
       if (config_.has_key("sea_level_toy.energy_sigma")) {
-        _sea_level_toy_setup_.energy_sigma = config_.fetch_real("sea_level_toy.energy_sigma");
-        if (!config_.has_explicit_unit("sea_level_toy.energy_sigma")) {
-          _sea_level_toy_setup_.energy_sigma *= energy_unit;
-        }
+        _sea_level_toy_setup_.energy_sigma
+          = config_.fetch_real_with_explicit_dimension("sea_level_toy.energy_sigma", "energy");
       }
       if (config_.has_key("sea_level_toy.maximum_theta")) {
-        _sea_level_toy_setup_.maximum_theta = config_.fetch_real("sea_level_toy.maximum_theta");
-        if (!config_.has_explicit_unit("sea_level_toy.maximum_theta")) {
-          _sea_level_toy_setup_.maximum_theta *= angle_unit;
-        }
-        DT_THROW_IF(_sea_level_toy_setup_.maximum_theta < 0.0, std::range_error,
-                    "Invalid 'sea_level_toy.maximum_theta' value for particle generator '"
-                        << get_name() << "' !");
-        DT_THROW_IF(_sea_level_toy_setup_.maximum_theta > 90.0 * CLHEP::degree, std::range_error,
-                    "Invalid 'sea_level_toy.maximum_theta' value for particle generator '"
-                        << get_name() << "' !");
+        _sea_level_toy_setup_.maximum_theta
+          = config_.fetch_real_with_explicit_dimension("sea_level_toy.maximum_theta", "angle");
+        DT_THROW_IF(_sea_level_toy_setup_.maximum_theta < 0.0 ||
+                    _sea_level_toy_setup_.maximum_theta > 90.0 * CLHEP::degree,
+                    std::range_error, "Invalid 'sea_level_toy.maximum_theta' value for particle generator '"
+                    << get_name() << "' !");
       }
       if (config_.has_key("sea_level_toy.muon_ratio")) {
         _sea_level_toy_setup_.muon_ratio = config_.fetch_real("sea_level_toy.muon_ratio");

--- a/source/falaise/snemo/simulation/gg_step_hit_processor.cc
+++ b/source/falaise/snemo/simulation/gg_step_hit_processor.cc
@@ -135,37 +135,22 @@ void gg_step_hit_processor::initialize(const ::datatools::properties &config_,
   }
 
   // set the time resolution of the Geiger cell TDC measurement:
-  const double time_unit = CLHEP::ns;
   if (config_.has_key("time_resolution")) {
-    _time_resolution_ = config_.fetch_real("time_resolution");
-    if (!config_.has_explicit_unit("time_resolution")) {
-      _time_resolution_ *= time_unit;
-    }
+    _time_resolution_ = config_.fetch_real_with_explicit_dimension("time_resolution", "time");
   }
 
-  const double length_unit = CLHEP::mm;
   // set the fiducial drift radius of the Geiger cell:
   if (config_.has_key("fiducial_drift_radius")) {
-    _fiducial_drift_radius_ = config_.fetch_real("fiducial_drift_radius");
-    if (!config_.has_explicit_unit("fiducial_drift_radius")) {
-      _fiducial_drift_radius_ *= length_unit;
-    }
+    _fiducial_drift_radius_ = config_.fetch_real_with_explicit_dimension("fiducial_drift_radius", "length");
   }
   // set the fiducial drift length of the Geiger cell:
   if (config_.has_key("fiducial_drift_length")) {
-    _fiducial_drift_length_ = config_.fetch_real("fiducial_drift_length");
-    if (!config_.has_explicit_unit("fiducial_drift_length")) {
-      _fiducial_drift_length_ *= length_unit;
-    }
+    _fiducial_drift_length_ = config_.fetch_real_with_explicit_dimension("fiducial_drift_length", "length");
   }
 
   // set the mean ionization energy in the tracking gas:
-  const double energy_unit = CLHEP::eV;
   if (config_.has_key("mean_ionization_energy")) {
-    _mean_ionization_energy_ = config_.fetch_real("mean_ionization_energy");
-    if (!config_.has_explicit_unit("mean_ionization_energy")) {
-      _mean_ionization_energy_ *= energy_unit;
-    }
+    _mean_ionization_energy_ = config_.fetch_real_with_explicit_dimension("mean_ionization_energy", "energy");
   }
 
   // pickup the ID mapping from the geometry manager:


### PR DESCRIPTION
Changes proposed in this pull request:
- If users want to override default values for parameter, they must provide a correct
dimension otherwise the program throws an error and then do not assume anymore a default dimension
value. This avoid misleading initialization of module by assuming wrong default parameter units.

Does this pull request fix any reported issues?
- Fixes #80 .

Additional comments or information
----------------------------------
1) Even if this compiles and seems to work, this fix needs to wait for this PR https://github.com/BxCppDev/Bayeux/pull/15 to work properly.

2) If this looks ok, then one will have to propagate such good habits to all external modules. 
