### PR TITLE
Make fecom's base_hit comparator call const

### DIFF
--- a/companions/fecom/src/libs/libfecom/fecom/base_hit.cpp
+++ b/companions/fecom/src/libs/libfecom/fecom/base_hit.cpp
@@ -64,7 +64,7 @@ void base_hit::tree_dump(std::ostream& out_, const std::string& title_, const st
   return;
 }
 
-bool base_hit::compare::operator()(const base_hit& a, const base_hit& b) {
+bool base_hit::compare::operator()(const base_hit& a, const base_hit& b) const {
   if (a.hit_id < b.hit_id) {
     return true;
   } else if ((a.hit_id == b.hit_id)) {

--- a/companions/fecom/src/libs/libfecom/fecom/base_hit.hpp
+++ b/companions/fecom/src/libs/libfecom/fecom/base_hit.hpp
@@ -27,7 +27,7 @@ struct base_hit : public datatools::i_serializable {
 
   /// Compare two base hits by hit id
   struct compare {
-    bool operator()(const base_hit& a, const base_hit& b);
+    bool operator()(const base_hit& a, const base_hit& b) const;
   };
 
   /// Compare two base hits by timestamp


### PR DESCRIPTION
Please fill in the following details as appropriate for your pull request.
You can leave any entries that aren't relevant blank. If you think the pull request
will need further commits before being ready for review/merge, prepend "WIP:" to
the title.

Changes proprosed in this pull request:
- single const clarification to `base_hit::compare` call operator

Does this pull request fix any reported issues?
- Fixes #.

Additional comments or information
----------------------------------
AppleClang 9.1 now fails to compile fecom base_hit with a
promoted-to-error warning about base_hit::compare's call
operator not being const.

Make operator explicitly const as it is!

