### PR TITLE
Always catch exception by reference

### DIFF
--- a/source/falaise/testing/test_property_reader.cxx
+++ b/source/falaise/testing/test_property_reader.cxx
@@ -14,7 +14,7 @@ TEST_CASE("property_reader scalars Work", "") {
 
   SECTION("Integer extraction") {
     REQUIRE(flp::getRequiredValue<int>(test, "foo") == 1);
-    REQUIRE_THROWS_AS(flp::getRequiredValue<double>(test, "foo"), flp::WrongType);
+    REQUIRE_THROWS_AS(flp::getRequiredValue<double>(test, "foo"), flp::WrongType&);
 
     REQUIRE(flp::getValueOrDefault<int>(test, "foo", 42) == 1);
     REQUIRE(flp::getValueOrDefault<int>(test, "ICouldBePresentButAmNot", 42) == 42);
@@ -22,13 +22,13 @@ TEST_CASE("property_reader scalars Work", "") {
 
   SECTION("Real extraction") {
     REQUIRE(flp::getRequiredValue<double>(test, "bar") == Approx(3.14));
-    REQUIRE_THROWS_AS(flp::getRequiredValue<int>(test, "bar"), flp::WrongType);
+    REQUIRE_THROWS_AS(flp::getRequiredValue<int>(test, "bar"), flp::WrongType&);
   }
 
   SECTION("Boolean extraction") {
     REQUIRE(flp::getRequiredValue<bool>(test, "baz"));
     REQUIRE_FALSE(flp::getValueOrDefault<bool>(test, "ICouldBePresentButAmNot", false));
-    REQUIRE_THROWS_AS(flp::getRequiredValue<bool>(test, "foo"), flp::WrongType);
+    REQUIRE_THROWS_AS(flp::getRequiredValue<bool>(test, "foo"), flp::WrongType&);
   }
 
   SECTION("String extraction") {
@@ -40,7 +40,7 @@ TEST_CASE("property_reader scalars Work", "") {
   SECTION("Failure conditions") {
     // Unsupported types should be a compile-time error
     REQUIRE_THROWS_AS(flp::getRequiredValue<double>(test, "IMustBePresentButAmNot"),
-                      flp::MissingKey);
+                      flp::MissingKey&);
   }
 }
 
@@ -68,7 +68,7 @@ TEST_CASE("property_reader vector extraction", "") {
     REQUIRE_NOTHROW(flp::getRequiredValue<std::vector<int> >(test, "singular"));
 
     // ... and is not convertible to a single element
-    REQUIRE_THROWS_AS(flp::getRequiredValue<int>(test, "singular"), flp::WrongType);
+    REQUIRE_THROWS_AS(flp::getRequiredValue<int>(test, "singular"), flp::WrongType&);
 
     // Defaults should work in place
     // NB: test composition does outside macro due to seeming limitation of not

--- a/source/flreconstruct/tests/testFhiclProperties.cc
+++ b/source/flreconstruct/tests/testFhiclProperties.cc
@@ -384,12 +384,12 @@ TEST_CASE("properties conversion works", "") {
   auto metadata = falaise::metadata::read_datatools(fixture);
 
   SECTION("Failure conditions") {
-    REQUIRE_THROWS_AS(metadata.get<bool>("a.bad.path"), falaise::metadata::key_error);
+    REQUIRE_THROWS_AS(metadata.get<bool>("a.bad.path"), falaise::metadata::key_error&);
   }
 
   SECTION("Integer Extraction") {
     REQUIRE(metadata.get<int>("foo") == 42);
-    REQUIRE_THROWS_AS(metadata.get<double>("foo"), falaise::metadata::type_error);
+    REQUIRE_THROWS_AS(metadata.get<double>("foo"), falaise::metadata::type_error&);
     REQUIRE(metadata.get("foo_opt", 24) == 24);
     metadata.put("foo_opt", 234);
     REQUIRE(metadata.get("foo_opt", 4321) == 234);


### PR DESCRIPTION
Changes proprosed in this pull request:
- Fix future gcc 8 warnings but it does not hurt to catch exception by reference as explained here in 2010 https://blog.knatten.org/2010/04/02/always-catch-exceptions-by-reference/