### PR TITLE
Fix interfaces for Boost 1.68

### DIFF
--- a/modules/ChargedParticleTracking/source/falaise/snemo/reconstruction/calorimeter_association_driver.cc
+++ b/modules/ChargedParticleTracking/source/falaise/snemo/reconstruction/calorimeter_association_driver.cc
@@ -230,7 +230,7 @@ void calorimeter_association_driver::_measure_matching_calorimeters_(
       gveto_locator.get_neighbours_ids(a_current_gid, neighbour_ids);
     }
     for (snemo::datamodel::calibrated_data::calorimeter_hit_collection_type::const_iterator jcalo =
-             boost::next(icalo);
+             std::next(icalo);
          jcalo != calorimeter_hits_.end(); ++jcalo) {
       const snemo::datamodel::calibrated_calorimeter_hit& j_calo_hit = jcalo->get();
       const geomtools::geom_id& a_gid = j_calo_hit.get_geom_id();

--- a/modules/GammaClustering/source/falaise/snemo/reconstruction/gamma_clustering_driver.cc
+++ b/modules/GammaClustering/source/falaise/snemo/reconstruction/gamma_clustering_driver.cc
@@ -312,7 +312,7 @@ void gamma_clustering_driver::_get_time_neighbours(cluster_type& cluster_,
   cluster_type::iterator it = cluster_.begin();
   for (; it != cluster_.end(); ++it) {
     const double current_time = it->first;
-    const double next_time = boost::next(it)->first;
+    const double next_time = std::next(it)->first;
     const double delta_time = next_time - current_time;
     if (delta_time > _cluster_time_range_) {
       DT_LOG_TRACE(get_logging_priority(),
@@ -328,8 +328,8 @@ void gamma_clustering_driver::_get_time_neighbours(cluster_type& cluster_,
   // of clusters otherwise clusters_ stays in a frozen state if the cluster
   // is added first and then filled.
   cluster_type a_cluster;
-  a_cluster.insert(boost::next(it), cluster_.end());
-  cluster_.erase(boost::next(it), cluster_.end());
+  a_cluster.insert(std::next(it), cluster_.end());
+  cluster_.erase(std::next(it), cluster_.end());
   clusters_.push_back(a_cluster);
 
   _get_time_neighbours(a_cluster, clusters_);

--- a/modules/GammaClustering/testing/test_gamma_clustering_driver.cxx
+++ b/modules/GammaClustering/testing/test_gamma_clustering_driver.cxx
@@ -64,8 +64,8 @@ void generate_hits(snemo::datamodel::calibrated_data::calorimeter_hit_collection
   return;
 }
 
-int main() {
-  falaise::initialize();
+int main(int argc, char* argv[]) {
+  falaise::initialize(argc, argv);
   int error_code = EXIT_SUCCESS;
   try {
     std::clog << "Test program for the 'gamma_clustering_driver' class." << std::endl;

--- a/source/falaise/snemo/processing/base_tracker_clusterizer.cc
+++ b/source/falaise/snemo/processing/base_tracker_clusterizer.cc
@@ -572,7 +572,7 @@ int base_tracker_clusterizer::process(
       sdm::tracker_clustering_solution &sol_prompt = isol->grab();
       datatools::properties &aux_prompt = sol_prompt.grab_auxiliaries();
       if (!aux_prompt.has_flag(sdm::tracker_clustering_data::prompt_key())) continue;
-      for (sdm::tracker_clustering_data::solution_col_type::iterator jsol = boost::next(isol);
+      for (sdm::tracker_clustering_data::solution_col_type::iterator jsol = std::next(isol);
            jsol != the_solutions.end(); ++jsol) {
         sdm::tracker_clustering_solution &sol_delayed = jsol->grab();
         datatools::properties &aux_delayed = sol_delayed.grab_auxiliaries();

--- a/source/falaise/testing/test_falaise.cxx
+++ b/source/falaise/testing/test_falaise.cxx
@@ -11,8 +11,8 @@
 #include <falaise/resource.h>
 #include <falaise/version.h>
 
-int main(int /* argc_ */, char** /* argv_ */) {
-  falaise::initialize();
+int main(int argc, char** argv) {
+  falaise::initialize(argc, argv);
   int error_code = EXIT_SUCCESS;
   try {
     std::clog << "Test program for the 'Falaise' library." << std::endl;

--- a/source/falaise/testing/test_falaise_tags.cxx
+++ b/source/falaise/testing/test_falaise_tags.cxx
@@ -18,8 +18,8 @@
 #include <falaise/version.h>
 #include <falaise/tags.h>
 
-int main(int /* argc_ */, char** /* argv_ */) {
-  falaise::initialize();
+int main(int argc, char** argv) {
+  falaise::initialize(argc, argv);
   int error_code = EXIT_SUCCESS;
   try {
     std::clog << "Test program for the 'Falaise' library." << std::endl;

--- a/source/falaise/testing/test_io_data.cxx
+++ b/source/falaise/testing/test_io_data.cxx
@@ -25,7 +25,7 @@ struct io_data_config {
 void test_1(const io_data_config& cfg_);
 
 int main(int argc_, char** argv_) {
-  falaise::initialize();
+  falaise::initialize(argc_, argv_);
   int error_code = EXIT_SUCCESS;
   try {
     std::clog << "Test I/O data program for the 'Falaise' library." << std::endl;

--- a/source/flreconstruct/flreconstructmain.cc
+++ b/source/flreconstruct/flreconstructmain.cc
@@ -69,7 +69,7 @@ falaise::exit_code do_flreconstruct(int argc, char* argv[]);
 // MAIN PROGRAM
 //----------------------------------------------------------------------
 int main(int argc, char* argv[]) {
-  falaise::initialize();
+  falaise::initialize(argc, argv);
 
   // - Do the reconstruction
   // Ideally, exceptions SHOULD NOT propagate out of this - the error

--- a/source/flsimulate/flsimulatecfgmain.cc
+++ b/source/flsimulate/flsimulatecfgmain.cc
@@ -93,7 +93,7 @@ falaise::exit_code do_flsimulate_config(int argc, char* argv[]);
 // MAIN PROGRAM
 //----------------------------------------------------------------------
 int main(int argc, char* argv[]) {
-  falaise::initialize();
+  falaise::initialize(argc, argv);
 
   // - Do the configuration.
   falaise::exit_code ret = FLSimulateConfig::do_flsimulate_config(argc, argv);

--- a/source/flsimulate/flsimulatemain.cc
+++ b/source/flsimulate/flsimulatemain.cc
@@ -91,7 +91,7 @@ falaise::exit_code do_metadata(const FLSimulateArgs &, datatools::multi_properti
 // MAIN PROGRAM
 //----------------------------------------------------------------------
 int main(int argc, char *argv[]) {
-  falaise::initialize();
+  falaise::initialize(argc, argv);
 
   // - Do the simulation.
   // Ideally, exceptions SHOULD NOT propagate out of this  - the error


### PR DESCRIPTION
Please fill in the following details as appropriate for your pull request.
You can leave any entries that aren't relevant blank. If you think the pull request
will need further commits before being ready for review/merge, prepend "WIP:" to
the title.

Changes proprosed in this pull request:
- Replace use of obsolete Boost interfaces by `std::` equivalents
- Always pass valid args, argv  to `falaise::initialise` because `boost::program_options` requires non-null pointer.

Does this pull request fix any reported issues?
- Fixes #.

Additional comments or information
----------------------------------
Needed irrespective of requested upstream fixes in Bayeux: bxcppdev/Bayeux#36