### PR TITLE
Lock Falaise's system URN Db Service before registration

### DIFF
--- a/source/falaise/detail/falaise_sys.cc
+++ b/source/falaise/detail/falaise_sys.cc
@@ -240,6 +240,7 @@ void falaise_sys::_initialize_urn_services_() {
     }
     DT_LOG_TRACE(_logging_, "Publishing the URN info DB '"
                                 << urnSetupDb.get_name() << "' to the Bayeux/datatools' kernel...");
+    urnSetupDb.lock();
     urnSetupDb.kernel_push();
     DT_LOG_TRACE(_logging_, "URN info DB has been plugged in the Bayeux/datatools' kernel.");
   }
@@ -295,6 +296,7 @@ void falaise_sys::_shutdown_urn_services_() {
                                 << urnSetupDb.get_name()
                                 << "' from the  Bayeux/datatools's kernel...");
     urnSetupDb.kernel_pop();
+    urnSetupDb.unlock();
     DT_LOG_TRACE(_logging_,
                  "URN info setup DB has been removed from the  Bayeux/datatools kernel.");
     urnSetupDb.reset();

--- a/source/falaise/testing/test_falaise.cxx
+++ b/source/falaise/testing/test_falaise.cxx
@@ -6,10 +6,18 @@
 #include <iostream>
 #include <string>
 
+// Third party:
+// - Bayeux:
+#include <bayeux/datatools/kernel.h>
+#include <bayeux/datatools/library_info.h>
+#include <bayeux/datatools/urn_query_service.h>
+#include <bayeux/datatools/urn_db_service.h>
+
 // This project:
 #include <falaise/falaise.h>
 #include <falaise/resource.h>
 #include <falaise/version.h>
+#include <falaise/detail/falaise_sys.h>
 
 int main(int /* argc_ */, char** /* argv_ */) {
   falaise::initialize();
@@ -17,10 +25,27 @@ int main(int /* argc_ */, char** /* argv_ */) {
   try {
     std::clog << "Test program for the 'Falaise' library." << std::endl;
 
-    std::clog << "Falaise version : " << falaise::version::get_version() << std::endl;
-    std::clog << "Falaise resource dir : '" << falaise::get_resource_dir() << "'" << std::endl;
+    std::clog << "Falaise version       : " << falaise::version::get_version() << std::endl;
+    std::clog << "Falaise resource dir  : '" << falaise::get_resource_dir() << "'" << std::endl;
     std::clog << "Falaise resource file : '" << falaise::get_resource("README.rst") << "'"
               << std::endl;
+
+    {
+      if (datatools::kernel::is_instantiated()) {
+        datatools::kernel & krnl = datatools::kernel::instance();
+        if (krnl.has_library_info_register()) {
+          const datatools::library_info & lib_info_reg = krnl.get_library_info_register();
+          lib_info_reg.tree_dump(std::clog, "Kernel library info register: ");
+          std::clog << std::endl;
+        }
+        if (krnl.get_urn_query().has_db(falaise::detail::falaise_sys::fl_setup_db_name())) {
+          const datatools::urn_db_service & flUrnDb =
+            krnl.get_urn_query().get_db(falaise::detail::falaise_sys::fl_setup_db_name());
+          flUrnDb.tree_dump(std::clog, "Falaise library's URN Database Service: ");
+          std::clog << std::endl;
+        }
+      }
+    }
 
     std::clog << "The end." << std::endl;
   } catch (std::exception& x) {

--- a/source/falaise/testing/test_falaise.cxx
+++ b/source/falaise/testing/test_falaise.cxx
@@ -38,12 +38,14 @@ int main(int /* argc_ */, char** /* argv_ */) {
           lib_info_reg.tree_dump(std::clog, "Kernel library info register: ");
           std::clog << std::endl;
         }
-        if (krnl.get_urn_query().has_db(falaise::detail::falaise_sys::fl_setup_db_name())) {
-          const datatools::urn_db_service & flUrnDb =
-            krnl.get_urn_query().get_db(falaise::detail::falaise_sys::fl_setup_db_name());
-          flUrnDb.tree_dump(std::clog, "Falaise library's URN Database Service: ");
-          std::clog << std::endl;
-        }
+        // Only with Bayeux from 3.3.0 because the 'datatools::urn_query_service::get_db' method
+        // is not available before.
+        // if (krnl.get_urn_query().has_db(falaise::detail::falaise_sys::fl_setup_db_name())) {
+        //   const datatools::urn_db_service & flUrnDb =
+        //     krnl.get_urn_query().get_db(falaise::detail::falaise_sys::fl_setup_db_name());
+        //   flUrnDb.tree_dump(std::clog, "Falaise library's URN Database Service: ");
+        //   std::clog << std::endl;
+        // }
       }
     }
 


### PR DESCRIPTION
Changes proposed in this pull request:
- explicit lock/unlock the Falaise's system URN Database Service at init/reset.
- change the `test_falaise.cxx` program to print the status and contents of embedded services registered in the Bayeux/datatools' kernel.

Does this pull request fix any reported issues?
-
Additional comments or information
----------------------------------
-  Falaise publishes a set of official URNs, corresponding to specific experimental/simulation/reconstruction setups with associated configuration & data files, through a dedicated system URN Database Service.
The service is instantiated as a singleton of the falaise::detail::falaise_sys class.
When loaded, the URN Database Service registers itself to the Bayeux datatools' kernel, making itself visible to and usable by other components/libraries.
A client URN Database Service object (the depender) has the hability to mount the Falaise's system URN Database Service object (the dependee/provider) and then use some URNs registered in this database. However, this operation is only allowed if the dependee service is locked, which means it is not possible to remove or add more URNs in it, to suppress the risk to break dependencies for the depender client service which subscribed to the dependee service.
The current implementation lacks the explicit lock/unlock calls that would enable the mounting
of the Falaise's system URN Database Service by external components. This is considered as a bug.
The proposed solution is the same that was implemented to solve BxCppDev/Bayeux#16.


- see: https://github.com/BxCppDev/Bayeux/issues/16
