### PR TITLE
Alpha finder vertex matching fix

### DIFF
--- a/modules/ChargedParticleTracking/source/falaise/snemo/reconstruction/alpha_finder_driver.cc
+++ b/modules/ChargedParticleTracking/source/falaise/snemo/reconstruction/alpha_finder_driver.cc
@@ -436,6 +436,7 @@ namespace snemo {
               // we want to check against the already asigned distance to see
               // if this vertex is closer
               if (distance < _minimal_vertex_distance_ && distance < closest_vertex_distance) {
+                closest_vertex_distance = distance;
                 associated_vertex = last;
               }
             }

--- a/modules/ChargedParticleTracking/source/falaise/snemo/reconstruction/alpha_finder_driver.cc
+++ b/modules/ChargedParticleTracking/source/falaise/snemo/reconstruction/alpha_finder_driver.cc
@@ -142,16 +142,10 @@ namespace snemo {
 
       // Minimal anode time to consider Geiger hit as delayed
       if (setup_.has_key("minimal_delayed_time")) {
-        std::cout << "Has minimal delay time in setup!!!!" << std::endl;
-        std::cout << "Delay time before fetch: " << _minimal_delayed_time_ << std::endl;
         _minimal_delayed_time_ = setup_.fetch_real("minimal_delayed_time");
-        std::cout << "Delay time after fetch: " << _minimal_delayed_time_ << std::endl;
         if (! setup_.has_explicit_unit("minimal_delayed_time")) {
           _minimal_delayed_time_ *= CLHEP::microsecond;
         }
-      }
-      else{
-        std::cout << "Did not find minimal delay time in setup!!!!" << std::endl;
       }
 
       // Minimal distance in XY coordinate between Geiger hits

--- a/modules/EventBrowser/source/CMakeLists.txt
+++ b/modules/EventBrowser/source/CMakeLists.txt
@@ -122,6 +122,8 @@ else()
     set(CMAKE_INSTALL_LIBDIR_OLD "${CMAKE_INSTALL_LIBDIR}")
     set(CMAKE_INSTALL_LIBDIR "${CMAKE_INSTALL_LIBDIR_OLD}/Falaise/modules")
   endif()
+  # Root 6.12 requires additional include path
+  include_directories("${CMAKE_CURRENT_SOURCE_DIR}")
   root_generate_dictionary(event_browser_dict
     "${FalaiseEventBrowserPlugin_DICT_HEADERS}"
     ${__EVENTBROWSER_MODULE_ARG}


### PR DESCRIPTION
Please fill in the following details as appropriate for your pull request.
You can leave any entries that aren't relevant blank. If you think the pull request
will need further commits before being ready for review/merge, prepend "WIP:" to
the title.

Changes proprosed in this pull request:
- Stores closest distance between alpha and prompt track, and associates the alpha to the shortest distance.
- Previously alpha finder arbitrarily selected a prompt vertex to associated the alpha to, as long as it was within the distance thresholds.
- Small change to CMakeLists for compatibility with root 6.12. This may have already been implemented.

Does this pull request fix any reported issues?
- Fixes #.

Additional comments or information
----------------------------------
