### PR TITLE
Apply clang-tidy fixes to Falaise library and applications

### DIFF
--- a/source/falaise/CMakeLists.txt
+++ b/source/falaise/CMakeLists.txt
@@ -71,7 +71,7 @@ set(FalaiseLibrary_TESTS_CATCH)
 include(common.cmake)
 include(app.cmake)
 include(snemo.cmake)
-include(bipo3.cmake)
+#include(bipo3.cmake)
 include(TrackerPreClustering.cmake)
 
 # - Publish headers

--- a/source/falaise/TrackerPreClustering/interface.cc
+++ b/source/falaise/TrackerPreClustering/interface.cc
@@ -15,9 +15,7 @@ void setup_data::set_last_error_message(const std::string& message_) {
   _last_error_message = message_;
 }
 
-setup_data::setup_data() {
-  reset();
-}
+setup_data::setup_data() { reset(); }
 
 void setup_data::reset() {
   logging = datatools::logger::PRIO_WARNING;
@@ -30,7 +28,7 @@ void setup_data::reset() {
 }
 
 bool setup_data::check() const {
-  setup_data* mutable_this = const_cast<setup_data*>(this);
+  auto* mutable_this = const_cast<setup_data*>(this);
   if (cell_size != cell_size) {
     std::ostringstream message;
     message << "TrackerPreClustering::setup_data::check: "

--- a/source/falaise/TrackerPreClustering/testing/event_display.cc
+++ b/source/falaise/TrackerPreClustering/testing/event_display.cc
@@ -14,17 +14,11 @@
 
 namespace TrackerPreClustering {
 
-void event_display::set_cell_size(double cell_size_) {
-  _cell_size_ = cell_size_;
-}
+void event_display::set_cell_size(double cell_size_) { _cell_size_ = cell_size_; }
 
-void event_display::set_nb_layers(unsigned int nb_layers_) {
-  _nb_layers_ = nb_layers_;
-}
+void event_display::set_nb_layers(unsigned int nb_layers_) { _nb_layers_ = nb_layers_; }
 
-void event_display::set_nb_rows(unsigned int nb_rows_) {
-  _nb_rows_ = nb_rows_;
-}
+void event_display::set_nb_rows(unsigned int nb_rows_) { _nb_rows_ = nb_rows_; }
 
 event_display::event_display() {
   _nb_layers_ = 9;
@@ -82,7 +76,7 @@ void event_display::plot_clustered_item(std::ostream& out_, int /* id_ */, doubl
   double z0 = z_;
   double dz0 = ez_;
   out_ << x0 + s << ' ' << y0 + s << ' ' << z0 << std::endl;
-  if (count % 2) {
+  if ((count % 2) != 0) {
     // gnuplot 3D-plot trick
     out_ << x0 + s << ' ' << y0 << ' ' << z0 + dz0 << std::endl;
   }

--- a/source/falaise/TrackerPreClustering/testing/event_generator.cc
+++ b/source/falaise/TrackerPreClustering/testing/event_generator.cc
@@ -29,21 +29,13 @@
 
 namespace TrackerPreClustering {
 
-void event_generator::set_seed(long seed_) {
-  _seed_ = seed_;
-}
+void event_generator::set_seed(long seed_) { _seed_ = seed_; }
 
-void event_generator::set_cell_size(double cell_size_) {
-  _cell_size_ = cell_size_;
-}
+void event_generator::set_cell_size(double cell_size_) { _cell_size_ = cell_size_; }
 
-void event_generator::set_nb_layers(unsigned int nb_layers_) {
-  _nb_layers_ = nb_layers_;
-}
+void event_generator::set_nb_layers(unsigned int nb_layers_) { _nb_layers_ = nb_layers_; }
 
-void event_generator::set_nb_rows(unsigned int nb_rows_) {
-  _nb_rows_ = nb_rows_;
-}
+void event_generator::set_nb_rows(unsigned int nb_rows_) { _nb_rows_ = nb_rows_; }
 
 event_generator::event_generator() {
   set_seed(0);
@@ -74,13 +66,13 @@ void event_generator::reset() {
 
 int event_generator::build_gid(int side_, int layer_, int row_) const {
   int gid = layer_ * 1000 + row_;
-  if (side_ == 0) gid *= -1;
+  if (side_ == 0) {
+    gid *= -1;
+  }
   return gid;
 }
 
-void event_generator::register_gid(int gid_, bool delayed_) {
-  _gids_[gid_] = delayed_;
-}
+void event_generator::register_gid(int gid_, bool delayed_) { _gids_[gid_] = delayed_; }
 
 bool event_generator::has_gid(int gid_) const { return _gids_.find(gid_) != _gids_.end(); }
 
@@ -129,8 +121,10 @@ void event_generator::generate_prompt_gg_hits(std::vector<const gg_hit *> &hits_
         }
         attempts++;
       }
-      if (attempts >= 5) break;
-      h->sterile = uni() < 0.1 ? true : false;
+      if (attempts >= 5) {
+        break;
+      }
+      h->sterile = uni() < 0.1;
       h->peripheral = false;
       h->noisy = false;
       h->missing_top_cathode = false;
@@ -202,8 +196,10 @@ void event_generator::generate_delayed_gg_hits(std::vector<const gg_hit *> &hits
         }
         attempts++;
       }
-      if (attempts >= 5) break;
-      h->sterile = uni() < 0.1 ? true : false;
+      if (attempts >= 5) {
+        break;
+      }
+      h->sterile = uni() < 0.1;
       h->delayed = true;
       h->peripheral = false;
       h->noisy = false;

--- a/source/falaise/TrackerPreClustering/testing/event_generator.cc
+++ b/source/falaise/TrackerPreClustering/testing/event_generator.cc
@@ -52,7 +52,7 @@ event_generator::event_generator(long seed_) {
   initialize();
 }
 
-bool event_generator::is_initialized() { return _generator_.get() != 0; }
+bool event_generator::is_initialized() { return _generator_.get() != nullptr; }
 
 void event_generator::initialize() {
   DT_THROW_IF(is_initialized(), std::logic_error, "Event generator is already initialized!");
@@ -99,7 +99,7 @@ void event_generator::generate_prompt_gg_hits(std::vector<const gg_hit *> &hits_
     double z0 = (-100. + 200. * uni()) * CLHEP::cm;
     int n0 = 0;
     for (unsigned int ihit = 0; ihit < nb_prompt_hits; ihit++) {
-      gg_hit *h = new gg_hit;
+      auto *h = new gg_hit;
       {
         boost::shared_ptr<gg_hit> sp(h);
         _hits_gc_.push_back(sp);
@@ -175,7 +175,7 @@ void event_generator::generate_delayed_gg_hits(std::vector<const gg_hit *> &hits
     double delayed_time = (10. + 4000. * uni()) * CLHEP::microsecond;
     int n0 = 0;
     for (unsigned int ihit = 0; ihit < nb_delayed_hits; ihit++) {
-      gg_hit *h = new gg_hit;
+      auto *h = new gg_hit;
       {
         boost::shared_ptr<gg_hit> sp(h);
         _hits_gc_.push_back(sp);

--- a/source/falaise/TrackerPreClustering/testing/gg_hit.cc
+++ b/source/falaise/TrackerPreClustering/testing/gg_hit.cc
@@ -27,7 +27,6 @@ void gg_hit::set_defaults() {
   noisy = false;
   missing_top_cathode = false;
   missing_bottom_cathode = false;
-  return;
 }
 
 int32_t gg_hit::get_id() const { return id; }
@@ -44,15 +43,9 @@ bool gg_hit::has_geom_id() const {
   return (module >= 0) && (side >= 0) && (layer >= 0) && (row >= 0);
 }
 
-gg_hit::gg_hit() {
-  set_defaults();
-  return;
-}
+gg_hit::gg_hit() { set_defaults(); }
 
-void gg_hit::reset() {
-  set_defaults();
-  return;
-}
+void gg_hit::reset() { set_defaults(); }
 
 bool gg_hit::has_xy() const { return (x == x) && (y == y); }
 

--- a/source/falaise/app/metadata_utils.cc
+++ b/source/falaise/app/metadata_utils.cc
@@ -31,7 +31,6 @@ void metadata_input::reset() {
   digiSetupUrn = "";
   doReconstruction = false;
   recSetupUrn = "";
-  return;
 }
 
 void metadata_input::print(std::ostream& out_) const {
@@ -53,7 +52,6 @@ void metadata_input::print(std::ostream& out_) const {
   out_ << tag << "digiSetupUrn          = " << digiSetupUrn << std::endl;
   out_ << tag << "doReconstruction      = " << std::boolalpha << doReconstruction << std::endl;
   out_ << last_tag << "recSetupUrn           = " << recSetupUrn << std::endl;
-  return;
 }
 
 void metadata_input::scan(const datatools::multi_properties& mp_) {
@@ -146,8 +144,6 @@ void metadata_input::scan(const datatools::multi_properties& mp_) {
     }
 
   }  // Input metadata from FLReconstruct
-
-  return;
 }
 
 metadata_collector::metadata_collector(const uint32_t /*flags_*/) {}
@@ -189,7 +185,7 @@ datatools::multi_properties metadata_collector::get_metadata() const {
   return md;
 }
 
-metadata_scanner::metadata_scanner(const datatools::multi_properties& mp_) : _mp_(mp_) { return; }
+metadata_scanner::metadata_scanner(const datatools::multi_properties& mp_) : _mp_(mp_) {}
 
 bool metadata_scanner::_find_data_in_section_(const std::string& section_name_,
                                               const std::string& section_type_,
@@ -208,7 +204,9 @@ bool metadata_scanner::_find_data_in_section_(const std::string& section_name_,
 
 bool metadata_scanner::check_section(const std::string& section_name_,
                                      const std::string& section_type_) const {
-  if (_mp_.empty()) return false;
+  if (_mp_.empty()) {
+    return false;
+  }
   if (!_mp_.has_key_with_meta(section_name_, section_type_)) {
     return false;
   }
@@ -227,7 +225,9 @@ bool metadata_scanner::find_boolean(const std::string& section_name_,
   if (!_find_data_in_section_(section_name_, section_type_, propKey_, d)) {
     return false;
   }
-  if (!d.is_boolean()) return false;
+  if (!d.is_boolean()) {
+    return false;
+  }
   propValue_ = d.get_boolean_value();
   return true;
 }
@@ -238,7 +238,9 @@ bool metadata_scanner::find_path(const std::string& section_name_, const std::st
   if (!_find_data_in_section_(section_name_, section_type_, propKey_, d)) {
     return false;
   }
-  if (!d.is_path()) return false;
+  if (!d.is_path()) {
+    return false;
+  }
   propValue_ = d.get_string_value();
   return true;
 }
@@ -250,7 +252,9 @@ bool metadata_scanner::find_string(const std::string& section_name_,
   if (!_find_data_in_section_(section_name_, section_type_, propKey_, d)) {
     return false;
   }
-  if (!d.is_string()) return false;
+  if (!d.is_string()) {
+    return false;
+  }
   propValue_ = d.get_string_value();
   return true;
 }
@@ -261,7 +265,9 @@ bool metadata_scanner::find_size(const std::string& section_name_, const std::st
   if (!_find_data_in_section_(section_name_, section_type_, propKey_, d)) {
     return false;
   }
-  if (!d.is_integer()) return false;
+  if (!d.is_integer()) {
+    return false;
+  }
   propValue_ = (std::size_t)d.get_integer_value();
   return true;
 }
@@ -273,7 +279,9 @@ bool metadata_scanner::find_integer(const std::string& section_name_,
   if (!_find_data_in_section_(section_name_, section_type_, propKey_, d)) {
     return false;
   }
-  if (!d.is_integer()) return false;
+  if (!d.is_integer()) {
+    return false;
+  }
   propValue_ = d.get_integer_value();
   return true;
 }
@@ -284,7 +292,9 @@ bool metadata_scanner::find_real(const std::string& section_name_, const std::st
   if (!_find_data_in_section_(section_name_, section_type_, propKey_, d)) {
     return false;
   }
-  if (!d.is_real()) return false;
+  if (!d.is_real()) {
+    return false;
+  }
   propValue_ = d.get_real_value();
   return true;
 }

--- a/source/falaise/bipo3/processing/calorimeter_s2c_module.h
+++ b/source/falaise/bipo3/processing/calorimeter_s2c_module.h
@@ -76,7 +76,7 @@ class calorimeter_s2c_module : public dpp::base_module {
   virtual void reset();
 
   /// Data record processing
-  virtual process_status process(datatools::things& data_);
+  virtual process_status process(datatools::things& event);
 
  protected:
   /// Getting random number generator

--- a/source/falaise/common/user_profile.cc
+++ b/source/falaise/common/user_profile.cc
@@ -7,7 +7,7 @@ namespace common {
 
 const std::set<std::string>& supported_user_profiles() {
   static std::set<std::string> _ups;
-  if (_ups.size() == 0) {
+  if (_ups.empty()) {
     _ups.insert("expert");
     _ups.insert("normal");
     _ups.insert("production");

--- a/source/falaise/config/property_reader.cc
+++ b/source/falaise/config/property_reader.cc
@@ -23,27 +23,28 @@ bool visit_impl(const datatools::properties& p, const std::string& key, bool /*u
   return p.is_boolean(key) && p.is_scalar(key);
 }
 
-bool visit_impl(const datatools::properties& p, const std::string& key, std::string /*unused*/) {
+bool visit_impl(const datatools::properties& p, const std::string& key,
+                const std::string& /*unused*/) {
   return p.is_string(key) && p.is_scalar(key);
 }
 
 bool visit_impl(const datatools::properties& p, const std::string& key,
-                std::vector<int> /*unused*/) {
+                const std::vector<int>& /*unused*/) {
   return p.is_integer(key) && p.is_vector(key);
 }
 
 bool visit_impl(const datatools::properties& p, const std::string& key,
-                std::vector<double> /*unused*/) {
+                const std::vector<double>& /*unused*/) {
   return p.is_real(key) && p.is_vector(key);
 }
 
 bool visit_impl(const datatools::properties& p, const std::string& key,
-                std::vector<bool> /*unused*/) {
+                const std::vector<bool>& /*unused*/) {
   return p.is_boolean(key) && p.is_vector(key);
 }
 
 bool visit_impl(const datatools::properties& p, const std::string& key,
-                std::vector<std::string> /*unused*/) {
+                const std::vector<std::string>& /*unused*/) {
   return p.is_string(key) && p.is_vector(key);
 }
 

--- a/source/falaise/config/property_reader.cc
+++ b/source/falaise/config/property_reader.cc
@@ -11,35 +11,39 @@ namespace type_check_visitor {
 
 namespace detail {
 
-bool visit_impl(const datatools::properties& p, const std::string& key, int) {
+bool visit_impl(const datatools::properties& p, const std::string& key, int /*unused*/) {
   return p.is_integer(key) && p.is_scalar(key);
 }
 
-bool visit_impl(const datatools::properties& p, const std::string& key, double) {
+bool visit_impl(const datatools::properties& p, const std::string& key, double /*unused*/) {
   return p.is_real(key) && p.is_scalar(key);
 }
 
-bool visit_impl(const datatools::properties& p, const std::string& key, bool) {
+bool visit_impl(const datatools::properties& p, const std::string& key, bool /*unused*/) {
   return p.is_boolean(key) && p.is_scalar(key);
 }
 
-bool visit_impl(const datatools::properties& p, const std::string& key, std::string) {
+bool visit_impl(const datatools::properties& p, const std::string& key, std::string /*unused*/) {
   return p.is_string(key) && p.is_scalar(key);
 }
 
-bool visit_impl(const datatools::properties& p, const std::string& key, std::vector<int>) {
+bool visit_impl(const datatools::properties& p, const std::string& key,
+                std::vector<int> /*unused*/) {
   return p.is_integer(key) && p.is_vector(key);
 }
 
-bool visit_impl(const datatools::properties& p, const std::string& key, std::vector<double>) {
+bool visit_impl(const datatools::properties& p, const std::string& key,
+                std::vector<double> /*unused*/) {
   return p.is_real(key) && p.is_vector(key);
 }
 
-bool visit_impl(const datatools::properties& p, const std::string& key, std::vector<bool>) {
+bool visit_impl(const datatools::properties& p, const std::string& key,
+                std::vector<bool> /*unused*/) {
   return p.is_boolean(key) && p.is_vector(key);
 }
 
-bool visit_impl(const datatools::properties& p, const std::string& key, std::vector<std::string>) {
+bool visit_impl(const datatools::properties& p, const std::string& key,
+                std::vector<std::string> /*unused*/) {
   return p.is_string(key) && p.is_vector(key);
 }
 

--- a/source/falaise/config/property_reader.h
+++ b/source/falaise/config/property_reader.h
@@ -70,11 +70,11 @@ namespace detail {
 bool visit_impl(const datatools::properties& p, const std::string& key, int);
 bool visit_impl(const datatools::properties& p, const std::string& key, double);
 bool visit_impl(const datatools::properties& p, const std::string& key, bool);
-bool visit_impl(const datatools::properties& p, const std::string& key, std::string);
-bool visit_impl(const datatools::properties& p, const std::string& key, std::vector<int>);
-bool visit_impl(const datatools::properties& p, const std::string& key, std::vector<double>);
-bool visit_impl(const datatools::properties& p, const std::string& key, std::vector<bool>);
-bool visit_impl(const datatools::properties& p, const std::string& key, std::vector<std::string>);
+bool visit_impl(const datatools::properties& p, const std::string& key, const std::string&);
+bool visit_impl(const datatools::properties& p, const std::string& key, const std::vector<int>&);
+bool visit_impl(const datatools::properties& p, const std::string& key, const std::vector<double>&);
+bool visit_impl(const datatools::properties& p, const std::string& key, const std::vector<bool>&);
+bool visit_impl(const datatools::properties& p, const std::string& key, const std::vector<std::string>&);
 }  // namespace detail
 
 // Compile-time fail on any other type (needs improvement, but does the job

--- a/source/falaise/config/property_set.cpp
+++ b/source/falaise/config/property_set.cpp
@@ -63,38 +63,41 @@ bool property_set::is_type_impl_(std::string const& key, bool /*unused*/) const 
   return ps_.is_boolean(key) && ps_.is_scalar(key);
 }
 
-bool property_set::is_type_impl_(std::string const& key, std::string /*unused*/) const {
+bool property_set::is_type_impl_(std::string const& key, const std::string& /*unused*/) const {
   // Request for raw string implies a non-path type string is wanted
   return ps_.is_string(key) && (!ps_.is_explicit_path(key)) && ps_.is_scalar(key);
 }
 
-bool property_set::is_type_impl_(std::string const& key, falaise::config::path /*unused*/) const {
+bool property_set::is_type_impl_(std::string const& key,
+                                 const falaise::config::path& /*unused*/) const {
   return ps_.is_explicit_path(key) && ps_.is_scalar(key);
 }
 
 bool property_set::is_type_impl_(std::string const& key,
-                                 falaise::config::quantity /*unused*/) const {
+                                 const falaise::config::quantity& /*unused*/) const {
   // Quantity must be real, and have explicit unit *and* unit symbol
   return ps_.is_real(key) && ps_.has_explicit_unit(key) && ps_.has_unit_symbol(key) &&
          ps_.is_scalar(key);
 }
 
-bool property_set::is_type_impl_(std::string const& key, std::vector<int> /*unused*/) const {
+bool property_set::is_type_impl_(std::string const& key, const std::vector<int>& /*unused*/) const {
   return ps_.is_integer(key) && ps_.is_vector(key);
 }
 
-bool property_set::is_type_impl_(std::string const& key, std::vector<double> /*unused*/) const {
+bool property_set::is_type_impl_(std::string const& key,
+                                 const std::vector<double>& /*unused*/) const {
   // vector of raw doubles is always dimensionless
   return ps_.is_real(key) && (!ps_.has_explicit_unit(key)) && (!ps_.has_unit_symbol(key)) &&
          ps_.is_vector(key);
 }
 
-bool property_set::is_type_impl_(std::string const& key, std::vector<bool> /*unused*/) const {
+bool property_set::is_type_impl_(std::string const& key,
+                                 const std::vector<bool>& /*unused*/) const {
   return ps_.is_boolean(key) && ps_.is_vector(key);
 }
 
 bool property_set::is_type_impl_(std::string const& key,
-                                 std::vector<std::string> /*unused*/) const {
+                                 const std::vector<std::string>& /*unused*/) const {
   return ps_.is_string(key) && ps_.is_vector(key);
 }
 

--- a/source/falaise/config/property_set.cpp
+++ b/source/falaise/config/property_set.cpp
@@ -25,16 +25,14 @@ bool property_set::is_key_to_sequence(std::string const& key) const {
 
 bool property_set::is_key_to_property_set(std::string const& key) const {
   // Has to be a key and not a sequence/property
-  if ( is_key_to_property(key) || is_key_to_sequence(key) ) {
+  if (is_key_to_property(key) || is_key_to_sequence(key)) {
     return false;
   }
 
   // Otherwise, must have > 0 keys starting with "prefix."
   auto keyCount = ps_.keys_starting_with(key + ".");
-  return keyCount.size() > 0 ? true : false;
+  return !keyCount.empty();
 }
-
-
 
 std::string property_set::to_string() const {
   std::ostringstream oss;
@@ -51,50 +49,52 @@ bool property_set::erase(std::string const& key) {
   return false;
 }
 
-bool property_set::is_type_impl_(std::string const& key, int) const {
+bool property_set::is_type_impl_(std::string const& key, int /*unused*/) const {
   return ps_.is_integer(key) && ps_.is_scalar(key);
 }
 
-bool property_set::is_type_impl_(std::string const& key, double) const {
+bool property_set::is_type_impl_(std::string const& key, double /*unused*/) const {
   // Request for raw double implies a dimensionless number is wanted
   return ps_.is_real(key) && (!ps_.has_explicit_unit(key)) && (!ps_.has_unit_symbol(key)) &&
          ps_.is_scalar(key);
 }
 
-bool property_set::is_type_impl_(std::string const& key, bool) const {
+bool property_set::is_type_impl_(std::string const& key, bool /*unused*/) const {
   return ps_.is_boolean(key) && ps_.is_scalar(key);
 }
 
-bool property_set::is_type_impl_(std::string const& key, std::string) const {
+bool property_set::is_type_impl_(std::string const& key, std::string /*unused*/) const {
   // Request for raw string implies a non-path type string is wanted
   return ps_.is_string(key) && (!ps_.is_explicit_path(key)) && ps_.is_scalar(key);
 }
 
-bool property_set::is_type_impl_(std::string const& key, falaise::config::path) const {
+bool property_set::is_type_impl_(std::string const& key, falaise::config::path /*unused*/) const {
   return ps_.is_explicit_path(key) && ps_.is_scalar(key);
 }
 
-bool property_set::is_type_impl_(std::string const& key, falaise::config::quantity) const {
+bool property_set::is_type_impl_(std::string const& key,
+                                 falaise::config::quantity /*unused*/) const {
   // Quantity must be real, and have explicit unit *and* unit symbol
   return ps_.is_real(key) && ps_.has_explicit_unit(key) && ps_.has_unit_symbol(key) &&
          ps_.is_scalar(key);
 }
 
-bool property_set::is_type_impl_(std::string const& key, std::vector<int>) const {
+bool property_set::is_type_impl_(std::string const& key, std::vector<int> /*unused*/) const {
   return ps_.is_integer(key) && ps_.is_vector(key);
 }
 
-bool property_set::is_type_impl_(std::string const& key, std::vector<double>) const {
+bool property_set::is_type_impl_(std::string const& key, std::vector<double> /*unused*/) const {
   // vector of raw doubles is always dimensionless
   return ps_.is_real(key) && (!ps_.has_explicit_unit(key)) && (!ps_.has_unit_symbol(key)) &&
          ps_.is_vector(key);
 }
 
-bool property_set::is_type_impl_(std::string const& key, std::vector<bool>) const {
+bool property_set::is_type_impl_(std::string const& key, std::vector<bool> /*unused*/) const {
   return ps_.is_boolean(key) && ps_.is_vector(key);
 }
 
-bool property_set::is_type_impl_(std::string const& key, std::vector<std::string>) const {
+bool property_set::is_type_impl_(std::string const& key,
+                                 std::vector<std::string> /*unused*/) const {
   return ps_.is_string(key) && ps_.is_vector(key);
 }
 

--- a/source/falaise/config/property_set.h
+++ b/source/falaise/config/property_set.h
@@ -360,26 +360,26 @@ class property_set {
   bool is_type_impl_(std::string const& key, bool) const;
 
   //! Return true if value at key is a non-path std::string
-  bool is_type_impl_(std::string const& key, std::string) const;
+  bool is_type_impl_(std::string const& key, const std::string&) const;
 
   //! Return true if value at key is a falaise::path
-  bool is_type_impl_(std::string const& key, falaise::config::path) const;
+  bool is_type_impl_(std::string const& key, const falaise::config::path&) const;
 
   //! Return true if value at key is a falaise::quantity
-  bool is_type_impl_(std::string const& key, falaise::config::quantity) const;
+  bool is_type_impl_(std::string const& key, const falaise::config::quantity&) const;
 
   //! Return true if value at key is a std::vector<int>
-  bool is_type_impl_(std::string const& key, std::vector<int>) const;
+  bool is_type_impl_(std::string const& key, const std::vector<int>&) const;
 
   //! Return true if value at key is a std::vector<double> (dimensionless
   //! doubles)
-  bool is_type_impl_(std::string const& key, std::vector<double>) const;
+  bool is_type_impl_(std::string const& key, const std::vector<double>&) const;
 
   //! Return true if value at key is a std::vector<bool>
-  bool is_type_impl_(std::string const& key, std::vector<bool>) const;
+  bool is_type_impl_(std::string const& key, const std::vector<bool>&) const;
 
   //! Return true if value at key is a std::vector<std::string>
-  bool is_type_impl_(std::string const& key, std::vector<std::string>) const;
+  bool is_type_impl_(std::string const& key, const std::vector<std::string>&) const;
 
   //! Insert key-value pair
   /*!
@@ -450,7 +450,8 @@ T property_set::get(std::string const& key, T const& default_value) const {
 
 // Specialization of get for @ref property_set
 template <>
-inline property_set property_set::get(std::string const& key, property_set const& default_value) const {
+inline property_set property_set::get(std::string const& key,
+                                      property_set const& default_value) const {
   if (!is_key_to_property_set(key)) {
     return default_value;
   }
@@ -470,13 +471,13 @@ void property_set::put(std::string const& key, T const& value) {
 // Specialization of put for @ref property_set
 template <>
 inline void property_set::put(std::string const& key, property_set const& value) {
- // Check both key/table existence
+  // Check both key/table existence
   if (ps_.has_key(key) || is_key_to_property_set(key)) {
     throw existing_key_error{"property_set already contains key " + key};
   }
   // Have to resort to the low level interface to put data in
   for (auto& subkey : (value.ps_).keys()) {
-    ps_.store(key+"."+subkey, (value.ps_).get(subkey));
+    ps_.store(key + "." + subkey, (value.ps_).get(subkey));
   }
 }
 
@@ -520,7 +521,8 @@ inline void property_set::put_impl_(std::string const& key, falaise::config::pat
 
 //! Private specialization of put_impl_ for @ref quantity
 template <>
-inline void property_set::put_impl_(std::string const& key, falaise::config::quantity const& value) {
+inline void property_set::put_impl_(std::string const& key,
+                                    falaise::config::quantity const& value) {
   ps_.store_with_explicit_unit(key, value.value());
   ps_.set_unit_symbol(key, value.unit());
 }
@@ -546,7 +548,8 @@ inline void property_set::get_impl_(std::string const& key, falaise::config::pat
 
 // Private specialization of get_impl_ for @ref units::quantity type
 template <>
-inline void property_set::get_impl_(std::string const& key, falaise::config::quantity& result) const {
+inline void property_set::get_impl_(std::string const& key,
+                                    falaise::config::quantity& result) const {
   result = {ps_.fetch_real_with_explicit_unit(key), ps_.get_unit_symbol(key)};
 }
 

--- a/source/falaise/config/quantity.cpp
+++ b/source/falaise/config/quantity.cpp
@@ -1,8 +1,10 @@
 #include "falaise/config/quantity.h"
 
+#include <utility>
+
 namespace falaise {
 namespace config {
-quantity::quantity(double value, std::string const& unit) : value_(value), unit_name(unit) {
+quantity::quantity(double value, std::string  unit) : value_(value), unit_name(std::move(unit)) {
   if (!datatools::units::find_unit(unit_name, unit_scale, dimension_name)) {
     throw unknown_unit_error{"unit '" + unit_name + "' is unknown"};
   }

--- a/source/falaise/config/quantity.h
+++ b/source/falaise/config/quantity.h
@@ -101,7 +101,7 @@ class quantity {
    * \param[in] unit @ref datatools::units::unit tag
    * \throws falaise::config::unknown_unit_error if unit is not supported by @ref datatools::units
    */
-  quantity(double value, std::string const& unit);
+  quantity(double value, std::string unit);
 
   //! Destructor
   virtual ~quantity() = default;

--- a/source/falaise/detail/falaise_sys.cc
+++ b/source/falaise/detail/falaise_sys.cc
@@ -38,7 +38,7 @@ const std::string &falaise_sys::fl_resource_resolver_name() {
 datatools::logger::priority falaise_sys::process_logging_env() {
   datatools::logger::priority logging = datatools::logger::PRIO_FATAL;
   char *l = getenv("FALAISE_SYS_LOGGING");
-  if (l) {
+  if (l != nullptr) {
     std::string level_label(l);
     ::datatools::logger::priority prio = ::datatools::logger::get_priority(level_label);
     if (prio != ::datatools::logger::PRIO_UNDEFINED) {
@@ -63,7 +63,6 @@ falaise_sys::falaise_sys() {
               "Falaise system singleton is already set!");
   falaise_sys::_instance_ = this;
   DT_LOG_TRACE_EXITING(_logging_);
-  return;
 }
 
 falaise_sys::~falaise_sys() {
@@ -73,7 +72,6 @@ falaise_sys::~falaise_sys() {
   }
   falaise_sys::_instance_ = nullptr;
   DT_LOG_TRACE_EXITING(_logging_);
-  return;
 }
 
 datatools::logger::priority falaise_sys::get_logging() const { return _logging_; }
@@ -99,7 +97,6 @@ void falaise_sys::initialize() {
 
   _initialized_ = true;
   DT_LOG_TRACE_EXITING(_logging_);
-  return;
 }
 
 void falaise_sys::shutdown() {
@@ -119,7 +116,6 @@ void falaise_sys::shutdown() {
   _libinfo_deregistration_();
 
   DT_LOG_TRACE_EXITING(_logging_);
-  return;
 }
 
 datatools::service_manager &falaise_sys::grab_services() { return _services_; }
@@ -194,7 +190,6 @@ void falaise_sys::_libinfo_registration_() {
   }
 
   DT_LOG_TRACE_EXITING(_logging_);
-  return;
 }
 
 void falaise_sys::_libinfo_deregistration_() {
@@ -219,7 +214,6 @@ void falaise_sys::_libinfo_deregistration_() {
   }
 
   DT_LOG_TRACE_EXITING(_logging_);
-  return;
 }
 
 void falaise_sys::_initialize_urn_services_() {
@@ -268,7 +262,6 @@ void falaise_sys::_initialize_urn_services_() {
   }
 
   DT_LOG_TRACE_EXITING(_logging_);
-  return;
 }
 
 void falaise_sys::_shutdown_urn_services_() {
@@ -303,7 +296,6 @@ void falaise_sys::_shutdown_urn_services_() {
   }
 
   DT_LOG_TRACE_EXITING(_logging_);
-  return;
 }
 
 }  // end of namespace detail

--- a/source/falaise/resource.cc.in
+++ b/source/falaise/resource.cc.in
@@ -97,7 +97,7 @@ namespace {
   }
 
   std::string getLibraryDir() {
-    char* exePath(0);
+    char* exePath(nullptr);
     exePath = br_find_exe_dir("");
     boost::filesystem::path sExePath(exePath);
     free(exePath);

--- a/source/falaise/snemo/cuts/calibrated_data_cut.cc
+++ b/source/falaise/snemo/cuts/calibrated_data_cut.cc
@@ -34,43 +34,40 @@ void calibrated_data_cut::_set_defaults() {
   _hit_category_range_max_ = -1;
   _tracker_hit_trait_bits_ = snemo::datamodel::calibrated_tracker_hit::none;
   _tracker_hit_delay_time_ = 0.0 * CLHEP::microsecond;
-  return;
 }
 
 void calibrated_data_cut::set_CD_label(const std::string& CD_label_) {
   DT_THROW_IF(is_initialized(), std::logic_error,
               "Cut '" << get_name() << "' is already initialized ! ");
   _CD_label_ = CD_label_;
-  return;
 }
 
 const std::string& calibrated_data_cut::get_CD_label() const { return _CD_label_; }
 
 uint32_t calibrated_data_cut::get_mode() const { return _mode_; }
 
-bool calibrated_data_cut::is_mode_flag() const { return _mode_ & MODE_FLAG; }
+bool calibrated_data_cut::is_mode_flag() const { return (_mode_ & MODE_FLAG) != 0u; }
 
 bool calibrated_data_cut::is_mode_range_hit_category() const {
-  return _mode_ & MODE_RANGE_HIT_CATEGORY;
+  return (_mode_ & MODE_RANGE_HIT_CATEGORY) != 0u;
 }
 
 bool calibrated_data_cut::is_mode_has_hit_category() const {
-  return _mode_ & MODE_HAS_HIT_CATEGORY;
+  return (_mode_ & MODE_HAS_HIT_CATEGORY) != 0u;
 }
 
 bool calibrated_data_cut::is_mode_tracker_hit_has_traits() const {
-  return _mode_ & MODE_TRACKER_HIT_HAS_TRAITS;
+  return (_mode_ & MODE_TRACKER_HIT_HAS_TRAITS) != 0u;
 }
 
 bool calibrated_data_cut::is_mode_tracker_hit_is_delayed() const {
-  return _mode_ & MODE_TRACKER_HIT_IS_DELAYED;
+  return (_mode_ & MODE_TRACKER_HIT_IS_DELAYED) != 0u;
 }
 
 void calibrated_data_cut::set_flag_name(const std::string& flag_name_) {
   DT_THROW_IF(is_initialized(), std::logic_error,
               "Cut '" << get_name() << "' is already initialized ! ");
   _flag_name_ = flag_name_;
-  return;
 }
 
 const std::string& calibrated_data_cut::get_flag_name() const { return _flag_name_; }
@@ -78,19 +75,17 @@ const std::string& calibrated_data_cut::get_flag_name() const { return _flag_nam
 calibrated_data_cut::calibrated_data_cut(datatools::logger::priority logger_priority_)
     : cuts::i_cut(logger_priority_) {
   _set_defaults();
-  return;
 }
 
 calibrated_data_cut::~calibrated_data_cut() {
-  if (is_initialized()) this->calibrated_data_cut::reset();
-  return;
+  if (is_initialized()) { this->calibrated_data_cut::reset();
+}
 }
 
 void calibrated_data_cut::reset() {
   _set_defaults();
   this->i_cut::_reset();
   this->i_cut::_set_initialized(false);
-  return;
 }
 
 void calibrated_data_cut::initialize(const datatools::properties& configuration_,
@@ -230,7 +225,6 @@ void calibrated_data_cut::initialize(const datatools::properties& configuration_
   }
 
   this->i_cut::_set_initialized(true);
-  return;
 }
 
 int calibrated_data_cut::_accept() {

--- a/source/falaise/snemo/cuts/calibrated_data_cut.cc
+++ b/source/falaise/snemo/cuts/calibrated_data_cut.cc
@@ -78,8 +78,9 @@ calibrated_data_cut::calibrated_data_cut(datatools::logger::priority logger_prio
 }
 
 calibrated_data_cut::~calibrated_data_cut() {
-  if (is_initialized()) { this->calibrated_data_cut::reset();
-}
+  if (is_initialized()) {
+    this->calibrated_data_cut::reset();
+  }
 }
 
 void calibrated_data_cut::reset() {
@@ -189,8 +190,7 @@ void calibrated_data_cut::initialize(const datatools::properties& configuration_
                   "Missing 'tracker_hit_has_traits.bits_name' property !");
       std::vector<std::string> bits_name;
       configuration_.fetch("tracker_hit_has_traits.bits_name", bits_name);
-      for (size_t i = 0; i < bits_name.size(); ++i) {
-        const std::string& bit_name = bits_name[i];
+      for (const auto& bit_name : bits_name) {
         if (bit_name == "delayed") {
           _tracker_hit_trait_bits_ |= snemo::datamodel::calibrated_tracker_hit::delayed;
         } else if (bit_name == "noisy") {
@@ -218,8 +218,8 @@ void calibrated_data_cut::initialize(const datatools::properties& configuration_
     if (is_mode_tracker_hit_is_delayed()) {
       DT_LOG_DEBUG(get_logging_priority(), "Using TRACKER_HIT_IS_DELAYED mode...");
       if (configuration_.has_key("tracker_hit_is_delayed.delay_time")) {
-        _tracker_hit_delay_time_ =
-          configuration_.fetch_real_with_explicit_dimension("tracker_hit_is_delayed.delay_time", "time");
+        _tracker_hit_delay_time_ = configuration_.fetch_real_with_explicit_dimension(
+            "tracker_hit_is_delayed.delay_time", "time");
       }
     }  // end of is_mode_tracker_hit_is_delayed
   }
@@ -231,7 +231,7 @@ int calibrated_data_cut::_accept() {
   uint32_t cut_returned = cuts::SELECTION_INAPPLICABLE;
 
   // Get event record
-  const datatools::things& ER = get_user_data<datatools::things>();
+  const auto& ER = get_user_data<datatools::things>();
 
   if (!ER.has(_CD_label_)) {
     DT_LOG_DEBUG(get_logging_priority(), "Event record has no '" << _CD_label_ << "' bank !");
@@ -239,8 +239,7 @@ int calibrated_data_cut::_accept() {
   }
 
   // Get calibrated data bank
-  const snemo::datamodel::calibrated_data& CD =
-      ER.get<snemo::datamodel::calibrated_data>(_CD_label_);
+  const auto& CD = ER.get<snemo::datamodel::calibrated_data>(_CD_label_);
 
   // Check if the calibrated data has a property flag with a specific name :
   bool check_flag = true;
@@ -317,10 +316,8 @@ int calibrated_data_cut::_accept() {
     check_tracker_hit_has_traits = false;
     const snemo::datamodel::calibrated_data::tracker_hit_collection_type& hits =
         CD.calibrated_tracker_hits();
-    for (snemo::datamodel::calibrated_data::tracker_hit_collection_type::const_iterator ihit =
-             hits.begin();
-         ihit != hits.end(); ++ihit) {
-      const snemo::datamodel::calibrated_tracker_hit& a_hit = ihit->get();
+    for (const auto& hit : hits) {
+      const snemo::datamodel::calibrated_tracker_hit& a_hit = hit.get();
       if (a_hit.get_trait_bit(_tracker_hit_trait_bits_)) {
         check_tracker_hit_has_traits = true;
         break;
@@ -340,10 +337,8 @@ int calibrated_data_cut::_accept() {
     check_tracker_hit_is_delayed = false;
     const snemo::datamodel::calibrated_data::tracker_hit_collection_type& hits =
         CD.calibrated_tracker_hits();
-    for (snemo::datamodel::calibrated_data::tracker_hit_collection_type::const_iterator ihit =
-             hits.begin();
-         ihit != hits.end(); ++ihit) {
-      const snemo::datamodel::calibrated_tracker_hit& a_hit = ihit->get();
+    for (const auto& hit : hits) {
+      const snemo::datamodel::calibrated_tracker_hit& a_hit = hit.get();
       if (a_hit.is_delayed() && a_hit.get_delayed_time() > _tracker_hit_delay_time_) {
         check_tracker_hit_is_delayed = true;
         break;

--- a/source/falaise/snemo/cuts/event_header_cut.cc
+++ b/source/falaise/snemo/cuts/event_header_cut.cc
@@ -31,51 +31,42 @@ void event_header_cut::_set_defaults() {
   _run_number_max_ = -1;
   _event_number_min_ = -1;
   _event_number_max_ = -1;
-  return;
 }
 
-void event_header_cut::set_EH_label(const std::string& EH_label_) {
-  _EH_label_ = EH_label_;
-  return;
-}
+void event_header_cut::set_EH_label(const std::string& EH_label_) { _EH_label_ = EH_label_; }
 
 const std::string& event_header_cut::get_EH_label() const { return _EH_label_; }
 
 uint32_t event_header_cut::get_mode() const { return _mode_; }
 
-bool event_header_cut::is_mode_flag() const { return _mode_ & MODE_FLAG; }
+bool event_header_cut::is_mode_flag() const { return (_mode_ & MODE_FLAG) != 0u; }
 
-bool event_header_cut::is_mode_run_number() const { return _mode_ & MODE_RUN_NUMBER; }
+bool event_header_cut::is_mode_run_number() const { return (_mode_ & MODE_RUN_NUMBER) != 0u; }
 
-bool event_header_cut::is_mode_event_number() const { return _mode_ & MODE_EVENT_NUMBER; }
+bool event_header_cut::is_mode_event_number() const { return (_mode_ & MODE_EVENT_NUMBER) != 0u; }
 
-bool event_header_cut::is_mode_list_of_event_ids() const { return _mode_ & MODE_LIST_OF_EVENT_IDS; }
-
-void event_header_cut::set_flag_name(const std::string& flag_name_) {
-  _flag_name_ = flag_name_;
-  return;
+bool event_header_cut::is_mode_list_of_event_ids() const {
+  return (_mode_ & MODE_LIST_OF_EVENT_IDS) != 0u;
 }
+
+void event_header_cut::set_flag_name(const std::string& flag_name_) { _flag_name_ = flag_name_; }
 
 const std::string& event_header_cut::get_flag_name() const { return _flag_name_; }
 
 void event_header_cut::set_run_number_min(int run_number_min_) {
   _run_number_min_ = run_number_min_ >= 0 ? run_number_min_ : -1;
-  return;
 }
 
 void event_header_cut::set_run_number_max(int run_number_max_) {
   _run_number_max_ = run_number_max_ >= 0 ? run_number_max_ : -1;
-  return;
 }
 
 void event_header_cut::set_event_number_min(int event_number_min_) {
   _event_number_min_ = event_number_min_ >= 0 ? event_number_min_ : -1;
-  return;
 }
 
 void event_header_cut::set_event_number_max(int event_number_max_) {
   _event_number_max_ = event_number_max_ >= 0 ? event_number_max_ : -1;
-  return;
 }
 
 void event_header_cut::list_of_event_ids_dump(std::ostream& out_) const {
@@ -83,7 +74,6 @@ void event_header_cut::list_of_event_ids_dump(std::ostream& out_) const {
        i != _list_of_events_ids_.end(); i++) {
     out_ << *i << std::endl;
   }
-  return;
 }
 
 void event_header_cut::list_of_event_ids_load(const std::string& filename_) {
@@ -119,29 +109,29 @@ void event_header_cut::list_of_event_ids_load(const std::string& filename_) {
       }
     }
     ifs >> std::ws;
-    if (ifs.eof()) break;
+    if (ifs.eof()) {
+      break;
+    }
   }
 
   _mode_ |= MODE_LIST_OF_EVENT_IDS;
-  return;
 }
 
 event_header_cut::event_header_cut(datatools::logger::priority logger_priority_)
     : cuts::i_cut(logger_priority_) {
   _set_defaults();
-  return;
 }
 
 event_header_cut::~event_header_cut() {
-  if (is_initialized()) this->event_header_cut::reset();
-  return;
+  if (is_initialized()) {
+    this->event_header_cut::reset();
+  }
 }
 
 void event_header_cut::reset() {
   _set_defaults();
   this->i_cut::_reset();
   this->i_cut::_set_initialized(false);
-  return;
 }
 
 void event_header_cut::initialize(const datatools::properties& configuration_,
@@ -259,7 +249,6 @@ void event_header_cut::initialize(const datatools::properties& configuration_,
   }
 
   this->i_cut::_set_initialized(true);
-  return;
 }
 
 int event_header_cut::_accept() {
@@ -296,10 +285,14 @@ int event_header_cut::_accept() {
     const int rn = EH.get_id().get_run_number();
     bool check = true;
     if (_run_number_min_ >= 0) {
-      if (rn < _run_number_min_) check = false;
+      if (rn < _run_number_min_) {
+        check = false;
+      }
     }
     if (_run_number_max_ >= 0) {
-      if (rn > _run_number_max_) check = false;
+      if (rn > _run_number_max_) {
+        check = false;
+      }
     }
     if (!check) {
       check_run_number = false;
@@ -325,10 +318,14 @@ int event_header_cut::_accept() {
     const int en = EH.get_id().get_event_number();
     bool check = true;
     if (_event_number_min_ >= 0) {
-      if (en < _event_number_min_) check = false;
+      if (en < _event_number_min_) {
+        check = false;
+      }
     }
     if (_event_number_max_ >= 0) {
-      if (en > _event_number_max_) check = false;
+      if (en > _event_number_max_) {
+        check = false;
+      }
     }
     if (!check) {
       check_event_number = false;

--- a/source/falaise/snemo/cuts/event_header_cut.cc
+++ b/source/falaise/snemo/cuts/event_header_cut.cc
@@ -70,9 +70,8 @@ void event_header_cut::set_event_number_max(int event_number_max_) {
 }
 
 void event_header_cut::list_of_event_ids_dump(std::ostream& out_) const {
-  for (std::set<datatools::event_id>::const_iterator i = _list_of_events_ids_.begin();
-       i != _list_of_events_ids_.end(); i++) {
-    out_ << *i << std::endl;
+  for (const auto& _list_of_events_id : _list_of_events_ids_) {
+    out_ << _list_of_events_id << std::endl;
   }
 }
 
@@ -224,12 +223,12 @@ void event_header_cut::initialize(const datatools::properties& configuration_,
       if (configuration_.has_key("list_of_event_ids.ids")) {
         std::vector<std::string> str_ids;
         configuration_.fetch("list_of_event_ids.ids", str_ids);
-        for (size_t i = 0; i < str_ids.size(); i++) {
-          std::istringstream id_iss(str_ids[i]);
+        for (const auto& str_id : str_ids) {
+          std::istringstream id_iss(str_id);
           datatools::event_id the_event_id;
           id_iss >> the_event_id;
           DT_THROW_IF(!id_iss, std::logic_error,
-                      "Invalid format for event ID ('" << str_ids[i] << "') !");
+                      "Invalid format for event ID ('" << str_id << "') !");
           _list_of_events_ids_.insert(the_event_id);
         }
         count++;
@@ -255,7 +254,7 @@ int event_header_cut::_accept() {
   uint32_t cut_returned = cuts::SELECTION_INAPPLICABLE;
 
   // Get event record
-  const datatools::things& ER = get_user_data<datatools::things>();
+  const auto& ER = get_user_data<datatools::things>();
 
   if (!ER.has(_EH_label_)) {
     DT_LOG_DEBUG(get_logging_priority(), "Event record has no '" << _EH_label_ << "' bank !");
@@ -263,7 +262,7 @@ int event_header_cut::_accept() {
   }
 
   // Get event header bank
-  const snemo::datamodel::event_header& EH = ER.get<snemo::datamodel::event_header>(_EH_label_);
+  const auto& EH = ER.get<snemo::datamodel::event_header>(_EH_label_);
 
   // Check if the event header has a property flag with a specific name :
   bool check_flag = true;
@@ -348,7 +347,7 @@ int event_header_cut::_accept() {
     if (!EH.get_id().is_valid()) {
       return cut_returned;
     }
-    std::set<datatools::event_id>::const_iterator found = _list_of_events_ids_.find(EH.get_id());
+    auto found = _list_of_events_ids_.find(EH.get_id());
     bool check = true;
     if (found == _list_of_events_ids_.end()) {
       check = false;

--- a/source/falaise/snemo/cuts/particle_track_cut.cc
+++ b/source/falaise/snemo/cuts/particle_track_cut.cc
@@ -28,45 +28,42 @@ void particle_track_cut::_set_defaults() {
   _calorimeter_hits_range_category_ = "";
   _calorimeter_hits_range_min_ = -1;
   _calorimeter_hits_range_max_ = -1;
-  return;
 }
 
 uint32_t particle_track_cut::get_mode() const { return _mode_; }
 
-bool particle_track_cut::is_mode_flag() const { return _mode_ & MODE_FLAG; }
+bool particle_track_cut::is_mode_flag() const { return (_mode_ & MODE_FLAG) != 0u; }
 
 bool particle_track_cut::is_mode_has_associated_calorimeter_hits() const {
-  return _mode_ & MODE_HAS_ASSOCIATED_CALORIMETER_HITS;
+  return (_mode_ & MODE_HAS_ASSOCIATED_CALORIMETER_HITS) != 0u;
 }
 
 bool particle_track_cut::is_mode_range_associated_calorimeter_hits() const {
-  return _mode_ & MODE_RANGE_ASSOCIATED_CALORIMETER_HITS;
+  return (_mode_ & MODE_RANGE_ASSOCIATED_CALORIMETER_HITS) != 0u;
 }
 
-bool particle_track_cut::is_mode_has_vertex() const { return _mode_ & MODE_HAS_VERTEX; }
+bool particle_track_cut::is_mode_has_vertex() const { return (_mode_ & MODE_HAS_VERTEX) != 0u; }
 
-bool particle_track_cut::is_mode_has_charge() const { return _mode_ & MODE_HAS_CHARGE; }
+bool particle_track_cut::is_mode_has_charge() const { return (_mode_ & MODE_HAS_CHARGE) != 0u; }
 
 bool particle_track_cut::is_mode_has_delayed_cluster() const {
-  return _mode_ & MODE_HAS_DELAYED_CLUSTER;
+  return (_mode_ & MODE_HAS_DELAYED_CLUSTER) != 0u;
 }
 
 particle_track_cut::particle_track_cut(datatools::logger::priority logger_priority_)
     : cuts::i_cut(logger_priority_) {
   _set_defaults();
-  return;
 }
 
 particle_track_cut::~particle_track_cut() {
-  if (is_initialized()) this->particle_track_cut::reset();
-  return;
+  if (is_initialized()) { this->particle_track_cut::reset();
+}
 }
 
 void particle_track_cut::reset() {
   _set_defaults();
   this->i_cut::_reset();
   this->i_cut::_set_initialized(false);
-  return;
 }
 
 void particle_track_cut::initialize(const datatools::properties& configuration_,
@@ -177,7 +174,6 @@ void particle_track_cut::initialize(const datatools::properties& configuration_,
   }
 
   this->i_cut::_set_initialized(true);
-  return;
 }
 
 int particle_track_cut::_accept() {

--- a/source/falaise/snemo/cuts/particle_track_cut.cc
+++ b/source/falaise/snemo/cuts/particle_track_cut.cc
@@ -181,7 +181,7 @@ int particle_track_cut::_accept() {
   uint32_t cut_returned = cuts::SELECTION_INAPPLICABLE;
 
   // Get particle track
-  const snemo::datamodel::particle_track& a_particle =
+  const auto& a_particle =
       get_user_data<snemo::datamodel::particle_track>();
 
   // Check if the calibrated data has a property flag with a specific name :
@@ -243,10 +243,8 @@ int particle_track_cut::_accept() {
                        << " , max = " << _calorimeter_hits_range_max_ << ")");
     } else {
       // Look for special calorimeter category
-      for (snemo::datamodel::calibrated_calorimeter_hit::collection_type::const_iterator icalo =
-               the_calorimeters.begin();
-           icalo != the_calorimeters.end(); ++icalo) {
-        const snemo::datamodel::calibrated_calorimeter_hit& a_calo_hit = icalo->get();
+      for (const auto & the_calorimeter : the_calorimeters) {
+        const snemo::datamodel::calibrated_calorimeter_hit& a_calo_hit = the_calorimeter.get();
         const datatools::properties& aux = a_calo_hit.get_auxiliaries();
         if (aux.has_key("category") &&
             aux.fetch_string("category") == _calorimeter_hits_range_category_) {
@@ -279,10 +277,8 @@ int particle_track_cut::_accept() {
       bool has_vertex = false;
       const snemo::datamodel::particle_track::vertex_collection_type& the_vertices =
           a_particle.get_vertices();
-      for (snemo::datamodel::particle_track::vertex_collection_type::const_iterator ivertex =
-               the_vertices.begin();
-           ivertex != the_vertices.end(); ++ivertex) {
-        const geomtools::blur_spot& a_vertex = ivertex->get();
+      for (const auto & the_vertice : the_vertices) {
+        const geomtools::blur_spot& a_vertex = the_vertice.get();
         const snemo::datamodel::particle_track::vertex_type vtype =
             snemo::datamodel::particle_track::label_to_vertex_type(_vertex_type_);
         if (snemo::datamodel::particle_track::vertex_is(a_vertex, vtype)) {

--- a/source/falaise/snemo/cuts/particle_track_data_cut.cc
+++ b/source/falaise/snemo/cuts/particle_track_data_cut.cc
@@ -31,37 +31,36 @@ void particle_track_data_cut::_set_defaults() {
   _particles_range_max_ = -1;
   _non_associated_calorimeter_hits_range_min_ = -1;
   _non_associated_calorimeter_hits_range_max_ = -1;
-  return;
 }
 
 void particle_track_data_cut::set_PTD_label(const std::string& PTD_label_) {
   _PTD_label_ = PTD_label_;
-  return;
 }
 
 const std::string& particle_track_data_cut::get_PTD_label() const { return _PTD_label_; }
 
 uint32_t particle_track_data_cut::get_mode() const { return _mode_; }
 
-bool particle_track_data_cut::is_mode_flag() const { return _mode_ & MODE_FLAG; }
+bool particle_track_data_cut::is_mode_flag() const { return (_mode_ & MODE_FLAG) != 0u; }
 
 bool particle_track_data_cut::is_mode_has_non_associated_calorimeter_hits() const {
-  return _mode_ & MODE_HAS_NON_ASSOCIATED_CALORIMETER_HITS;
+  return (_mode_ & MODE_HAS_NON_ASSOCIATED_CALORIMETER_HITS) != 0u;
 }
 
 bool particle_track_data_cut::is_mode_range_non_associated_calorimeter_hits() const {
-  return _mode_ & MODE_RANGE_NON_ASSOCIATED_CALORIMETER_HITS;
+  return (_mode_ & MODE_RANGE_NON_ASSOCIATED_CALORIMETER_HITS) != 0u;
 }
 
-bool particle_track_data_cut::is_mode_has_particles() const { return _mode_ & MODE_HAS_PARTICLES; }
+bool particle_track_data_cut::is_mode_has_particles() const {
+  return (_mode_ & MODE_HAS_PARTICLES) != 0u;
+}
 
 bool particle_track_data_cut::is_mode_range_particles() const {
-  return _mode_ & MODE_RANGE_PARTICLES;
+  return (_mode_ & MODE_RANGE_PARTICLES) != 0u;
 }
 
 void particle_track_data_cut::set_flag_name(const std::string& flag_name_) {
   _flag_name_ = flag_name_;
-  return;
 }
 
 const std::string& particle_track_data_cut::get_flag_name() const { return _flag_name_; }
@@ -69,19 +68,18 @@ const std::string& particle_track_data_cut::get_flag_name() const { return _flag
 particle_track_data_cut::particle_track_data_cut(datatools::logger::priority logger_priority_)
     : cuts::i_cut(logger_priority_) {
   _set_defaults();
-  return;
 }
 
 particle_track_data_cut::~particle_track_data_cut() {
-  if (is_initialized()) this->particle_track_data_cut::reset();
-  return;
+  if (is_initialized()) {
+    this->particle_track_data_cut::reset();
+  }
 }
 
 void particle_track_data_cut::reset() {
   _set_defaults();
   this->i_cut::_reset();
   this->i_cut::_set_initialized(false);
-  return;
 }
 
 void particle_track_data_cut::initialize(const datatools::properties& configuration_,
@@ -203,7 +201,6 @@ void particle_track_data_cut::initialize(const datatools::properties& configurat
   }
 
   this->i_cut::_set_initialized(true);
-  return;
 }
 
 int particle_track_data_cut::_accept() {

--- a/source/falaise/snemo/cuts/particle_track_data_cut.cc
+++ b/source/falaise/snemo/cuts/particle_track_data_cut.cc
@@ -207,7 +207,7 @@ int particle_track_data_cut::_accept() {
   uint32_t cut_returned = cuts::SELECTION_INAPPLICABLE;
 
   // Get event record
-  const datatools::things& ER = get_user_data<datatools::things>();
+  const auto& ER = get_user_data<datatools::things>();
 
   if (!ER.has(_PTD_label_)) {
     DT_LOG_DEBUG(get_logging_priority(), "Event record has no '" << _PTD_label_ << "' bank !");
@@ -215,8 +215,7 @@ int particle_track_data_cut::_accept() {
   }
 
   // Get Particle Track Data bank
-  const snemo::datamodel::particle_track_data& PTD =
-      ER.get<snemo::datamodel::particle_track_data>(_PTD_label_);
+  const auto& PTD = ER.get<snemo::datamodel::particle_track_data>(_PTD_label_);
 
   // Check if the tracker clustering data has a property flag with a specific name :
   bool check_flag = true;

--- a/source/falaise/snemo/cuts/simulated_data_cut.cc
+++ b/source/falaise/snemo/cuts/simulated_data_cut.cc
@@ -32,51 +32,47 @@ void simulated_data_cut::_set_defaults() {
   _hit_category_range_min_ = -1;
   _hit_category_range_max_ = -1;
   _hit_property_logic_ = "";
-  return;
 }
 
-void simulated_data_cut::set_SD_label(const std::string& SD_label_) {
-  _SD_label_ = SD_label_;
-  return;
-}
+void simulated_data_cut::set_SD_label(const std::string& SD_label_) { _SD_label_ = SD_label_; }
 
 const std::string& simulated_data_cut::get_SD_label() const { return _SD_label_; }
 
 uint32_t simulated_data_cut::get_mode() const { return _mode_; }
 
-bool simulated_data_cut::is_mode_flag() const { return _mode_ & MODE_FLAG; }
+bool simulated_data_cut::is_mode_flag() const { return (_mode_ & MODE_FLAG) != 0u; }
 
 bool simulated_data_cut::is_mode_range_hit_category() const {
-  return _mode_ & MODE_RANGE_HIT_CATEGORY;
+  return (_mode_ & MODE_RANGE_HIT_CATEGORY) != 0u;
 }
 
-bool simulated_data_cut::is_mode_has_hit_category() const { return _mode_ & MODE_HAS_HIT_CATEGORY; }
-
-bool simulated_data_cut::is_mode_has_hit_property() const { return _mode_ & MODE_HAS_HIT_PROPERTY; }
-
-void simulated_data_cut::set_flag_name(const std::string& flag_name_) {
-  _flag_name_ = flag_name_;
-  return;
+bool simulated_data_cut::is_mode_has_hit_category() const {
+  return (_mode_ & MODE_HAS_HIT_CATEGORY) != 0u;
 }
+
+bool simulated_data_cut::is_mode_has_hit_property() const {
+  return (_mode_ & MODE_HAS_HIT_PROPERTY) != 0u;
+}
+
+void simulated_data_cut::set_flag_name(const std::string& flag_name_) { _flag_name_ = flag_name_; }
 
 const std::string& simulated_data_cut::get_flag_name() const { return _flag_name_; }
 
 simulated_data_cut::simulated_data_cut(datatools::logger::priority logger_priority_)
     : cuts::i_cut(logger_priority_) {
   _set_defaults();
-  return;
 }
 
 simulated_data_cut::~simulated_data_cut() {
-  if (is_initialized()) this->simulated_data_cut::reset();
-  return;
+  if (is_initialized()) {
+    this->simulated_data_cut::reset();
+  }
 }
 
 void simulated_data_cut::reset() {
   _set_defaults();
   this->i_cut::_reset();
   this->i_cut::_set_initialized(false);
-  return;
 }
 
 void simulated_data_cut::initialize(const datatools::properties& configuration_,
@@ -198,7 +194,6 @@ void simulated_data_cut::initialize(const datatools::properties& configuration_,
   }
 
   this->i_cut::_set_initialized(true);
-  return;
 }
 
 int simulated_data_cut::_accept() {
@@ -295,7 +290,9 @@ int simulated_data_cut::_accept() {
           std::find_if(istart, istop, pred_via_handle);
       if (ifound == the_step_hits.end()) {
         check_has_hit_property = false;
-        if (_hit_property_logic_ == "and") break;
+        if (_hit_property_logic_ == "and") {
+          break;
+        }
         // Go to the next property (OR mode)
         istart = the_step_hits.begin();
         istop = the_step_hits.end();
@@ -309,7 +306,9 @@ int simulated_data_cut::_accept() {
       } else {
         // Found one hit : check next property for this hit
         check_has_hit_property = true;
-        if (_hit_property_logic_ == "or") break;
+        if (_hit_property_logic_ == "or") {
+          break;
+        }
         istart = ifound;
         istop = ++ifound;
         iprop++;

--- a/source/falaise/snemo/cuts/simulated_data_cut.cc
+++ b/source/falaise/snemo/cuts/simulated_data_cut.cc
@@ -200,7 +200,7 @@ int simulated_data_cut::_accept() {
   int cut_returned = cuts::SELECTION_INAPPLICABLE;
 
   // Get event record
-  const datatools::things& ER = get_user_data<datatools::things>();
+  const auto& ER = get_user_data<datatools::things>();
 
   if (!ER.has(_SD_label_)) {
     DT_LOG_DEBUG(get_logging_priority(), "Event record has no '" << _SD_label_ << "' bank !");
@@ -208,7 +208,7 @@ int simulated_data_cut::_accept() {
   }
 
   // Get simulated data bank
-  const mctools::simulated_data& SD = ER.get<mctools::simulated_data>(_SD_label_);
+  const auto& SD = ER.get<mctools::simulated_data>(_SD_label_);
 
   // Check if the simulated data has a property flag with a specific name :
   bool check_flag = true;
@@ -269,9 +269,8 @@ int simulated_data_cut::_accept() {
         SD.get_step_hits(_hit_category_);
 
     // Iterators
-    mctools::simulated_data::hit_handle_collection_type::const_iterator istart =
-        the_step_hits.begin();
-    mctools::simulated_data::hit_handle_collection_type::const_iterator istop = the_step_hits.end();
+    auto istart = the_step_hits.begin();
+    auto istop = the_step_hits.end();
     property_values_dict_type::const_iterator iprop = _hit_property_values_.begin();
 
     while (iprop != _hit_property_values_.end()) {
@@ -286,8 +285,7 @@ int simulated_data_cut::_accept() {
       datatools::handle_predicate<mctools::base_step_hit> pred_via_handle(pred);
 
       // Update iterator position
-      mctools::simulated_data::hit_handle_collection_type::const_iterator ifound =
-          std::find_if(istart, istop, pred_via_handle);
+      auto ifound = std::find_if(istart, istop, pred_via_handle);
       if (ifound == the_step_hits.end()) {
         check_has_hit_property = false;
         if (_hit_property_logic_ == "and") {

--- a/source/falaise/snemo/cuts/tracker_clustering_data_cut.cc
+++ b/source/falaise/snemo/cuts/tracker_clustering_data_cut.cc
@@ -39,20 +39,22 @@ const std::string& tracker_clustering_data_cut::get_TCD_label() const { return _
 
 uint32_t tracker_clustering_data_cut::get_mode() const { return _mode_; }
 
-bool tracker_clustering_data_cut::is_mode_flag() const { return _mode_ & MODE_FLAG; }
+bool tracker_clustering_data_cut::is_mode_flag() const { return (_mode_ & MODE_FLAG) != 0u; }
 
-bool tracker_clustering_data_cut::is_mode_has_cluster() const { return _mode_ & MODE_HAS_CLUSTER; }
+bool tracker_clustering_data_cut::is_mode_has_cluster() const {
+  return (_mode_ & MODE_HAS_CLUSTER) != 0u;
+}
 
 bool tracker_clustering_data_cut::is_mode_range_cluster() const {
-  return _mode_ & MODE_RANGE_CLUSTER;
+  return (_mode_ & MODE_RANGE_CLUSTER) != 0u;
 }
 
 bool tracker_clustering_data_cut::is_mode_has_unclustered_hits() const {
-  return _mode_ & MODE_HAS_UNCLUSTERED_HITS;
+  return (_mode_ & MODE_HAS_UNCLUSTERED_HITS) != 0u;
 }
 
 bool tracker_clustering_data_cut::is_mode_range_unclustered_hits() const {
-  return _mode_ & MODE_RANGE_UNCLUSTERED_HITS;
+  return (_mode_ & MODE_RANGE_UNCLUSTERED_HITS) != 0u;
 }
 
 void tracker_clustering_data_cut::set_flag_name(const std::string& flag_name_) {
@@ -68,7 +70,9 @@ tracker_clustering_data_cut::tracker_clustering_data_cut(
 }
 
 tracker_clustering_data_cut::~tracker_clustering_data_cut() {
-  if (is_initialized()) this->tracker_clustering_data_cut::reset();
+  if (is_initialized()) {
+    this->tracker_clustering_data_cut::reset();
+  }
 }
 
 void tracker_clustering_data_cut::reset() {
@@ -190,7 +194,6 @@ void tracker_clustering_data_cut::initialize(const datatools::properties& config
   }
 
   this->i_cut::_set_initialized(true);
-  return;
 }
 
 int tracker_clustering_data_cut::_accept() {
@@ -219,10 +222,11 @@ int tracker_clustering_data_cut::_accept() {
   if (is_mode_has_cluster()) {
     DT_LOG_DEBUG(get_logging_priority(), "Running HAS_CLUSTER mode...");
     // 2012-05-13 XG: Here we only take care of the default solution
-    if (!TCD.has_default_solution())
+    if (!TCD.has_default_solution()) {
       check_has_cluster = false;
-    else
+    } else {
       check_has_cluster = !TCD.get_default_solution().get_clusters().empty();
+    }
   }
 
   // Check if the tracker clustering data has a range of clusters :
@@ -231,10 +235,11 @@ int tracker_clustering_data_cut::_accept() {
     DT_LOG_DEBUG(get_logging_priority(), "Running RANGE_CLUSTER mode...");
     // 2012-05-13 XG: Here we only take care of the default solution
     bool check_has_cluster_2 = true;
-    if (!TCD.has_default_solution())
+    if (!TCD.has_default_solution()) {
       check_has_cluster_2 = false;
-    else
+    } else {
       check_has_cluster_2 = !TCD.get_default_solution().get_clusters().empty();
+    }
     if (!check_has_cluster_2) {
       DT_LOG_DEBUG(get_logging_priority(), "Tracker clustering data has no clusters");
       return cuts::SELECTION_INAPPLICABLE;
@@ -263,10 +268,11 @@ int tracker_clustering_data_cut::_accept() {
   if (is_mode_has_unclustered_hits()) {
     DT_LOG_DEBUG(get_logging_priority(), "Running HAS_UNCLUSTERED_HITS mode...");
     // 2012-05-13 XG: Here we only take care of the default solution
-    if (!TCD.has_default_solution())
+    if (!TCD.has_default_solution()) {
       check_has_unclustered_hits = false;
-    else
+    } else {
       check_has_unclustered_hits = !TCD.get_default_solution().get_unclustered_hits().empty();
+    }
   }
 
   // Check if the tracker clustering data has a range of unclustered hits :
@@ -275,10 +281,11 @@ int tracker_clustering_data_cut::_accept() {
     DT_LOG_DEBUG(get_logging_priority(), "Running RANGE_UNCLUSTERED_HITS mode...");
     // 2012-05-13 XG: Here we only take care of the default solution
     bool check_has_unclustered_hits_2 = true;
-    if (!TCD.has_default_solution())
+    if (!TCD.has_default_solution()) {
       check_has_unclustered_hits_2 = false;
-    else
+    } else {
       check_has_unclustered_hits_2 = !TCD.get_default_solution().get_unclustered_hits().empty();
+    }
     if (!check_has_unclustered_hits_2) {
       DT_LOG_DEBUG(get_logging_priority(), "Tracker clustering data has no unclustered hits");
       return cuts::SELECTION_INAPPLICABLE;

--- a/source/falaise/snemo/cuts/tracker_clustering_data_cut.cc
+++ b/source/falaise/snemo/cuts/tracker_clustering_data_cut.cc
@@ -200,7 +200,7 @@ int tracker_clustering_data_cut::_accept() {
   int cut_returned = cuts::SELECTION_INAPPLICABLE;
 
   // Get event record
-  const datatools::things& ER = get_user_data<datatools::things>();
+  const auto& ER = get_user_data<datatools::things>();
 
   if (!ER.has(_TCD_label_)) {
     DT_LOG_DEBUG(get_logging_priority(), "Event record has no '" << _TCD_label_ << "' bank !");
@@ -208,8 +208,7 @@ int tracker_clustering_data_cut::_accept() {
   }
 
   // Get tracker clustering data bank
-  const snemo::datamodel::tracker_clustering_data& TCD =
-      ER.get<snemo::datamodel::tracker_clustering_data>(_TCD_label_);
+  const auto& TCD = ER.get<snemo::datamodel::tracker_clustering_data>(_TCD_label_);
 
   // Check if the tracker clustering data has a property flag with a specific name :
   bool check_flag = false;

--- a/source/falaise/snemo/cuts/tracker_trajectory_data_cut.cc
+++ b/source/falaise/snemo/cuts/tracker_trajectory_data_cut.cc
@@ -41,18 +41,18 @@ const std::string& tracker_trajectory_data_cut::get_TTD_label() const { return _
 
 uint32_t tracker_trajectory_data_cut::get_mode() const { return _mode_; }
 
-bool tracker_trajectory_data_cut::is_mode_flag() const { return _mode_ & MODE_FLAG; }
+bool tracker_trajectory_data_cut::is_mode_flag() const { return (_mode_ & MODE_FLAG) != 0u; }
 
 bool tracker_trajectory_data_cut::is_mode_has_solution() const {
-  return _mode_ & MODE_HAS_SOLUTION;
+  return (_mode_ & MODE_HAS_SOLUTION) != 0u;
 }
 
 bool tracker_trajectory_data_cut::is_mode_range_chi2ndf() const {
-  return _mode_ & MODE_RANGE_CHI2NDF;
+  return (_mode_ & MODE_RANGE_CHI2NDF) != 0u;
 }
 
 bool tracker_trajectory_data_cut::is_mode_range_pvalue() const {
-  return _mode_ & MODE_RANGE_PVALUE;
+  return (_mode_ & MODE_RANGE_PVALUE) != 0u;
 }
 
 void tracker_trajectory_data_cut::set_flag_name(const std::string& flag_name_) {
@@ -68,7 +68,9 @@ tracker_trajectory_data_cut::tracker_trajectory_data_cut(
 }
 
 tracker_trajectory_data_cut::~tracker_trajectory_data_cut() {
-  if (is_initialized()) this->tracker_trajectory_data_cut::reset();
+  if (is_initialized()) {
+    this->tracker_trajectory_data_cut::reset();
+  }
 }
 
 void tracker_trajectory_data_cut::reset() {
@@ -155,14 +157,16 @@ void tracker_trajectory_data_cut::initialize(const datatools::properties& config
       DT_LOG_DEBUG(get_logging_priority(), "Using RANGE_PVALUE mode...");
       int count = 0;
       if (configuration_.has_key("range_pvalue.min")) {
-        const double pmin = configuration_.fetch_real_with_explicit_dimension("range_pvalue.min", "fraction");
+        const double pmin =
+            configuration_.fetch_real_with_explicit_dimension("range_pvalue.min", "fraction");
         DT_THROW_IF(pmin < 0.0 * CLHEP::perCent || pmin > 100.0 * CLHEP::perCent, std::range_error,
                     "Invalid min value of p-value (" << pmin << ") !");
         _pvalue_range_min_ = pmin;
         count++;
       }
       if (configuration_.has_key("range_pvalue.max")) {
-        const double pmax = configuration_.fetch_real_with_explicit_dimension("range_pvalue.max", "fraction");
+        const double pmax =
+            configuration_.fetch_real_with_explicit_dimension("range_pvalue.max", "fraction");
         DT_THROW_IF(pmax < 0.0 * CLHEP::perCent || pmax > 100.0 * CLHEP::perCent, std::range_error,
                     "Invalid max value of p-value (" << pmax << ") !");
         _pvalue_range_max_ = pmax;
@@ -199,8 +203,8 @@ int tracker_trajectory_data_cut::_accept() {
   bool check_flag = true;
   if (is_mode_flag()) {
     DT_LOG_ERROR(get_logging_priority(), "FLAG mode is no longer supported...");
-    //const bool check = TTD.get_auxiliaries().has_flag(_flag_name_);
-    //if (!check) {
+    // const bool check = TTD.get_auxiliaries().has_flag(_flag_name_);
+    // if (!check) {
     //  check_flag = false;
     //}
   }
@@ -210,7 +214,9 @@ int tracker_trajectory_data_cut::_accept() {
   if (is_mode_has_solution()) {
     DT_LOG_DEBUG(get_logging_priority(), "Running HAS_TRAJECTORY mode...");
     // 2012-05-13 XG: Here we only take care of the default solution
-    if (!TTD.has_default_solution()) check_has_solution = false;
+    if (!TTD.has_default_solution()) {
+      check_has_solution = false;
+    }
   }
 
   // Check if the tracker trajectory data has a range of chi2/ndf values
@@ -237,7 +243,9 @@ int tracker_trajectory_data_cut::_accept() {
       const snemo::datamodel::tracker_trajectory& a_trajectory = itraj->get();
 
       const datatools::properties& properties = a_trajectory.get_auxiliaries();
-      if (!properties.has_key("chi2") || !properties.has_key("ndof")) continue;
+      if (!properties.has_key("chi2") || !properties.has_key("ndof")) {
+        continue;
+      }
       const double chi2 = properties.fetch_real("chi2");
       const size_t ndof = properties.fetch_integer("ndof");
 

--- a/source/falaise/snemo/cuts/tracker_trajectory_data_cut.cc
+++ b/source/falaise/snemo/cuts/tracker_trajectory_data_cut.cc
@@ -188,7 +188,7 @@ int tracker_trajectory_data_cut::_accept() {
   int cut_returned = cuts::SELECTION_INAPPLICABLE;
 
   // Get event record
-  const datatools::things& ER = get_user_data<datatools::things>();
+  const auto& ER = get_user_data<datatools::things>();
 
   if (!ER.has(_TTD_label_)) {
     DT_LOG_DEBUG(get_logging_priority(), "Event record has no '" << _TTD_label_ << "' bank !");
@@ -196,8 +196,7 @@ int tracker_trajectory_data_cut::_accept() {
   }
 
   // Get tracker trajectory data bank
-  const snemo::datamodel::tracker_trajectory_data& TTD =
-      ER.get<snemo::datamodel::tracker_trajectory_data>(_TTD_label_);
+  const auto& TTD = ER.get<snemo::datamodel::tracker_trajectory_data>(_TTD_label_);
 
   // Check if the tracker trajectory data has a property flag with a specific name :
   bool check_flag = true;
@@ -237,10 +236,8 @@ int tracker_trajectory_data_cut::_accept() {
 
     const snemo::datamodel::tracker_trajectory_solution::trajectory_col_type& the_trajectories =
         a_default_solution.get_trajectories();
-    for (snemo::datamodel::tracker_trajectory_solution::trajectory_col_type::const_iterator itraj =
-             the_trajectories.begin();
-         itraj != the_trajectories.end(); ++itraj) {
-      const snemo::datamodel::tracker_trajectory& a_trajectory = itraj->get();
+    for (const auto& the_trajectorie : the_trajectories) {
+      const snemo::datamodel::tracker_trajectory& a_trajectory = the_trajectorie.get();
 
       const datatools::properties& properties = a_trajectory.get_auxiliaries();
       if (!properties.has_key("chi2") || !properties.has_key("ndof")) {

--- a/source/falaise/snemo/datamodels/base_trajectory_pattern.cc
+++ b/source/falaise/snemo/datamodels/base_trajectory_pattern.cc
@@ -14,8 +14,7 @@ namespace datamodel {
 DATATOOLS_SERIALIZATION_SERIAL_TAG_IMPLEMENTATION(base_trajectory_pattern,
                                                   "snemo::datamodel::base_trajectory_pattern")
 
-base_trajectory_pattern::base_trajectory_pattern(const std::string& pid)
-    :  _pattern_id_(pid) {}
+base_trajectory_pattern::base_trajectory_pattern(std::string pid) : _pattern_id_(std::move(pid)) {}
 
 bool base_trajectory_pattern::has_pattern_id() const { return !_pattern_id_.empty(); }
 

--- a/source/falaise/snemo/datamodels/base_trajectory_pattern.h
+++ b/source/falaise/snemo/datamodels/base_trajectory_pattern.h
@@ -27,7 +27,7 @@ class base_trajectory_pattern : public datatools::i_serializable {
   /// Constructors
   base_trajectory_pattern() = default;
 
-  base_trajectory_pattern(const std::string& pid);
+  base_trajectory_pattern(std::string pid);
 
   /// Destructor
   virtual ~base_trajectory_pattern() = default;

--- a/source/falaise/snemo/geometry/calo_locator.cc
+++ b/source/falaise/snemo/geometry/calo_locator.cc
@@ -92,11 +92,10 @@ double calo_locator::get_column_y(uint32_t side_, uint32_t column_) const {
     DT_THROW_IF(column_ >= _back_block_y_.size(), std::logic_error,
                 "Invalid column number (" << column_ << ">" << _back_block_y_.size() - 1 << ")!");
     return _back_block_y_[column_];
-  } else {
-    DT_THROW_IF(column_ >= _front_block_y_.size(), std::logic_error,
-                "Invalid column number (" << column_ << ">" << _front_block_y_.size() - 1 << ")!");
-    return _front_block_y_[column_];
   }
+  DT_THROW_IF(column_ >= _front_block_y_.size(), std::logic_error,
+              "Invalid column number (" << column_ << ">" << _front_block_y_.size() - 1 << ")!");
+  return _front_block_y_[column_];
 }
 
 double calo_locator::get_row_z(uint32_t side_, uint32_t row_) const {
@@ -106,18 +105,16 @@ double calo_locator::get_row_z(uint32_t side_, uint32_t row_) const {
     DT_THROW_IF(row_ >= _back_block_z_.size(), std::logic_error,
                 "Invalid row number (" << row_ << ">" << _back_block_z_.size() - 1 << ")!");
     return _back_block_z_[row_];
-  } else {
-    DT_THROW_IF(row_ >= _front_block_z_.size(), std::logic_error,
-                "Invalid row number (" << row_ << ">" << _front_block_z_.size() - 1 << ")!");
-    return _front_block_z_[row_];
   }
+  DT_THROW_IF(row_ >= _front_block_z_.size(), std::logic_error,
+              "Invalid row number (" << row_ << ">" << _front_block_z_.size() - 1 << ")!");
+  return _front_block_z_[row_];
 }
 
 void calo_locator::compute_block_position(uint32_t side_, uint32_t column_, uint32_t row_,
                                           geomtools::vector_3d &module_position_) const {
   geomtools::invalidate(module_position_);
   module_position_.set(get_wall_x(side_), get_column_y(side_, column_), get_row_z(side_, row_));
-  return;
 }
 
 void calo_locator::compute_block_window_position(uint32_t side_, uint32_t column_, uint32_t row_,
@@ -125,7 +122,6 @@ void calo_locator::compute_block_window_position(uint32_t side_, uint32_t column
   geomtools::invalidate(module_position_);
   module_position_.set(get_wall_window_x(side_), get_column_y(side_, column_),
                        get_row_z(side_, row_));
-  return;
 }
 
 geomtools::vector_3d calo_locator::get_block_position(uint32_t side_, uint32_t column_,
@@ -159,7 +155,6 @@ void calo_locator::get_block_position(const geomtools::geom_id &gid_,
                                         << "!=" << _module_number_ << ")!");
   return get_block_position(gid_.get(_side_address_index_), gid_.get(_column_address_index_),
                             gid_.get(_row_address_index_), position_);
-  return;
 }
 
 void calo_locator::get_block_position(uint32_t side_, uint32_t column_, uint32_t row_,
@@ -180,7 +175,6 @@ void calo_locator::get_block_position(uint32_t side_, uint32_t column_, uint32_t
                 "Invalid row number (" << row_ << ">" << _front_block_z_.size() - 1 << ")!");
     position_.set(_block_x_[utils::SIDE_FRONT], _front_block_y_[column_], _front_block_z_[row_]);
   }
-  return;
 }
 
 void calo_locator::get_neighbours_ids(const geomtools::geom_id &gid_,
@@ -191,7 +185,6 @@ void calo_locator::get_neighbours_ids(const geomtools::geom_id &gid_,
                                         << "!=" << _module_number_ << ")!");
   get_neighbours_ids(gid_.get(_side_address_index_), gid_.get(_column_address_index_),
                      gid_.get(_row_address_index_), ids_, mask_);
-  return;
 }
 
 void calo_locator::get_neighbours_ids(uint32_t side_, uint32_t column_, uint32_t row_,
@@ -202,9 +195,9 @@ void calo_locator::get_neighbours_ids(uint32_t side_, uint32_t column_, uint32_t
   ids_.clear();
   ids_.reserve(8);
 
-  const bool sides = mask_ & utils::NEIGHBOUR_SIDE;
-  const bool diagonal = mask_ & utils::NEIGHBOUR_DIAG;
-  const bool second = mask_ & utils::NEIGHBOUR_SECOND;
+  const bool sides = (mask_ & utils::NEIGHBOUR_SIDE) != 0;
+  const bool diagonal = (mask_ & utils::NEIGHBOUR_DIAG) != 0;
+  const bool second = (mask_ & utils::NEIGHBOUR_SECOND) != 0;
 
   // prepare neighbour GID :
   geomtools::geom_id gid;
@@ -321,10 +314,16 @@ void calo_locator::get_neighbours_ids(uint32_t side_, uint32_t column_, uint32_t
      */
     if (second) {
       for (int ir = -2; ir <= +2; ir++) {
-        if (row_ + ir > (_back_block_z_.size() - 1)) continue;
+        if (row_ + ir > (_back_block_z_.size() - 1)) {
+          continue;
+        }
         for (int ic = -2; ic <= +2; ic++) {
-          if (column_ + ic > (_back_block_y_.size() - 1)) continue;
-          if (std::abs(ir) != 2 && std::abs(ic) != 2) continue;
+          if (column_ + ic > (_back_block_y_.size() - 1)) {
+            continue;
+          }
+          if (std::abs(ir) != 2 && std::abs(ic) != 2) {
+            continue;
+          }
           gid.set(_column_address_index_, column_ + ic);
           gid.set(_row_address_index_, row_ + ir);
           ids_.push_back(gid);
@@ -434,10 +433,16 @@ void calo_locator::get_neighbours_ids(uint32_t side_, uint32_t column_, uint32_t
      */
     if (second) {
       for (int ir = -2; ir <= +2; ir++) {
-        if (row_ + ir > (_back_block_z_.size() - 1)) continue;
+        if (row_ + ir > (_back_block_z_.size() - 1)) {
+          continue;
+        }
         for (int ic = -2; ic <= +2; ic++) {
-          if (column_ + ic > (_back_block_y_.size() - 1)) continue;
-          if (std::abs(ir) != 2 && std::abs(ic) != 2) continue;
+          if (column_ + ic > (_back_block_y_.size() - 1)) {
+            continue;
+          }
+          if (std::abs(ir) != 2 && std::abs(ic) != 2) {
+            continue;
+          }
           gid.set(_column_address_index_, column_ + ic);
           gid.set(_row_address_index_, row_ + ir);
           ids_.push_back(gid);
@@ -445,8 +450,6 @@ void calo_locator::get_neighbours_ids(uint32_t side_, uint32_t column_, uint32_t
       }
     }
   }
-
-  return;
 }
 
 size_t calo_locator::get_number_of_neighbours(uint32_t side_, uint32_t column_, uint32_t row_,
@@ -454,8 +457,8 @@ size_t calo_locator::get_number_of_neighbours(uint32_t side_, uint32_t column_, 
   DT_THROW_IF(!is_initialized(), std::logic_error, "Locator is not initialized !");
   bool corner = false;
   bool side = false;
-  const bool sides = mask_ & utils::NEIGHBOUR_SIDE;
-  const bool diagonal = mask_ & utils::NEIGHBOUR_DIAG;
+  const bool sides = (mask_ & utils::NEIGHBOUR_SIDE) != 0;
+  const bool diagonal = (mask_ & utils::NEIGHBOUR_DIAG) != 0;
   if (side_ == (uint32_t)utils::SIDE_BACK) {
     if ((column_ == 0) || (column_ == _back_block_y_.size() - 1)) {
       if ((row_ == 0) || (row_ == _back_block_z_.size() - 1)) {
@@ -476,34 +479,58 @@ size_t calo_locator::get_number_of_neighbours(uint32_t side_, uint32_t column_, 
   }
   size_t number = 0;
   if (corner) {
-    if (sides) number += 2;
-    if (diagonal) number += 1;
+    if (sides) {
+      number += 2;
+    }
+    if (diagonal) {
+      number += 1;
+    }
   } else if (side) {
-    if (sides) number += 3;
-    if (diagonal) number += 2;
+    if (sides) {
+      number += 3;
+    }
+    if (diagonal) {
+      number += 2;
+    }
   } else {
-    if (sides) number += 4;
-    if (diagonal) number += 4;
+    if (sides) {
+      number += 4;
+    }
+    if (diagonal) {
+      number += 4;
+    }
   }
 
-  const bool second = mask_ & utils::NEIGHBOUR_SECOND;
+  const bool second = (mask_ & utils::NEIGHBOUR_SECOND) != 0;
   if (second) {
     if (side_ == (uint32_t)utils::SIDE_BACK) {
       for (int ir = -2; ir <= +2; ir++) {
-        if (row_ + ir > (_back_block_z_.size() - 1)) continue;
+        if (row_ + ir > (_back_block_z_.size() - 1)) {
+          continue;
+        }
         for (int ic = -2; ic <= +2; ic++) {
-          if (column_ + ic > (_back_block_y_.size() - 1)) continue;
-          if (std::abs(ir) != 2 && std::abs(ic) != 2) continue;
+          if (column_ + ic > (_back_block_y_.size() - 1)) {
+            continue;
+          }
+          if (std::abs(ir) != 2 && std::abs(ic) != 2) {
+            continue;
+          }
           number++;
         }
       }
     }
     if (side_ == (uint32_t)utils::SIDE_FRONT) {
       for (int ir = -2; ir <= +2; ir++) {
-        if (row_ + ir > (_front_block_z_.size() - 1)) continue;
+        if (row_ + ir > (_front_block_z_.size() - 1)) {
+          continue;
+        }
         for (int ic = -2; ic <= +2; ic++) {
-          if (column_ + ic > (_front_block_y_.size() - 1)) continue;
-          if (std::abs(ir) != 2 && std::abs(ic) != 2) continue;
+          if (column_ + ic > (_front_block_y_.size() - 1)) {
+            continue;
+          }
+          if (std::abs(ir) != 2 && std::abs(ic) != 2) {
+            continue;
+          }
           number++;
         }
       }
@@ -571,26 +598,19 @@ void calo_locator::_set_defaults_() {
   _part_address_index_ = geomtools::geom_id::INVALID_ADDRESS;
 
   _initialized_ = false;
-  return;
 }
 
 // Constructor:
-calo_locator::calo_locator() : base_locator() {
-  _set_defaults_();
-  return;
-}
+calo_locator::calo_locator() { _set_defaults_(); }
 
 // Constructor:
 calo_locator::calo_locator(const ::geomtools::manager &mgr_, uint32_t module_number_,
-                           uint32_t block_part_)
-    : base_locator() {
+                           uint32_t block_part_) {
   _set_defaults_();
 
   set_geo_manager(mgr_);
   set_module_number(module_number_);
   set_block_part(block_part_);
-
-  return;
 }
 
 // dtor:
@@ -598,7 +618,6 @@ calo_locator::~calo_locator() {
   if (is_initialized()) {
     reset();
   }
-  return;
 }
 
 bool calo_locator::is_block_partitioned() const { return _block_partitioned_; }
@@ -751,7 +770,9 @@ void calo_locator::_construct() {
   vcy[utils::SIDE_BACK] = &_back_block_y_;
   vcy[utils::SIDE_FRONT] = &_front_block_y_;
   for (size_t iside = 0; iside < utils::NSIDES; iside++) {
-    if (!_submodules_[iside]) continue;
+    if (!_submodules_[iside]) {
+      continue;
+    }
     size_t i_column = 0;
     vcy[iside]->reserve(20);
     while (true) {
@@ -796,7 +817,9 @@ void calo_locator::_construct() {
   vrz[utils::SIDE_BACK] = &_back_block_z_;
   vrz[utils::SIDE_FRONT] = &_front_block_z_;
   for (size_t iside = 0; iside < utils::NSIDES; iside++) {
-    if (!_submodules_[iside]) continue;
+    if (!_submodules_[iside]) {
+      continue;
+    }
     size_t i_row = 0;
     vrz[iside]->reserve(13);
     while (true) {
@@ -825,8 +848,6 @@ void calo_locator::_construct() {
   _block_width_ = _block_box_->get_x();
   _block_height_ = _block_box_->get_y();
   _block_thickness_ = _block_box_->get_z();
-
-  return;
 }
 
 int calo_locator::get_module_address_index() const { return _module_address_index_; }
@@ -873,13 +894,11 @@ bool calo_locator::is_calo_block_in_current_module(const geomtools::geom_id &gid
 void calo_locator::set_module_number(uint32_t a_module_number) {
   DT_THROW_IF(is_initialized(), std::logic_error, "Locator is already initialized !");
   _module_number_ = a_module_number;
-  return;
 }
 
 void calo_locator::set_block_part(uint32_t a_block_part) {
   DT_THROW_IF(is_initialized(), std::logic_error, "Locator is already initialized !");
   _block_part_ = a_block_part;
-  return;
 }
 
 uint32_t calo_locator::get_module_number() const { return _module_number_; }
@@ -889,7 +908,6 @@ uint32_t calo_locator::get_block_part() const { return _block_part_; }
 void calo_locator::initialize() {
   datatools::properties dummy;
   initialize(dummy);
-  return;
 }
 
 void calo_locator::_hack_trace() {
@@ -902,7 +920,6 @@ void calo_locator::_hack_trace() {
                    "Trace logging activated through env 'FLGEOMLOCATOR'...");
     }
   }
-  return;
 }
 
 void calo_locator::initialize(const datatools::properties &config_) {
@@ -915,12 +932,10 @@ void calo_locator::initialize(const datatools::properties &config_) {
   if (datatools::logger::is_trace(get_logging_priority())) {
     tree_dump(std::cerr, "Main calo locator : ", "[trace] ");
   }
-  return;
 }
 
 void calo_locator::dump(std::ostream &out_) const {
   calo_locator::tree_dump(out_, "snemo::geometry:calo_locator::dump: ");
-  return;
 }
 
 void calo_locator::tree_dump(std::ostream &out_, const std::string &title_,
@@ -1025,7 +1040,6 @@ void calo_locator::tree_dump(std::ostream &out_, const std::string &title_,
     out_ << indent << datatools::i_tree_dumpable::inherit_tag(inherit_)
          << "Part address GID index   = " << _part_address_index_ << std::endl;
   }
-  return;
 }
 
 void calo_locator::reset() {
@@ -1035,21 +1049,18 @@ void calo_locator::reset() {
   _back_block_y_.clear();
   _front_block_y_.clear();
   _set_defaults_();
-  return;
 }
 
 void calo_locator::transform_world_to_module(const geomtools::vector_3d &world_position_,
                                              geomtools::vector_3d &module_position_) const {
   DT_THROW_IF(!is_initialized(), std::logic_error, "Locator is not initialized !");
   _module_world_placement_->mother_to_child(world_position_, module_position_);
-  return;
 }
 
 void calo_locator::transform_module_to_world(const geomtools::vector_3d &module_position_,
                                              geomtools::vector_3d &world_position_) const {
   DT_THROW_IF(!is_initialized(), std::logic_error, "Locator is not initialized !");
   _module_world_placement_->child_to_mother(module_position_, world_position_);
-  return;
 }
 
 bool calo_locator::is_in_module(const geomtools::vector_3d &module_position_,
@@ -1235,7 +1246,7 @@ bool calo_locator::find_block_geom_id_(const geomtools::vector_3d &in_module_pos
       // 2012-05-31 FM : we check if the 'world' position is in the volume:
       geomtools::vector_3d world_position;
       transform_module_to_world(in_module_position_, world_position);
-      if (_mapping_->check_inside(*ginfo_ptr, world_position, tolerance)) {
+      if (geomtools::mapping::check_inside(*ginfo_ptr, world_position, tolerance)) {
         DT_LOG_TRACE(get_logging_priority(), "INSIDE " << gid);
         DT_LOG_TRACE_EXITING(get_logging_priority());
         return true;

--- a/source/falaise/snemo/geometry/gg_locator.cc
+++ b/source/falaise/snemo/geometry/gg_locator.cc
@@ -88,11 +88,10 @@ double gg_locator::get_layer_x(uint32_t side_, uint32_t layer_) const {
     DT_THROW_IF(layer_ >= _back_cell_x_.size(), std::logic_error,
                 "Invalid layer number (" << layer_ << ">" << _back_cell_x_.size() - 1 << ")!");
     return _back_cell_x_[layer_];
-  } else {
-    DT_THROW_IF(layer_ >= _front_cell_x_.size(), std::logic_error,
-                "Invalid layer number (" << layer_ << ">" << _front_cell_x_.size() - 1 << ")!");
-    return _front_cell_x_[layer_];
   }
+  DT_THROW_IF(layer_ >= _front_cell_x_.size(), std::logic_error,
+              "Invalid layer number (" << layer_ << ">" << _front_cell_x_.size() - 1 << ")!");
+  return _front_cell_x_[layer_];
 }
 
 double gg_locator::get_row_y(uint32_t side_, uint32_t row_) const {
@@ -102,18 +101,16 @@ double gg_locator::get_row_y(uint32_t side_, uint32_t row_) const {
     DT_THROW_IF(row_ >= _back_cell_y_.size(), std::logic_error,
                 "Invalid row number (" << row_ << ">" << _back_cell_y_.size() - 1 << ")!");
     return _back_cell_y_[row_];
-  } else {
-    DT_THROW_IF(row_ >= _front_cell_y_.size(), std::logic_error,
-                "Invalid row number (" << row_ << ">" << _front_cell_y_.size() - 1 << ")!");
-    return _front_cell_y_[row_];
   }
+  DT_THROW_IF(row_ >= _front_cell_y_.size(), std::logic_error,
+              "Invalid row number (" << row_ << ">" << _front_cell_y_.size() - 1 << ")!");
+  return _front_cell_y_[row_];
 }
 
 void gg_locator::compute_cell_position(uint32_t side_, uint32_t layer_, uint32_t row_,
                                        geomtools::vector_3d &module_position_) const {
   geomtools::invalidate(module_position_);
   module_position_.set(get_layer_x(side_, layer_), get_row_y(side_, row_), 0.0);
-  return;
 }
 
 geomtools::vector_3d gg_locator::get_cell_position(uint32_t side_, uint32_t layer_,
@@ -141,7 +138,6 @@ void gg_locator::get_cell_position(const geomtools::geom_id &gid_,
       "Invalid module number (" << gid_.get(_module_index_) << "!=" << _module_number_ << ")!");
   return get_cell_position(gid_.get(_side_index_), gid_.get(_layer_index_), gid_.get(_row_index_),
                            position_);
-  return;
 }
 
 void gg_locator::get_cell_position(uint32_t side_, uint32_t layer_, uint32_t row_,
@@ -163,7 +159,6 @@ void gg_locator::get_cell_position(uint32_t side_, uint32_t layer_, uint32_t row
                 "Invalid row number (" << row_ << ">" << _front_cell_y_.size() - 1 << ")!");
     position_.set(_front_cell_x_[layer_], _front_cell_y_[row_], 0.0);
   }
-  return;
 }
 
 void gg_locator::get_neighbours_ids(const geomtools::geom_id &gid_,
@@ -174,7 +169,6 @@ void gg_locator::get_neighbours_ids(const geomtools::geom_id &gid_,
       "Invalid module number (" << gid_.get(_module_index_) << "!=" << _module_number_ << ")!");
   get_neighbours_ids(gid_.get(_side_index_), gid_.get(_layer_index_), gid_.get(_row_index_), ids_,
                      other_side_);
-  return;
 }
 
 void gg_locator::get_neighbours_ids(uint32_t side_, uint32_t layer_, uint32_t row_,
@@ -378,7 +372,6 @@ void gg_locator::get_neighbours_ids(uint32_t side_, uint32_t layer_, uint32_t ro
       ids_.push_back(geomtools::geom_id(_cell_type_, _module_number_, side_ - 1, 0, row_ + 1));
     }
   }
-  return;
 }
 
 size_t gg_locator::get_number_of_neighbours(uint32_t side_, uint32_t layer_, uint32_t row_,
@@ -417,8 +410,12 @@ size_t gg_locator::get_number_of_neighbours(uint32_t side_, uint32_t layer_, uin
       }
     }
   }
-  if (corner) return 3 + plus;
-  if (side) return 5 + plus;
+  if (corner) {
+    return 3 + plus;
+  }
+  if (side) {
+    return 5 + plus;
+  }
   return 8;
 }
 
@@ -482,7 +479,6 @@ void gg_locator::_hack_trace() {
                    "Trace logging activated through env 'FLGEOMLOCATOR'...");
     }
   }
-  return;
 }
 
 void gg_locator::_set_defaults() {
@@ -519,24 +515,18 @@ void gg_locator::_set_defaults() {
   datatools::invalidate(_field_wire_diameter_);
 
   _initialized_ = false;
-  return;
 }
 
 // Constructor:
-gg_locator::gg_locator() : base_locator() {
-  _set_defaults();
-  return;
-}
+gg_locator::gg_locator() { _set_defaults(); }
 
 // Constructor:
-gg_locator::gg_locator(const ::geomtools::manager &mgr_, uint32_t module_number_) : base_locator() {
+gg_locator::gg_locator(const ::geomtools::manager &mgr_, uint32_t module_number_) {
   _set_defaults();
 
   // Setup :
   set_geo_manager(mgr_);
   set_module_number(module_number_);
-
-  return;
 }
 
 // Destructor:
@@ -544,7 +534,6 @@ gg_locator::~gg_locator() {
   if (is_initialized()) {
     reset();
   }
-  return;
 }
 
 void gg_locator::_construct() {
@@ -623,7 +612,9 @@ void gg_locator::_construct() {
   vlx[utils::SIDE_FRONT] = &_front_cell_x_;
   // Loop on tracker sides:
   for (size_t side = 0; side < utils::NSIDES; side++) {
-    if (!_submodules_[side]) continue;
+    if (!_submodules_[side]) {
+      continue;
+    }
     size_t i_layer = 0;
     vlx[side]->reserve(10);
     while (true) {
@@ -646,7 +637,9 @@ void gg_locator::_construct() {
   vcy[1] = &_front_cell_y_;
   // Loop on tracker sides:
   for (size_t side = 0; side < utils::NSIDES; side++) {
-    if (!_submodules_[side]) continue;
+    if (!_submodules_[side]) {
+      continue;
+    }
     size_t i_cell = 0;
     vlx[side]->reserve(130);
     while (true) {
@@ -754,20 +747,15 @@ void gg_locator::_construct() {
   _row_address_index_ = module_ci.get_subaddress_index("row");
 
   DT_LOG_TRACE_EXITING(get_logging_priority());
-  return;
 }
 
-void gg_locator::set_module_number(uint32_t module_number_) {
-  _module_number_ = module_number_;
-  return;
-}
+void gg_locator::set_module_number(uint32_t module_number_) { _module_number_ = module_number_; }
 
 uint32_t gg_locator::get_module_number() const { return _module_number_; }
 
 void gg_locator::initialize() {
   datatools::properties dummy;
   initialize(dummy);
-  return;
 }
 
 void gg_locator::initialize(const datatools::properties &config_) {
@@ -780,12 +768,10 @@ void gg_locator::initialize(const datatools::properties &config_) {
   if (datatools::logger::is_trace(get_logging_priority())) {
     tree_dump(std::cerr, "Geiger locator : ", "[trace] ");
   }
-  return;
 }
 
 void gg_locator::dump(std::ostream &out_) const {
   gg_locator::tree_dump(out_, "snemo::geometry:gg_locator::dump: ");
-  return;
 }
 
 void gg_locator::tree_dump(std::ostream &out_, const std::string &title_,
@@ -871,7 +857,6 @@ void gg_locator::tree_dump(std::ostream &out_, const std::string &title_,
   out_ << indent << itag << "Layer address GID index  = " << _layer_address_index_ << std::endl;
   out_ << indent << datatools::i_tree_dumpable::inherit_tag(inherit_)
        << "Row address GID index    = " << _row_address_index_ << std::endl;
-  return;
 }
 
 void gg_locator::reset() {
@@ -885,21 +870,18 @@ void gg_locator::reset() {
   _front_cell_y_.clear();
 
   _initialized_ = false;
-  return;
 }
 
 void gg_locator::transform_world_to_module(const geomtools::vector_3d &world_position_,
                                            geomtools::vector_3d &module_position_) const {
   DT_THROW_IF(!is_initialized(), std::logic_error, "Locator is not initialized !");
   _module_world_placement_->mother_to_child(world_position_, module_position_);
-  return;
 }
 
 void gg_locator::transform_module_to_world(const geomtools::vector_3d &module_position_,
                                            geomtools::vector_3d &world_position_) const {
   DT_THROW_IF(!is_initialized(), std::logic_error, "Locator is not initialized !");
   _module_world_placement_->child_to_mother(module_position_, world_position_);
-  return;
 }
 
 bool gg_locator::is_in_module(const geomtools::vector_3d &module_position_,
@@ -912,7 +894,9 @@ bool gg_locator::is_in_module(const geomtools::vector_3d &module_position_,
 bool gg_locator::is_in_cell(const geomtools::vector_3d &module_position_, uint32_t side_,
                             uint32_t layer_, uint32_t row_, double tolerance_) const {
   DT_THROW_IF(!is_initialized(), std::logic_error, "Locator is not initialized !");
-  if (!_submodules_[side_]) return false;
+  if (!_submodules_[side_]) {
+    return false;
+  }
   geomtools::vector_3d to_cell_pos = module_position_;
   to_cell_pos -= get_cell_position(side_, layer_, row_);
   // here one misses one transformation step (rotation) but it is ok :
@@ -924,7 +908,9 @@ bool gg_locator::is_world_position_in_cell(const geomtools::vector_3d &world_pos
                                            uint32_t side_, uint32_t layer_, uint32_t row_,
                                            double tolerance_) const {
   DT_THROW_IF(!is_initialized(), std::logic_error, "Locator is not initialized !");
-  if (!_submodules_[side_]) return false;
+  if (!_submodules_[side_]) {
+    return false;
+  }
   geomtools::vector_3d in_module_position;
   this->transform_world_to_module(world_position_, in_module_position);
   return is_in_cell(in_module_position, side_, layer_, row_, tolerance_);
@@ -1070,7 +1056,7 @@ bool gg_locator::_find_cell_geom_id(const geomtools::vector_3d &in_module_positi
       // 2012-05-31 FM : we check if the 'world' position is in the volume:
       geomtools::vector_3d world_position;
       transform_module_to_world(in_module_position_, world_position);
-      if (_mapping_->check_inside(*ginfo_ptr, world_position, tolerance, true)) {
+      if (geomtools::mapping::check_inside(*ginfo_ptr, world_position, tolerance, true)) {
         DT_LOG_TRACE(get_logging_priority(), "Position inside gid = " << gid);
         DT_LOG_TRACE_EXITING(get_logging_priority());
         return true;

--- a/source/falaise/snemo/geometry/gg_locator.cc
+++ b/source/falaise/snemo/geometry/gg_locator.cc
@@ -192,7 +192,7 @@ void gg_locator::get_neighbours_ids(uint32_t side_, uint32_t layer_, uint32_t ro
        *  [ ][.][x]
        *  [ ][ ][ ]
        */
-      ids_.push_back(geomtools::geom_id(_cell_type_, _module_number_, side_, layer_ - 1, row_));
+      ids_.emplace_back(_cell_type_, _module_number_, side_, layer_ - 1, row_);
     }
     if (layer_ < (_back_cell_x_.size() - 1)) {
       /*  L+1 L L-1
@@ -200,7 +200,7 @@ void gg_locator::get_neighbours_ids(uint32_t side_, uint32_t layer_, uint32_t ro
        *  [x][.][ ] R
        *  [ ][ ][ ] R-1
        */
-      ids_.push_back(geomtools::geom_id(_cell_type_, _module_number_, side_, layer_ + 1, row_));
+      ids_.emplace_back(_cell_type_, _module_number_, side_, layer_ + 1, row_);
     }
     if (row_ > 0) {
       /*  L+1 L L-1
@@ -208,7 +208,7 @@ void gg_locator::get_neighbours_ids(uint32_t side_, uint32_t layer_, uint32_t ro
        *  [ ][.][ ] R
        *  [ ][x][ ] R-1
        */
-      ids_.push_back(geomtools::geom_id(_cell_type_, _module_number_, side_, layer_, row_ - 1));
+      ids_.emplace_back(_cell_type_, _module_number_, side_, layer_, row_ - 1);
     }
     if (row_ < (_back_cell_y_.size() - 1)) {
       /*  L+1 L L-1
@@ -216,7 +216,7 @@ void gg_locator::get_neighbours_ids(uint32_t side_, uint32_t layer_, uint32_t ro
        *  [ ][.][ ] R
        *  [ ][ ][ ] R-1
        */
-      ids_.push_back(geomtools::geom_id(_cell_type_, _module_number_, side_, layer_, row_ + 1));
+      ids_.emplace_back(_cell_type_, _module_number_, side_, layer_, row_ + 1);
     }
 
     if ((layer_ < (_back_cell_x_.size() - 1)) && (row_ > 0)) {
@@ -225,7 +225,7 @@ void gg_locator::get_neighbours_ids(uint32_t side_, uint32_t layer_, uint32_t ro
        *  [ ][.][ ] R
        *  [x][ ][ ] R-1
        */
-      ids_.push_back(geomtools::geom_id(_cell_type_, _module_number_, side_, layer_ + 1, row_ - 1));
+      ids_.emplace_back(_cell_type_, _module_number_, side_, layer_ + 1, row_ - 1);
     }
     if ((layer_ < (_back_cell_x_.size() - 1)) && (row_ < (_back_cell_y_.size() - 1))) {
       /*  L+1 L L-1
@@ -233,7 +233,7 @@ void gg_locator::get_neighbours_ids(uint32_t side_, uint32_t layer_, uint32_t ro
        *  [ ][.][ ] R
        *  [ ][ ][ ] R-1
        */
-      ids_.push_back(geomtools::geom_id(_cell_type_, _module_number_, side_, layer_ + 1, row_ + 1));
+      ids_.emplace_back(_cell_type_, _module_number_, side_, layer_ + 1, row_ + 1);
     }
     if ((layer_ > 0) && (row_ > 0)) {
       /*  L+1 L L-1
@@ -241,7 +241,7 @@ void gg_locator::get_neighbours_ids(uint32_t side_, uint32_t layer_, uint32_t ro
        *  [ ][.][ ] R
        *  [ ][ ][x] R-1
        */
-      ids_.push_back(geomtools::geom_id(_cell_type_, _module_number_, side_, layer_ - 1, row_ - 1));
+      ids_.emplace_back(_cell_type_, _module_number_, side_, layer_ - 1, row_ - 1);
     }
     if ((layer_ > 0) && (row_ < (_back_cell_y_.size() - 1))) {
       /*  L+1 L L-1
@@ -249,7 +249,7 @@ void gg_locator::get_neighbours_ids(uint32_t side_, uint32_t layer_, uint32_t ro
        *  [ ][.][ ] R
        *  [ ][ ][ ] R-1
        */
-      ids_.push_back(geomtools::geom_id(_cell_type_, _module_number_, side_, layer_ - 1, row_ + 1));
+      ids_.emplace_back(_cell_type_, _module_number_, side_, layer_ - 1, row_ + 1);
     }
     if ((layer_ == 0) && (row_ > 0) && other_side_) {
       /*   1  0     0
@@ -257,7 +257,7 @@ void gg_locator::get_neighbours_ids(uint32_t side_, uint32_t layer_, uint32_t ro
        *  [ ][.] | [ ] R
        *  [ ][ ] | [x] R-1
        */
-      ids_.push_back(geomtools::geom_id(_cell_type_, _module_number_, side_ + 1, 0, row_ - 1));
+      ids_.emplace_back(_cell_type_, _module_number_, side_ + 1, 0, row_ - 1);
     }
     if ((layer_ == 0) && other_side_) {
       /*   1  0     0
@@ -265,7 +265,7 @@ void gg_locator::get_neighbours_ids(uint32_t side_, uint32_t layer_, uint32_t ro
        *  [ ][.] | [x] R
        *  [ ][ ] | [ ] R-1
        */
-      ids_.push_back(geomtools::geom_id(_cell_type_, _module_number_, side_ + 1, 0, row_));
+      ids_.emplace_back(_cell_type_, _module_number_, side_ + 1, 0, row_);
     }
     if ((layer_ == 0) && (row_ < (_back_cell_y_.size() - 1)) && other_side_) {
       /*   1  0     0
@@ -273,7 +273,7 @@ void gg_locator::get_neighbours_ids(uint32_t side_, uint32_t layer_, uint32_t ro
        *  [ ][.] | [ ] R
        *  [ ][ ] | [ ] R-1
        */
-      ids_.push_back(geomtools::geom_id(_cell_type_, _module_number_, side_ + 1, 0, row_ + 1));
+      ids_.emplace_back(_cell_type_, _module_number_, side_ + 1, 0, row_ + 1);
     }
   }
   // front:
@@ -288,7 +288,7 @@ void gg_locator::get_neighbours_ids(uint32_t side_, uint32_t layer_, uint32_t ro
        *  [x][.][ ]
        *  [ ][ ][ ]
        */
-      ids_.push_back(geomtools::geom_id(_cell_type_, _module_number_, side_, layer_ - 1, row_));
+      ids_.emplace_back(_cell_type_, _module_number_, side_, layer_ - 1, row_);
     }
     if (layer_ < (_front_cell_x_.size() - 1)) {
       /*  L-1 L L+1
@@ -296,7 +296,7 @@ void gg_locator::get_neighbours_ids(uint32_t side_, uint32_t layer_, uint32_t ro
        *  [ ][.][x] R
        *  [ ][ ][ ] R-1
        */
-      ids_.push_back(geomtools::geom_id(_cell_type_, _module_number_, side_, layer_ + 1, row_));
+      ids_.emplace_back(_cell_type_, _module_number_, side_, layer_ + 1, row_);
     }
     if (row_ > 0) {
       /*  L-1 L L+1
@@ -304,7 +304,7 @@ void gg_locator::get_neighbours_ids(uint32_t side_, uint32_t layer_, uint32_t ro
        *  [ ][.][ ] R
        *  [ ][x][ ] R-1
        */
-      ids_.push_back(geomtools::geom_id(_cell_type_, _module_number_, side_, layer_, row_ - 1));
+      ids_.emplace_back(_cell_type_, _module_number_, side_, layer_, row_ - 1);
     }
     if (row_ < (_front_cell_y_.size() - 1)) {
       /*  L-1 L L+1
@@ -312,7 +312,7 @@ void gg_locator::get_neighbours_ids(uint32_t side_, uint32_t layer_, uint32_t ro
        *  [ ][.][ ] R
        *  [ ][ ][ ] R-1
        */
-      ids_.push_back(geomtools::geom_id(_cell_type_, _module_number_, side_, layer_, row_ + 1));
+      ids_.emplace_back(_cell_type_, _module_number_, side_, layer_, row_ + 1);
     }
 
     if ((layer_ < (_front_cell_x_.size() - 1)) && (row_ > 0)) {
@@ -321,7 +321,7 @@ void gg_locator::get_neighbours_ids(uint32_t side_, uint32_t layer_, uint32_t ro
        *  [ ][.][ ] R
        *  [ ][ ][x] R-1
        */
-      ids_.push_back(geomtools::geom_id(_cell_type_, _module_number_, side_, layer_ + 1, row_ - 1));
+      ids_.emplace_back(_cell_type_, _module_number_, side_, layer_ + 1, row_ - 1);
     }
     if ((layer_ < (_front_cell_x_.size() - 1)) && (row_ < (_front_cell_y_.size() - 1))) {
       /*  L-1 L L+1
@@ -329,7 +329,7 @@ void gg_locator::get_neighbours_ids(uint32_t side_, uint32_t layer_, uint32_t ro
        *  [ ][.][ ] R
        *  [ ][ ][ ] R-1
        */
-      ids_.push_back(geomtools::geom_id(_cell_type_, _module_number_, side_, layer_ + 1, row_ + 1));
+      ids_.emplace_back(_cell_type_, _module_number_, side_, layer_ + 1, row_ + 1);
     }
     if ((layer_ > 0) && (row_ > 0)) {
       /*  L-1 L L+1
@@ -337,7 +337,7 @@ void gg_locator::get_neighbours_ids(uint32_t side_, uint32_t layer_, uint32_t ro
        *  [ ][.][ ] R
        *  [x][ ][ ] R-1
        */
-      ids_.push_back(geomtools::geom_id(_cell_type_, _module_number_, side_, layer_ - 1, row_ - 1));
+      ids_.emplace_back(_cell_type_, _module_number_, side_, layer_ - 1, row_ - 1);
     }
     if ((layer_ > 0) && (row_ < (_front_cell_y_.size() - 1))) {
       /*  L-1 L L+1
@@ -345,7 +345,7 @@ void gg_locator::get_neighbours_ids(uint32_t side_, uint32_t layer_, uint32_t ro
        *  [ ][.][ ] R
        *  [ ][ ][ ] R-1
        */
-      ids_.push_back(geomtools::geom_id(_cell_type_, _module_number_, side_, layer_ - 1, row_ + 1));
+      ids_.emplace_back(_cell_type_, _module_number_, side_, layer_ - 1, row_ + 1);
     }
     if ((layer_ == 0) && (row_ > 0) && other_side_) {
       /*   0     0  1
@@ -353,7 +353,7 @@ void gg_locator::get_neighbours_ids(uint32_t side_, uint32_t layer_, uint32_t ro
        *  [ ] | [.][ ] R
        *  [x] | [ ]| [x] R-1
        */
-      ids_.push_back(geomtools::geom_id(_cell_type_, _module_number_, side_ - 1, 0, row_ - 1));
+      ids_.emplace_back(_cell_type_, _module_number_, side_ - 1, 0, row_ - 1);
     }
     if ((layer_ == 0) && other_side_) {
       /*   0     0  1
@@ -361,7 +361,7 @@ void gg_locator::get_neighbours_ids(uint32_t side_, uint32_t layer_, uint32_t ro
        *  [x] | [.][ ] R
        *  [ ] | [ ]| [x] R-1
        */
-      ids_.push_back(geomtools::geom_id(_cell_type_, _module_number_, side_ - 1, 0, row_));
+      ids_.emplace_back(_cell_type_, _module_number_, side_ - 1, 0, row_);
     }
     if ((layer_ == 0) && (row_ < (_front_cell_y_.size() - 1)) && other_side_) {
       /*   0     0  1
@@ -369,7 +369,7 @@ void gg_locator::get_neighbours_ids(uint32_t side_, uint32_t layer_, uint32_t ro
        *  [ ] | [.][ ] R
        *  [ ] | [ ]| [x] R-1
        */
-      ids_.push_back(geomtools::geom_id(_cell_type_, _module_number_, side_ - 1, 0, row_ + 1));
+      ids_.emplace_back(_cell_type_, _module_number_, side_ - 1, 0, row_ + 1);
     }
   }
 }
@@ -471,7 +471,7 @@ bool gg_locator::is_drift_cell_volume_in_current_module(const geomtools::geom_id
 
 void gg_locator::_hack_trace() {
   char *ev = getenv("FLGEOMLOCATOR");
-  if (ev != 0) {
+  if (ev != nullptr) {
     std::string evstr(ev);
     if (evstr == "trace") {
       set_logging_priority(datatools::logger::PRIO_TRACE);
@@ -499,14 +499,14 @@ void gg_locator::_set_defaults() {
   _row_index_ = -1;
 
   _module_number_ = geomtools::geom_id::INVALID_ADDRESS;
-  _mapping_ = 0;
-  _id_manager_ = 0;
-  _module_ginfo_ = 0;
-  _module_box_ = 0;
-  _cell_box_ = 0;
+  _mapping_ = nullptr;
+  _id_manager_ = nullptr;
+  _module_ginfo_ = nullptr;
+  _module_box_ = nullptr;
+  _cell_box_ = nullptr;
 
-  for (size_t i = 0; i < utils::NSIDES; i++) {
-    _submodules_[i] = false;
+  for (bool &_submodule : _submodules_) {
+    _submodule = false;
   }
 
   datatools::invalidate(_anode_wire_length_);
@@ -663,7 +663,7 @@ void gg_locator::_construct() {
 
   {
     // extract the geometry model associated to the "anode_wire" :
-    const geomtools::i_model *anode_wire_model = 0;
+    const geomtools::i_model *anode_wire_model = nullptr;
     std::string model_name = "anode_wire.model";  // default model name
     if (geom_mgr_setup_vid.has_major()) {
       // trick for an old version of the geometry
@@ -673,8 +673,7 @@ void gg_locator::_construct() {
       }
     }
 
-    geomtools::models_col_type::const_iterator found =
-        get_geo_manager().get_factory().get_models().find(model_name);
+    auto found = get_geo_manager().get_factory().get_models().find(model_name);
     DT_THROW_IF(found == get_geo_manager().get_factory().get_models().end(), std::logic_error,
                 "You should have found the '" << model_name << "' model here !");
     anode_wire_model = found->second;
@@ -688,8 +687,7 @@ void gg_locator::_construct() {
     const geomtools::i_shape_3d &anode_wire_shape = anode_wire_log.get_shape();
 
     // we know the concret shape class is a box, so we cast it :
-    const geomtools::cylinder &anode_wire_cylinder =
-        dynamic_cast<const geomtools::cylinder &>(anode_wire_shape);
+    const auto &anode_wire_cylinder = dynamic_cast<const geomtools::cylinder &>(anode_wire_shape);
 
     _anode_wire_length_ = anode_wire_cylinder.get_z();
     _anode_wire_diameter_ = anode_wire_cylinder.get_diameter();
@@ -697,7 +695,7 @@ void gg_locator::_construct() {
 
   {
     // extract the geometry model associated to the "field_wire" :
-    const geomtools::i_model *field_wire_model = 0;
+    const geomtools::i_model *field_wire_model = nullptr;
     std::string model_name = "field_wire.model";  // default model name
     if (geom_mgr_setup_vid.has_major()) {
       // trick for an old version of the geometry
@@ -707,8 +705,7 @@ void gg_locator::_construct() {
       }
     }
 
-    geomtools::models_col_type::const_iterator found =
-        get_geo_manager().get_factory().get_models().find(model_name);
+    auto found = get_geo_manager().get_factory().get_models().find(model_name);
     DT_THROW_IF(found == get_geo_manager().get_factory().get_models().end(), std::logic_error,
                 "You should have found the '" << model_name << "' model here !");
     field_wire_model = found->second;
@@ -722,8 +719,7 @@ void gg_locator::_construct() {
     const geomtools::i_shape_3d &field_wire_shape = field_wire_log.get_shape();
 
     // we know the concret shape class is a cylinder, so we cast it :
-    const geomtools::cylinder &field_wire_cylinder =
-        dynamic_cast<const geomtools::cylinder &>(field_wire_shape);
+    const auto &field_wire_cylinder = dynamic_cast<const geomtools::cylinder &>(field_wire_shape);
 
     _field_wire_length_ = field_wire_cylinder.get_z();
     _field_wire_diameter_ = field_wire_cylinder.get_diameter();
@@ -802,22 +798,22 @@ void gg_locator::tree_dump(std::ostream &out_, const std::string &title_,
   out_ << indent << itag << "Tracker layer type         = " << _tracker_layer_type_ << std::endl;
   out_ << indent << itag << "Cell type                  = " << _cell_type_ << std::endl;
   out_ << indent << itag << "Module placement    : " << std::endl;
-  if (_module_world_placement_ != 0) {
+  if (_module_world_placement_ != nullptr) {
     _module_world_placement_->tree_dump(out_, "", indent + stag);
   }
   out_ << indent << itag << "Module box : " << std::endl;
-  if (_module_box_ != 0) {
+  if (_module_box_ != nullptr) {
     _module_box_->tree_dump(out_, "", indent + stag);
   }
   out_ << indent << itag << "Back  submodule : " << _submodules_[utils::SIDE_BACK] << std::endl;
   out_ << indent << itag << "Front submodule : " << _submodules_[utils::SIDE_FRONT] << std::endl;
   out_ << indent << itag << "Cell box : " << std::endl;
-  if (_cell_box_ != 0) {
+  if (_cell_box_ != nullptr) {
     _cell_box_->tree_dump(out_, "", indent + stag);
   }
   out_ << indent << itag << "Back layer X-pos [" << _back_cell_x_.size() << "] = ";
-  for (size_t i = 0; i < _back_cell_x_.size(); i++) {
-    out_ << _back_cell_x_[i] / CLHEP::mm << " ";
+  for (double i : _back_cell_x_) {
+    out_ << i / CLHEP::mm << " ";
   }
   out_ << " (mm)" << std::endl;
   out_ << indent << itag << "Back cell Y-pos [" << _back_cell_y_.size() << "] = ";
@@ -830,8 +826,8 @@ void gg_locator::tree_dump(std::ostream &out_, const std::string &title_,
   }
   out_ << " (mm)" << std::endl;
   out_ << indent << itag << "Front layer X-pos [" << _front_cell_x_.size() << "] =  ";
-  for (size_t i = 0; i < _front_cell_x_.size(); i++) {
-    out_ << _front_cell_x_[i] / CLHEP::mm << " ";
+  for (double i : _front_cell_x_) {
+    out_ << i / CLHEP::mm << " ";
   }
   out_ << " (mm)" << std::endl;
   out_ << indent << itag << "Front cell Y-pos [" << _front_cell_y_.size() << "] = ";
@@ -1046,7 +1042,7 @@ bool gg_locator::_find_cell_geom_id(const geomtools::vector_3d &in_module_positi
     if (gid.is_valid()) {
       // 2012-05-31 FM : use ginfo from mapping (see below)
       const geomtools::geom_info *ginfo_ptr = _mapping_->get_geom_info_ptr(gid);
-      if (ginfo_ptr == 0) {
+      if (ginfo_ptr == nullptr) {
         DT_LOG_TRACE(get_logging_priority(), "Unmapped gid = " << gid);
         DT_LOG_TRACE(get_logging_priority(), "Not a GG!");
         gid.invalidate();

--- a/source/falaise/snemo/geometry/gveto_locator.cc
+++ b/source/falaise/snemo/geometry/gveto_locator.cc
@@ -455,14 +455,14 @@ void gveto_locator::_set_defaults_() {
   _block_part_ = geomtools::geom_id::INVALID_ADDRESS;
   _block_partitioned_ = false;
 
-  _mapping_ = 0;
-  _id_manager_ = 0;
-  _module_ginfo_ = 0;
-  _module_world_placement_ = 0;
-  _module_box_ = 0;
-  _block_shape_ = 0;
+  _mapping_ = nullptr;
+  _id_manager_ = nullptr;
+  _module_ginfo_ = nullptr;
+  _module_world_placement_ = nullptr;
+  _module_box_ = nullptr;
+  _block_shape_ = nullptr;
   _composite_block_shape_ = false;
-  _block_box_ = 0;
+  _block_box_ = nullptr;
 
   for (unsigned int i = 0; i < utils::NSIDES; i++) {
     for (unsigned int j = 0; j < NWALLS_PER_SIDE; j++) {
@@ -612,8 +612,7 @@ void gveto_locator::_construct() {
     // Example : 'calo_scin_box_model' case :
     _composite_block_shape_ = true;
 
-    const geomtools::subtraction_3d &ref_s3d =
-        dynamic_cast<const geomtools::subtraction_3d &>(*_block_shape_);
+    const auto &ref_s3d = dynamic_cast<const geomtools::subtraction_3d &>(*_block_shape_);
     const geomtools::i_composite_shape_3d::shape_type &sht1 = ref_s3d.get_shape1();
     const geomtools::i_shape_3d &sh1 = sht1.get_shape();
     DT_THROW_IF(sh1.get_shape_name() != "box", std::logic_error,
@@ -623,13 +622,12 @@ void gveto_locator::_construct() {
     // Example : 'calo_tapered_scin_box_model' case :
     _composite_block_shape_ = true;
 
-    const geomtools::intersection_3d &ref_i3d =
-        dynamic_cast<const geomtools::intersection_3d &>(*_block_shape_);
+    const auto &ref_i3d = dynamic_cast<const geomtools::intersection_3d &>(*_block_shape_);
     const geomtools::i_composite_shape_3d::shape_type &sht1 = ref_i3d.get_shape1();
     const geomtools::i_shape_3d &sh1 = sht1.get_shape();
     DT_THROW_IF(sh1.get_shape_name() != "subtraction_3d", std::logic_error,
                 "Do not support non-subtraction_3d shaped block with ID = " << block_gid << " !");
-    const geomtools::subtraction_3d &ref_s3d = dynamic_cast<const geomtools::subtraction_3d &>(sh1);
+    const auto &ref_s3d = dynamic_cast<const geomtools::subtraction_3d &>(sh1);
     const geomtools::i_composite_shape_3d::shape_type &sht11 = ref_s3d.get_shape1();
     const geomtools::i_shape_3d &sh11 = sht11.get_shape();
     DT_THROW_IF(sh11.get_shape_name() != "box", std::logic_error,
@@ -811,11 +809,11 @@ void gveto_locator::tree_dump(std::ostream &out_, const std::string &title_,
   }
   out_ << indent << itag << "Module ginfo @             = " << _module_ginfo_ << std::endl;
   out_ << indent << itag << "Module placement : " << std::endl;
-  if (_module_world_placement_ != 0) {
+  if (_module_world_placement_ != nullptr) {
     _module_world_placement_->tree_dump(out_, "", indent + stag);
   }
   out_ << indent << itag << "Module box : " << std::endl;
-  if (_module_box_ != 0) {
+  if (_module_box_ != nullptr) {
     _module_box_->tree_dump(out_, "", indent + stag);
   }
   out_ << indent << itag << "Back  submodule : " << _submodules_[utils::SIDE_BACK] << std::endl;
@@ -823,21 +821,21 @@ void gveto_locator::tree_dump(std::ostream &out_, const std::string &title_,
   out_ << indent << itag << "Block shape : " << _block_shape_->get_shape_name() << std::endl;
   out_ << indent << itag << "Composite block shape = " << _composite_block_shape_ << std::endl;
   out_ << indent << itag << "Block box : " << std::endl;
-  if (_block_box_ != 0) {
+  if (_block_box_ != nullptr) {
     _block_box_->tree_dump(out_, "", indent + stag);
   }
   for (size_t i = 0; i < NWALLS_PER_SIDE; ++i) {
     const std::string wall_name = (i == (unsigned int)WALL_TOP) ? "top wall" : "bottom wall";
     out_ << indent << itag << "Back block X-pos on " << wall_name << " ["
          << _back_block_x_[i].size() << "] = ";
-    for (size_t j = 0; j < _back_block_x_[i].size(); j++) {
-      out_ << _back_block_x_[i][j] / CLHEP::mm << " ";
+    for (double j : _back_block_x_[i]) {
+      out_ << j / CLHEP::mm << " ";
     }
     out_ << "(mm)" << std::endl;
     out_ << indent << itag << "Front block X-pos on " << wall_name << " ["
          << _front_block_x_[i].size() << "] = ";
-    for (size_t j = 0; j < _front_block_x_[i].size(); j++) {
-      out_ << _front_block_x_[i][j] / CLHEP::mm << " ";
+    for (double j : _front_block_x_[i]) {
+      out_ << j / CLHEP::mm << " ";
     }
     out_ << "(mm)" << std::endl;
     out_ << indent << itag << "Back block Y-pos on " << wall_name << " ["
@@ -977,7 +975,7 @@ bool gveto_locator::id_is_valid(uint32_t side_, uint32_t wall_, uint32_t column_
 
 void gveto_locator::_hack_trace() {
   char *ev = getenv("FLGEOMLOCATOR");
-  if (ev != 0) {
+  if (ev != nullptr) {
     std::string evstr(ev);
     if (evstr == "trace") {
       set_logging_priority(datatools::logger::PRIO_TRACE);
@@ -1062,7 +1060,7 @@ bool gveto_locator::find_block_geom_id_(const geomtools::vector_3d &in_module_po
       if (delta_z < tolerance) {
         wall_number = WALL_BOTTOM;
         DT_LOG_TRACE(get_logging_priority(), "WALL_BOTTOM: wall_number=" << wall_number);
-        const std::vector<double> *block_y_ptr = 0;
+        const std::vector<double> *block_y_ptr = nullptr;
         if (_submodules_[utils::SIDE_BACK] && side_number == utils::SIDE_BACK) {
           block_y_ptr = &_back_block_y_[wall_number];
         }
@@ -1086,7 +1084,7 @@ bool gveto_locator::find_block_geom_id_(const geomtools::vector_3d &in_module_po
       if (delta_z < tolerance) {
         wall_number = WALL_TOP;
         DT_LOG_TRACE(get_logging_priority(), "WALL_TOP:  wall_number=" << wall_number);
-        const std::vector<double> *block_y_ptr = 0;
+        const std::vector<double> *block_y_ptr = nullptr;
         if (_submodules_[utils::SIDE_BACK] && side_number == utils::SIDE_BACK) {
           block_y_ptr = &_back_block_y_[wall_number];
         }
@@ -1139,7 +1137,7 @@ bool gveto_locator::find_block_geom_id_(const geomtools::vector_3d &in_module_po
     if (gid.is_valid()) {
       // 2012-05-31 FM : use ginfo from mapping(see below)
       const geomtools::geom_info *ginfo_ptr = _mapping_->get_geom_info_ptr(gid);
-      if (ginfo_ptr == 0) {
+      if (ginfo_ptr == nullptr) {
         DT_LOG_TRACE(get_logging_priority(), "Unmapped gid = " << gid);
         DT_LOG_TRACE(get_logging_priority(), "Not a G-veto!");
         gid.invalidate();

--- a/source/falaise/snemo/geometry/gveto_locator.cc
+++ b/source/falaise/snemo/geometry/gveto_locator.cc
@@ -104,12 +104,11 @@ double gveto_locator::get_column_x(uint32_t side_, uint32_t wall_, uint32_t colu
         column_ >= _back_block_x_[wall_].size(), std::logic_error,
         "Invalid column number(" << column_ << ">" << _back_block_x_[wall_].size() - 1 << ")!");
     return _back_block_x_[wall_][column_];
-  } else {
-    DT_THROW_IF(
-        column_ >= _front_block_x_[wall_].size(), std::logic_error,
-        "Invalid column number(" << column_ << ">" << _front_block_x_[wall_].size() - 1 << ")!");
-    return _front_block_x_[wall_][column_];
   }
+  DT_THROW_IF(
+      column_ >= _front_block_x_[wall_].size(), std::logic_error,
+      "Invalid column number(" << column_ << ">" << _front_block_x_[wall_].size() - 1 << ")!");
+  return _front_block_x_[wall_][column_];
 }
 
 double gveto_locator::get_column_y(uint32_t side_, uint32_t wall_, uint32_t column_) const {
@@ -124,12 +123,11 @@ double gveto_locator::get_column_y(uint32_t side_, uint32_t wall_, uint32_t colu
         column_ >= _back_block_y_[wall_].size(), std::logic_error,
         "Invalid column number(" << column_ << ">" << _back_block_y_[wall_].size() - 1 << ")!");
     return _back_block_y_[wall_][column_];
-  } else {
-    DT_THROW_IF(
-        column_ >= _front_block_y_[wall_].size(), std::logic_error,
-        "Invalid column number(" << column_ << ">" << _front_block_y_[wall_].size() - 1 << ")!");
-    return _front_block_y_[wall_][column_];
   }
+  DT_THROW_IF(
+      column_ >= _front_block_y_[wall_].size(), std::logic_error,
+      "Invalid column number(" << column_ << ">" << _front_block_y_[wall_].size() - 1 << ")!");
+  return _front_block_y_[wall_][column_];
 }
 
 void gveto_locator::compute_block_position(uint32_t side_, uint32_t wall_, uint32_t column_,
@@ -137,7 +135,6 @@ void gveto_locator::compute_block_position(uint32_t side_, uint32_t wall_, uint3
   geomtools::invalidate(module_position_);
   module_position_.set(get_column_x(side_, wall_, column_), get_column_y(side_, wall_, column_),
                        get_wall_z(side_, wall_));
-  return;
 }
 
 void gveto_locator::compute_block_window_position(uint32_t side_, uint32_t wall_, uint32_t column_,
@@ -145,7 +142,6 @@ void gveto_locator::compute_block_window_position(uint32_t side_, uint32_t wall_
   geomtools::invalidate(module_position_);
   module_position_.set(get_column_x(side_, wall_, column_), get_column_y(side_, wall_, column_),
                        get_wall_z(side_, wall_));
-  return;
 }
 
 geomtools::vector_3d gveto_locator::get_block_position(uint32_t side_, uint32_t wall_,
@@ -207,7 +203,6 @@ void gveto_locator::get_block_position(uint32_t side_, uint32_t wall_, uint32_t 
     position_.set(_front_block_x_[wall_][0], _front_block_y_[wall_][column_],
                   _block_z_[side_][wall_]);
   }
-  return;
 }
 
 void gveto_locator::get_neighbours_ids(const geomtools::geom_id &gid_,
@@ -220,7 +215,6 @@ void gveto_locator::get_neighbours_ids(const geomtools::geom_id &gid_,
                                        << "!=" << _module_number_ << ")!");
   get_neighbours_ids(gid_.get(_side_address_index_), gid_.get(_wall_address_index_),
                      gid_.get(_column_address_index_), ids_, mask_);
-  return;
 }
 
 void gveto_locator::get_neighbours_ids(uint32_t side_, uint32_t wall_, uint32_t column_,
@@ -234,9 +228,9 @@ void gveto_locator::get_neighbours_ids(uint32_t side_, uint32_t wall_, uint32_t 
   ids_.clear();
   ids_.reserve(8);
 
-  const bool sides = mask_ & utils::NEIGHBOUR_SIDE;
-  const bool diagonal = mask_ & utils::NEIGHBOUR_DIAG;
-  const bool second = mask_ & utils::NEIGHBOUR_SECOND;
+  const bool sides = (mask_ & utils::NEIGHBOUR_SIDE) != 0;
+  const bool diagonal = (mask_ & utils::NEIGHBOUR_DIAG) != 0;
+  const bool second = (mask_ & utils::NEIGHBOUR_SECOND) != 0;
   if (second) {
     DT_LOG_NOTICE(get_logging_priority(),
                   "Looking for second order neighbour of 'gveto' locator is not implemented !");
@@ -381,8 +375,6 @@ void gveto_locator::get_neighbours_ids(uint32_t side_, uint32_t wall_, uint32_t 
       ids_.push_back(gid);
     }
   }
-
-  return;
 }
 
 size_t gveto_locator::get_number_of_neighbours(uint32_t side_, uint32_t wall_, uint32_t column_,
@@ -395,9 +387,9 @@ size_t gveto_locator::get_number_of_neighbours(uint32_t side_, uint32_t wall_, u
 
   bool corner = false;
   bool side = false;
-  const bool sides = mask_ & utils::NEIGHBOUR_SIDE;
-  const bool diagonal = mask_ & utils::NEIGHBOUR_DIAG;
-  const bool second = mask_ & utils::NEIGHBOUR_SECOND;
+  const bool sides = (mask_ & utils::NEIGHBOUR_SIDE) != 0;
+  const bool diagonal = (mask_ & utils::NEIGHBOUR_DIAG) != 0;
+  const bool second = (mask_ & utils::NEIGHBOUR_SECOND) != 0;
   if (second) {
     DT_LOG_NOTICE(get_logging_priority(),
                   "Looking for second order neighbour of 'gveto' locator is not implemented !");
@@ -415,14 +407,26 @@ size_t gveto_locator::get_number_of_neighbours(uint32_t side_, uint32_t wall_, u
   }
   size_t number = 0;
   if (corner) {
-    if (sides) number += 2;
-    if (diagonal) number += 1;
+    if (sides) {
+      number += 2;
+    }
+    if (diagonal) {
+      number += 1;
+    }
   } else if (side) {
-    if (sides) number += 3;
-    if (diagonal) number += 2;
+    if (sides) {
+      number += 3;
+    }
+    if (diagonal) {
+      number += 2;
+    }
   } else {
-    if (sides) number += 4;
-    if (diagonal) number += 4;
+    if (sides) {
+      number += 4;
+    }
+    if (diagonal) {
+      number += 4;
+    }
   }
   return number;
 }
@@ -479,24 +483,17 @@ void gveto_locator::_set_defaults_() {
   _part_address_index_ = geomtools::geom_id::INVALID_ADDRESS;
 
   _initialized_ = false;
-  return;
 }
 
 // Constructor:
-gveto_locator::gveto_locator() : base_locator() {
-  _set_defaults_();
-  return;
-}
+gveto_locator::gveto_locator() { _set_defaults_(); }
 
 // Constructor:
-gveto_locator::gveto_locator(const ::geomtools::manager &mgr_, uint32_t module_number_)
-    : base_locator() {
+gveto_locator::gveto_locator(const ::geomtools::manager &mgr_, uint32_t module_number_) {
   _set_defaults_();
 
   set_geo_manager(mgr_);
   set_module_number(module_number_);
-
-  return;
 }
 
 // dtor:
@@ -504,7 +501,6 @@ gveto_locator::~gveto_locator() {
   if (is_initialized()) {
     reset();
   }
-  return;
 }
 
 bool gveto_locator::is_block_partitioned() const { return _block_partitioned_; }
@@ -658,7 +654,9 @@ void gveto_locator::_construct() {
   vcy[utils::SIDE_FRONT][WALL_TOP] = &_front_block_y_[WALL_TOP];
   vcy[utils::SIDE_FRONT][WALL_BOTTOM] = &_front_block_y_[WALL_BOTTOM];
   for (unsigned int iside = 0; iside < utils::NSIDES; iside++) {
-    if (!_submodules_[iside]) continue;
+    if (!_submodules_[iside]) {
+      continue;
+    }
     for (unsigned int wall = 0; wall < NWALLS_PER_SIDE; wall++) {
       size_t i_column = 0;
       vcx[iside][wall]->reserve(1);
@@ -708,8 +706,6 @@ void gveto_locator::_construct() {
   _block_width_ = _block_box_->get_x();
   _block_height_ = _block_box_->get_y();
   _block_thickness_ = _block_box_->get_z();
-
-  return;
 }
 
 int gveto_locator::get_module_address_index() const { return _module_address_index_; }
@@ -756,7 +752,6 @@ bool gveto_locator::is_calo_block_in_current_module(const geomtools::geom_id &gi
 void gveto_locator::set_module_number(uint32_t a_module_number) {
   DT_THROW_IF(is_initialized(), std::logic_error, "Locator is already initialized !");
   _module_number_ = a_module_number;
-  return;
 }
 
 uint32_t gveto_locator::get_module_number() const { return _module_number_; }
@@ -764,7 +759,6 @@ uint32_t gveto_locator::get_module_number() const { return _module_number_; }
 void gveto_locator::initialize() {
   datatools::properties dummy;
   initialize(dummy);
-  return;
 }
 
 void gveto_locator::initialize(const datatools::properties &config_) {
@@ -777,12 +771,10 @@ void gveto_locator::initialize(const datatools::properties &config_) {
   if (datatools::logger::is_trace(get_logging_priority())) {
     tree_dump(std::cerr, "Gamma-veto locator : ", "[trace] ");
   }
-  return;
 }
 
 void gveto_locator::dump(std::ostream &out_) const {
   gveto_locator::tree_dump(out_, "snemo::geometry:gveto_locator::dump: ");
-  return;
 }
 
 void gveto_locator::tree_dump(std::ostream &out_, const std::string &title_,
@@ -814,8 +806,9 @@ void gveto_locator::tree_dump(std::ostream &out_, const std::string &title_,
   out_ << indent << itag << "Calorimeter block type     = " << _block_type_ << std::endl;
   out_ << indent << itag << "Calorimeter wrapper type   = " << _wrapper_type_ << std::endl;
   out_ << indent << itag << "Block partitioned          = " << _block_partitioned_ << std::endl;
-  if (is_block_partitioned())
+  if (is_block_partitioned()) {
     out_ << indent << itag << "Block part                 = " << _block_part_ << std::endl;
+  }
   out_ << indent << itag << "Module ginfo @             = " << _module_ginfo_ << std::endl;
   out_ << indent << itag << "Module placement : " << std::endl;
   if (_module_world_placement_ != 0) {
@@ -891,7 +884,6 @@ void gveto_locator::tree_dump(std::ostream &out_, const std::string &title_,
     out_ << indent << datatools::i_tree_dumpable::inherit_tag(inherit_)
          << "Part address GID index   = " << _part_address_index_ << std::endl;
   }
-  return;
 }
 
 void gveto_locator::reset() {
@@ -903,21 +895,18 @@ void gveto_locator::reset() {
     _front_block_y_[i].clear();
   }
   _set_defaults_();
-  return;
 }
 
 void gveto_locator::transform_world_to_module(const geomtools::vector_3d &world_position_,
                                               geomtools::vector_3d &module_position_) const {
   DT_THROW_IF(!is_initialized(), std::logic_error, "Locator is not initialized !");
   _module_world_placement_->mother_to_child(world_position_, module_position_);
-  return;
 }
 
 void gveto_locator::transform_module_to_world(const geomtools::vector_3d &module_position_,
                                               geomtools::vector_3d &world_position_) const {
   DT_THROW_IF(!is_initialized(), std::logic_error, "Locator is not initialized !");
   _module_world_placement_->child_to_mother(module_position_, world_position_);
-  return;
 }
 
 bool gveto_locator::is_in_module(const geomtools::vector_3d &module_position_,
@@ -996,7 +985,6 @@ void gveto_locator::_hack_trace() {
                    "Trace logging activated through env 'FLGEOMLOCATOR'...");
     }
   }
-  return;
 }
 
 bool gveto_locator::find_block_geom_id(const geomtools::vector_3d &world_position_,
@@ -1142,7 +1130,9 @@ bool gveto_locator::find_block_geom_id_(const geomtools::vector_3d &in_module_po
     const int iy = (int)(((y - first_block_y) / block_delta_y) + 0.5);
     if ((iy >= 0) && (iy < (int)ncolumns)) {
       column_number = iy;
-      if (y > 0.0) column_number += ncolumns;
+      if (y > 0.0) {
+        column_number += ncolumns;
+      }
     }
     gid.set(_column_address_index_, column_number);
     DT_LOG_TRACE(get_logging_priority(), "gid = " << gid);
@@ -1161,7 +1151,7 @@ bool gveto_locator::find_block_geom_id_(const geomtools::vector_3d &in_module_po
       geomtools::vector_3d world_position;
       transform_module_to_world(in_module_position_, world_position);
       double tolerance_2 = 1.e-7 * CLHEP::mm;
-      if (_mapping_->check_inside(*ginfo_ptr, world_position, tolerance_2)) {
+      if (geomtools::mapping::check_inside(*ginfo_ptr, world_position, tolerance_2)) {
         DT_LOG_TRACE(get_logging_priority(), "INSIDE " << gid);
         DT_LOG_TRACE_EXITING(get_logging_priority());
         return true;

--- a/source/falaise/snemo/geometry/locator_plugin.cc
+++ b/source/falaise/snemo/geometry/locator_plugin.cc
@@ -59,10 +59,10 @@ locator_plugin::locator_dict_type& locator_plugin::grab_locators() {
 
 locator_plugin::locator_plugin() {
   _initialized_ = false;
-  _gg_locator_ = 0;
-  _calo_locator_ = 0;
-  _xcalo_locator_ = 0;
-  _gveto_locator_ = 0;
+  _gg_locator_ = nullptr;
+  _calo_locator_ = nullptr;
+  _xcalo_locator_ = nullptr;
+  _gveto_locator_ = nullptr;
 }
 
 locator_plugin::~locator_plugin() {
@@ -88,12 +88,12 @@ int locator_plugin::initialize(const datatools::properties& config_,
 }
 
 int locator_plugin::reset() {
-  _gg_locator_ = 0;
-  _calo_locator_ = 0;
-  _xcalo_locator_ = 0;
-  _gveto_locator_ = 0;
-  for (locator_dict_type::iterator iloc = _locators_.begin(); iloc != _locators_.end(); ++iloc) {
-    geomtools::base_locator& a_locator = iloc->second.locator_handle.grab();
+  _gg_locator_ = nullptr;
+  _calo_locator_ = nullptr;
+  _xcalo_locator_ = nullptr;
+  _gveto_locator_ = nullptr;
+  for (auto& _locator : _locators_) {
+    geomtools::base_locator& a_locator = _locator.second.locator_handle.grab();
     a_locator.reset();
   }
   _initialized_ = false;

--- a/source/falaise/snemo/geometry/locator_plugin.cc
+++ b/source/falaise/snemo/geometry/locator_plugin.cc
@@ -19,13 +19,13 @@ namespace geometry {
 
 GEOMTOOLS_PLUGIN_REGISTRATION_IMPLEMENT(locator_plugin, "snemo::geometry::locator_plugin")
 
-bool locator_plugin::has_gg_locator() const { return _gg_locator_; }
+bool locator_plugin::has_gg_locator() const { return _gg_locator_ != nullptr; }
 
-bool locator_plugin::has_calo_locator() const { return _calo_locator_; }
+bool locator_plugin::has_calo_locator() const { return _calo_locator_ != nullptr; }
 
-bool locator_plugin::has_xcalo_locator() const { return _xcalo_locator_; }
+bool locator_plugin::has_xcalo_locator() const { return _xcalo_locator_ != nullptr; }
 
-bool locator_plugin::has_gveto_locator() const { return _gveto_locator_; }
+bool locator_plugin::has_gveto_locator() const { return _gveto_locator_ != nullptr; }
 
 const snemo::geometry::gg_locator& locator_plugin::get_gg_locator() const {
   DT_THROW_IF(!is_initialized(), std::logic_error, "Locator plugin is not initialized !");
@@ -63,14 +63,12 @@ locator_plugin::locator_plugin() {
   _calo_locator_ = 0;
   _xcalo_locator_ = 0;
   _gveto_locator_ = 0;
-  return;
 }
 
 locator_plugin::~locator_plugin() {
   if (is_initialized()) {
     reset();
   }
-  return;
 }
 
 bool locator_plugin::is_initialized() const { return _initialized_; }
@@ -200,7 +198,6 @@ void locator_plugin::_build_locators(const datatools::properties& config_) {
   }
 
   DT_LOG_TRACE(get_logging_priority(), "Exiting.");
-  return;
 }
 
 }  // end of namespace geometry

--- a/source/falaise/snemo/geometry/mapped_magnetic_field.cc
+++ b/source/falaise/snemo/geometry/mapped_magnetic_field.cc
@@ -62,11 +62,15 @@ std::istream& safe_getline(std::istream& in_, std::string& out_) {
       case '\n':
         return in_;
       case '\r':
-        if (sb->sgetc() == '\n') sb->sbumpc();
+        if (sb->sgetc() == '\n') {
+          sb->sbumpc();
+        }
         return in_;
       case EOF:
         // Also handle the case when the last line has no line ending
-        if (out_.empty()) in_.setstate(std::ios::eofbit);
+        if (out_.empty()) {
+          in_.setstate(std::ios::eofbit);
+        }
         return in_;
       default:
         out_ += (char)c;
@@ -87,7 +91,7 @@ struct csv_map_0_type {
   csv_map_0_type();
   void init();
   void load();
-  void dump(std::ostream& = std::clog) const;
+  void dump(std::ostream& /*out_*/ = std::clog) const;
   void reset();
   int interpolate(const ::geomtools::vector_3d& position_,
                   ::geomtools::vector_3d& magnetic_field_) const;
@@ -126,7 +130,6 @@ csv_map_0_type::csv_map_0_type() {
   datatools::invalidate(dx);
   datatools::invalidate(dy);
   datatools::invalidate(dz);
-  return;
 }
 
 void csv_map_0_type::reset() {
@@ -138,7 +141,6 @@ void csv_map_0_type::reset() {
   datatools::invalidate(dx);
   datatools::invalidate(dy);
   datatools::invalidate(dz);
-  return;
 }
 
 void csv_map_0_type::dump(std::ostream& out_) const {
@@ -150,7 +152,6 @@ void csv_map_0_type::dump(std::ostream& out_) const {
   out_ << "  dx = " << dx / CLHEP::mm << " mm" << '\n';
   out_ << "  dy = " << dy / CLHEP::mm << " mm" << '\n';
   out_ << "  dz = " << dz / CLHEP::mm << " mm" << '\n';
-  return;
 }
 
 /// \brief Private working data
@@ -161,61 +162,44 @@ struct mapped_magnetic_field::_work_type {
   csv_map_0_type csv_map_0_data;
 };
 
-mapped_magnetic_field::_work_type::_work_type() { return; }
+mapped_magnetic_field::_work_type::_work_type() {}
 
-mapped_magnetic_field::_work_type::~_work_type() {
-  reset();
-  return;
-}
+mapped_magnetic_field::_work_type::~_work_type() { reset(); }
 
-void mapped_magnetic_field::_work_type::reset() {
-  csv_map_0_data.reset();
-  return;
-}
+void mapped_magnetic_field::_work_type::reset() { csv_map_0_data.reset(); }
 
 void mapped_magnetic_field::_set_defaults() {
   _mapping_mode_ = MM_INVALID;
   _zero_field_outside_map_ = true;
   _z_inverted_ = false;
-  return;
 }
 
 mapped_magnetic_field::mapped_magnetic_field(uint32_t flags_)
     : ::emfield::base_electromagnetic_field(flags_) {
   _set_defaults();
-  return;
 }
 
 mapped_magnetic_field::~mapped_magnetic_field() {
   if (is_initialized()) {
     reset();
   }
-  return;
 }
 
 void mapped_magnetic_field::set_map_filename(const std::string& mfn_) {
   DT_THROW_IF(is_initialized(), std::logic_error, "Cannot change the map source filename !");
   _map_filename_ = mfn_;
-  return;
 }
 
 void mapped_magnetic_field::set_mapping_mode(mapping_mode_type mm_) {
   DT_THROW_IF(is_initialized(), std::logic_error, "Cannot change the magnetic field value !");
   _mapping_mode_ = mm_;
-  return;
 }
 
-void mapped_magnetic_field::set_zero_field_outside_map(bool f_) {
-  _zero_field_outside_map_ = f_;
-  return;
-}
+void mapped_magnetic_field::set_zero_field_outside_map(bool f_) { _zero_field_outside_map_ = f_; }
 
 bool mapped_magnetic_field::is_zero_field_outside_map() const { return _zero_field_outside_map_; }
 
-void mapped_magnetic_field::set_z_inverted(bool f_) {
-  _z_inverted_ = f_;
-  return;
-}
+void mapped_magnetic_field::set_z_inverted(bool f_) { _z_inverted_ = f_; }
 
 bool mapped_magnetic_field::is_z_inverted() const { return _z_inverted_; }
 
@@ -269,7 +253,6 @@ void mapped_magnetic_field::initialize(const ::datatools::properties& config_,
   }
 
   _set_initialized(true);
-  return;
 }
 
 void mapped_magnetic_field::reset() {
@@ -283,7 +266,6 @@ void mapped_magnetic_field::reset() {
   _map_filename_.clear();
   _set_defaults();
   this->base_electromagnetic_field::_set_defaults();
-  return;
 }
 
 void mapped_magnetic_field::tree_dump(std::ostream& out_, const std::string& title_,
@@ -295,8 +277,6 @@ void mapped_magnetic_field::tree_dump(std::ostream& out_, const std::string& tit
 
   out_ << indent_ << datatools::i_tree_dumpable::inherit_tag(inherit_) << "Map file : '"
        << _map_filename_ << std::endl;
-
-  return;
 }
 
 int mapped_magnetic_field::compute_electric_field(const geomtools::vector_3d& /* position_ */,
@@ -328,10 +308,7 @@ int mapped_magnetic_field::compute_magnetic_field(const ::geomtools::vector_3d& 
   return status;
 }
 
-void csv_map_0_type::init() {
-  load();
-  return;
-}
+void csv_map_0_type::init() { load(); }
 
 void csv_map_0_type::load() {
   DT_LOG_TRACE_ENTERING(logging);
@@ -435,7 +412,6 @@ void csv_map_0_type::load() {
   }
 
   DT_LOG_TRACE_EXITING(logging);
-  return;
 }
 
 int csv_map_0_type::interpolate(const ::geomtools::vector_3d& position_,

--- a/source/falaise/snemo/geometry/mapped_magnetic_field.cc
+++ b/source/falaise/snemo/geometry/mapped_magnetic_field.cc
@@ -113,10 +113,10 @@ struct csv_map_0_type {
   double dy;
   double dz;
   // Mapped B-field:
-  typedef std::vector<int> vd;
-  typedef std::vector<vd> vvd;
-  typedef std::vector<vvd> vvvd;
-  typedef std::vector<vvvd> vvvvd;
+  using vd = std::vector<int>;
+  using vvd = std::vector<vd>;
+  using vvvd = std::vector<vvd>;
+  using vvvvd = std::vector<vvvd>;
   vvvvd bmap;
 };
 
@@ -162,7 +162,7 @@ struct mapped_magnetic_field::_work_type {
   csv_map_0_type csv_map_0_data;
 };
 
-mapped_magnetic_field::_work_type::_work_type() {}
+mapped_magnetic_field::_work_type::_work_type() = default;
 
 mapped_magnetic_field::_work_type::~_work_type() { reset(); }
 
@@ -391,9 +391,9 @@ void csv_map_0_type::load() {
           boost::split(btokens, bmap_line, boost::is_any_of(","));
           DT_LOG_TRACE(logging, "    btokens.size = [" << btokens.size() << "]");
           DT_THROW_IF(btokens.size() != nx + 3, std::logic_error, "Invalid B-line format!");
-          unsigned int axi = boost::lexical_cast<unsigned int>(btokens[0]);
-          unsigned int iyi = boost::lexical_cast<unsigned int>(btokens[1]);
-          unsigned int izi = boost::lexical_cast<unsigned int>(btokens[2]);
+          auto axi = boost::lexical_cast<unsigned int>(btokens[0]);
+          auto iyi = boost::lexical_cast<unsigned int>(btokens[1]);
+          auto izi = boost::lexical_cast<unsigned int>(btokens[2]);
           DT_LOG_TRACE(logging, "    axi=[" << axi << "] iyi=[" << iyi << "] izi=[" << izi << "] ");
           DT_THROW_IF(axi != ax || iyi != iy || izi != iz, std::logic_error,
                       "Invalid B map line format!");

--- a/source/falaise/snemo/geometry/utils.cc
+++ b/source/falaise/snemo/geometry/utils.cc
@@ -43,15 +43,23 @@ const std::string& utils::side_front_label() {
 
 // static
 bool utils::is_side_label_valid(const std::string& label_) {
-  if (label_ == side_back_label()) return true;
-  if (label_ == side_front_label()) return true;
+  if (label_ == side_back_label()) {
+    return true;
+  }
+  if (label_ == side_front_label()) {
+    return true;
+  }
   return false;
 }
 
 // static
 int utils::get_side_from_label(const std::string& label_) {
-  if (label_ == side_back_label()) return SIDE_BACK;
-  if (label_ == side_front_label()) return SIDE_FRONT;
+  if (label_ == side_back_label()) {
+    return SIDE_BACK;
+  }
+  if (label_ == side_front_label()) {
+    return SIDE_FRONT;
+  }
   return SIDE_INVALID;
 }
 

--- a/source/falaise/snemo/geometry/xcalo_locator.cc
+++ b/source/falaise/snemo/geometry/xcalo_locator.cc
@@ -105,12 +105,11 @@ double xcalo_locator::get_column_x(uint32_t side_, uint32_t wall_, uint32_t colu
         column_ >= _back_block_x_[wall_].size(), std::logic_error,
         "Invalid column number (" << column_ << ">" << _back_block_x_[wall_].size() - 1 << ")!");
     return _back_block_x_[wall_][column_];
-  } else {
-    DT_THROW_IF(
-        column_ >= _front_block_x_[wall_].size(), std::logic_error,
-        "Invalid column number (" << column_ << ">" << _front_block_x_[wall_].size() - 1 << ")!");
-    return _front_block_x_[wall_][column_];
   }
+  DT_THROW_IF(
+      column_ >= _front_block_x_[wall_].size(), std::logic_error,
+      "Invalid column number (" << column_ << ">" << _front_block_x_[wall_].size() - 1 << ")!");
+  return _front_block_x_[wall_][column_];
 }
 
 double xcalo_locator::get_row_z(uint32_t side_, uint32_t wall_, uint32_t row_) const {
@@ -124,11 +123,10 @@ double xcalo_locator::get_row_z(uint32_t side_, uint32_t wall_, uint32_t row_) c
     DT_THROW_IF(row_ >= _back_block_z_[wall_].size(), std::logic_error,
                 "Invalid row number (" << row_ << ">" << _back_block_z_[wall_].size() - 1 << ")!");
     return _back_block_z_[wall_][row_];
-  } else {
-    DT_THROW_IF(row_ >= _front_block_z_[wall_].size(), std::logic_error,
-                "Invalid row number (" << row_ << ">" << _front_block_z_[wall_].size() - 1 << ")!");
-    return _front_block_z_[wall_][row_];
   }
+  DT_THROW_IF(row_ >= _front_block_z_[wall_].size(), std::logic_error,
+              "Invalid row number (" << row_ << ">" << _front_block_z_[wall_].size() - 1 << ")!");
+  return _front_block_z_[wall_][row_];
 }
 
 void xcalo_locator::compute_block_position(uint32_t side_, uint32_t wall_, uint32_t column_,
@@ -137,7 +135,6 @@ void xcalo_locator::compute_block_position(uint32_t side_, uint32_t wall_, uint3
   geomtools::invalidate(module_position_);
   module_position_.set(get_column_x(side_, wall_, column_), get_wall_y(side_, wall_),
                        get_row_z(side_, wall_, row_));
-  return;
 }
 
 void xcalo_locator::compute_block_window_position(uint32_t side_, uint32_t wall_, uint32_t column_,
@@ -146,7 +143,6 @@ void xcalo_locator::compute_block_window_position(uint32_t side_, uint32_t wall_
   geomtools::invalidate(module_position_);
   module_position_.set(get_column_x(side_, wall_, column_), get_wall_window_y(side_, wall_),
                        get_row_z(side_, wall_, row_));
-  return;
 }
 
 geomtools::vector_3d xcalo_locator::get_block_position(uint32_t side_, uint32_t wall_,
@@ -188,7 +184,6 @@ void xcalo_locator::get_block_position(const geomtools::geom_id &gid_,
   return get_block_position(gid_.get(_side_address_index_), gid_.get(_wall_address_index_),
                             gid_.get(_column_address_index_), gid_.get(_row_address_index_),
                             position_);
-  return;
 }
 
 void xcalo_locator::get_block_position(uint32_t side_, uint32_t wall_, uint32_t column_,
@@ -216,7 +211,6 @@ void xcalo_locator::get_block_position(uint32_t side_, uint32_t wall_, uint32_t 
     position_.set(_front_block_x_[wall_][column_], _block_y_[utils::SIDE_FRONT][wall_],
                   _front_block_z_[wall_][row_]);
   }
-  return;
 }
 
 void xcalo_locator::get_neighbours_ids(const geomtools::geom_id &gid_,
@@ -229,7 +223,6 @@ void xcalo_locator::get_neighbours_ids(const geomtools::geom_id &gid_,
                                         << "!=" << _module_number_ << ")!");
   get_neighbours_ids(gid_.get(_side_address_index_), gid_.get(_wall_address_index_),
                      gid_.get(_column_address_index_), gid_.get(_row_address_index_), ids_, mask_);
-  return;
 }
 
 void xcalo_locator::get_neighbours_ids(uint32_t side_, uint32_t wall_, uint32_t column_,
@@ -244,9 +237,9 @@ void xcalo_locator::get_neighbours_ids(uint32_t side_, uint32_t wall_, uint32_t 
   ids_.clear();
   ids_.reserve(8);
 
-  const bool sides = mask_ & utils::NEIGHBOUR_SIDE;
-  const bool diagonal = mask_ & utils::NEIGHBOUR_DIAG;
-  const bool second = mask_ & utils::NEIGHBOUR_SECOND;
+  const bool sides = (mask_ & utils::NEIGHBOUR_SIDE) != 0;
+  const bool diagonal = (mask_ & utils::NEIGHBOUR_DIAG) != 0;
+  const bool second = (mask_ & utils::NEIGHBOUR_SECOND) != 0;
   if (second) {
     DT_LOG_NOTICE(get_logging_priority(),
                   "Looking for second order neighbour of 'xcalo' locator is not implemented !");
@@ -450,8 +443,6 @@ void xcalo_locator::get_neighbours_ids(uint32_t side_, uint32_t wall_, uint32_t 
       ids_.push_back(gid);
     }
   }
-
-  return;
 }
 
 size_t xcalo_locator::get_number_of_neighbours(uint32_t side_, uint32_t wall_, uint32_t column_,
@@ -464,9 +455,9 @@ size_t xcalo_locator::get_number_of_neighbours(uint32_t side_, uint32_t wall_, u
 
   bool corner = false;
   bool side = false;
-  const bool sides = mask_ & utils::NEIGHBOUR_SIDE;
-  const bool diagonal = mask_ & utils::NEIGHBOUR_DIAG;
-  const bool second = mask_ & utils::NEIGHBOUR_SECOND;
+  const bool sides = (mask_ & utils::NEIGHBOUR_SIDE) != 0;
+  const bool diagonal = (mask_ & utils::NEIGHBOUR_DIAG) != 0;
+  const bool second = (mask_ & utils::NEIGHBOUR_SECOND) != 0;
   if (second) {
     DT_LOG_NOTICE(get_logging_priority(),
                   "Looking for second order neighbour of 'xcalo' locator is not implemented !");
@@ -491,14 +482,26 @@ size_t xcalo_locator::get_number_of_neighbours(uint32_t side_, uint32_t wall_, u
   }
   size_t number = 0;
   if (corner) {
-    if (sides) number += 2;
-    if (diagonal) number += 1;
+    if (sides) {
+      number += 2;
+    }
+    if (diagonal) {
+      number += 1;
+    }
   } else if (side) {
-    if (sides) number += 3;
-    if (diagonal) number += 2;
+    if (sides) {
+      number += 3;
+    }
+    if (diagonal) {
+      number += 2;
+    }
   } else {
-    if (sides) number += 4;
-    if (diagonal) number += 4;
+    if (sides) {
+      number += 4;
+    }
+    if (diagonal) {
+      number += 4;
+    }
   }
   return number;
 }
@@ -571,24 +574,17 @@ void xcalo_locator::_set_defaults_() {
   _part_address_index_ = geomtools::geom_id::INVALID_ADDRESS;
 
   _initialized_ = false;
-  return;
 }
 
 // Constructor:
-xcalo_locator::xcalo_locator() : base_locator() {
-  _set_defaults_();
-  return;
-}
+xcalo_locator::xcalo_locator() { _set_defaults_(); }
 
 // Constructor:
-xcalo_locator::xcalo_locator(const ::geomtools::manager &gmgr_, uint32_t module_number_)
-    : base_locator() {
+xcalo_locator::xcalo_locator(const ::geomtools::manager &gmgr_, uint32_t module_number_) {
   _set_defaults_();
 
   set_geo_manager(gmgr_);
   set_module_number(module_number_);
-
-  return;
 }
 
 // dtor:
@@ -596,7 +592,6 @@ xcalo_locator::~xcalo_locator() {
   if (is_initialized()) {
     reset();
   }
-  return;
 }
 
 bool xcalo_locator::is_block_partitioned() const { return _block_partitioned_; }
@@ -750,7 +745,9 @@ void xcalo_locator::_construct() {
   vcx[utils::SIDE_FRONT][WALL_LEFT] = &_front_block_x_[WALL_LEFT];
   vcx[utils::SIDE_FRONT][WALL_RIGHT] = &_front_block_x_[WALL_RIGHT];
   for (size_t local_side = 0; local_side < utils::NSIDES; ++local_side) {
-    if (!_submodules_[local_side]) continue;
+    if (!_submodules_[local_side]) {
+      continue;
+    }
     for (size_t wall = 0; wall < NWALLS_PER_SIDE; wall++) {
       size_t i_column = 0;
       vcx[local_side][wall]->reserve(2);
@@ -801,7 +798,9 @@ void xcalo_locator::_construct() {
   vrz[utils::SIDE_FRONT][WALL_LEFT] = &_front_block_z_[WALL_LEFT];
   vrz[utils::SIDE_FRONT][WALL_RIGHT] = &_front_block_z_[WALL_RIGHT];
   for (size_t iside = 0; iside < utils::NSIDES; iside++) {
-    if (!_submodules_[iside]) continue;
+    if (!_submodules_[iside]) {
+      continue;
+    }
     for (size_t wall = 0; wall < NWALLS_PER_SIDE; wall++) {
       size_t i_row = 0;
       vrz[iside][wall]->reserve(16);
@@ -833,8 +832,6 @@ void xcalo_locator::_construct() {
   _block_width_ = _block_box_->get_x();
   _block_height_ = _block_box_->get_y();
   _block_thickness_ = _block_box_->get_z();
-
-  return;
 }
 
 int xcalo_locator::get_module_address_index() const { return _module_address_index_; }
@@ -887,7 +884,6 @@ bool xcalo_locator::is_calo_block_in_current_module(const geomtools::geom_id &gi
 void xcalo_locator::set_module_number(uint32_t a_module_number) {
   DT_THROW_IF(is_initialized(), std::logic_error, "Locator is already initialized !");
   _module_number_ = a_module_number;
-  return;
 }
 
 uint32_t xcalo_locator::get_module_number() const { return _module_number_; }
@@ -895,7 +891,6 @@ uint32_t xcalo_locator::get_module_number() const { return _module_number_; }
 void xcalo_locator::initialize() {
   datatools::properties dummy;
   initialize(dummy);
-  return;
 }
 
 void xcalo_locator::initialize(const datatools::properties &config_) {
@@ -908,12 +903,10 @@ void xcalo_locator::initialize(const datatools::properties &config_) {
   if (datatools::logger::is_trace(get_logging_priority())) {
     tree_dump(std::cerr, "X-calo locator : ", "[trace] ");
   }
-  return;
 }
 
 void xcalo_locator::dump(std::ostream &out_) const {
   xcalo_locator::tree_dump(out_, "snemo::geometry:xcalo_locator::dump: ");
-  return;
 }
 
 void xcalo_locator::tree_dump(std::ostream &out_, const std::string &title_,
@@ -945,8 +938,9 @@ void xcalo_locator::tree_dump(std::ostream &out_, const std::string &title_,
   out_ << indent << itag << "Calorimeter block type     = " << _block_type_ << std::endl;
   out_ << indent << itag << "Calorimeter wrapper type   = " << _wrapper_type_ << std::endl;
   out_ << indent << itag << "Block partitioned          = " << _block_partitioned_ << std::endl;
-  if (is_block_partitioned())
+  if (is_block_partitioned()) {
     out_ << indent << itag << "Block part                 = " << _block_part_ << std::endl;
+  }
   out_ << indent << itag << "Module ginfo @             = " << _module_ginfo_ << std::endl;
   out_ << indent << itag << "Module placement : " << std::endl;
   if (_module_world_placement_ != 0) {
@@ -1029,7 +1023,6 @@ void xcalo_locator::tree_dump(std::ostream &out_, const std::string &title_,
     out_ << indent << datatools::i_tree_dumpable::inherit_tag(inherit_)
          << "Part   address GID index = " << _part_address_index_ << std::endl;
   }
-  return;
 }
 
 void xcalo_locator::reset() {
@@ -1041,21 +1034,18 @@ void xcalo_locator::reset() {
     _front_block_x_[i].clear();
   }
   _set_defaults_();
-  return;
 }
 
 void xcalo_locator::transform_world_to_module(const geomtools::vector_3d &world_position_,
                                               geomtools::vector_3d &module_position_) const {
   DT_THROW_IF(!is_initialized(), std::logic_error, "Locator is not initialized !");
   _module_world_placement_->mother_to_child(world_position_, module_position_);
-  return;
 }
 
 void xcalo_locator::transform_module_to_world(const geomtools::vector_3d &module_position_,
                                               geomtools::vector_3d &world_position_) const {
   DT_THROW_IF(!is_initialized(), std::logic_error, "Locator is not initialized !");
   _module_world_placement_->child_to_mother(module_position_, world_position_);
-  return;
 }
 
 bool xcalo_locator::is_in_module(const geomtools::vector_3d &module_position_,
@@ -1139,7 +1129,6 @@ void xcalo_locator::_hack_trace() {
                    "Trace logging activated through env 'FLGEOMLOCATOR'...");
     }
   }
-  return;
 }
 
 bool xcalo_locator::find_block_geom_id(const geomtools::vector_3d &world_position_,
@@ -1315,7 +1304,7 @@ bool xcalo_locator::find_block_geom_id_(const geomtools::vector_3d &in_module_po
       geomtools::vector_3d world_position;
       transform_module_to_world(in_module_position_, world_position);
       double the_tolerance2 = 1.e-7 * CLHEP::mm;
-      if (_mapping_->check_inside(*ginfo_ptr, world_position, the_tolerance2)) {
+      if (geomtools::mapping::check_inside(*ginfo_ptr, world_position, the_tolerance2)) {
         DT_LOG_TRACE(get_logging_priority(), "INSIDE " << gid);
         DT_LOG_TRACE_EXITING(get_logging_priority());
         return true;

--- a/source/falaise/snemo/geometry/xcalo_locator.cc
+++ b/source/falaise/snemo/geometry/xcalo_locator.cc
@@ -545,14 +545,14 @@ void xcalo_locator::_set_defaults_() {
   _block_part_ = geomtools::geom_id::INVALID_ADDRESS;
   _block_partitioned_ = false;
 
-  _mapping_ = 0;
-  _id_manager_ = 0;
-  _module_ginfo_ = 0;
-  _module_world_placement_ = 0;
-  _module_box_ = 0;
-  _block_shape_ = 0;
+  _mapping_ = nullptr;
+  _id_manager_ = nullptr;
+  _module_ginfo_ = nullptr;
+  _module_world_placement_ = nullptr;
+  _module_box_ = nullptr;
+  _block_shape_ = nullptr;
   _composite_block_shape_ = false;
-  _block_box_ = 0;
+  _block_box_ = nullptr;
 
   for (size_t i = 0; i < utils::NSIDES; i++) {
     for (size_t j = 0; j < NWALLS_PER_SIDE; j++) {
@@ -707,8 +707,7 @@ void xcalo_locator::_construct() {
     // Example : 'calo_scin_box_model' case :
     _composite_block_shape_ = true;
 
-    const geomtools::subtraction_3d &ref_s3d =
-        dynamic_cast<const geomtools::subtraction_3d &>(*_block_shape_);
+    const auto &ref_s3d = dynamic_cast<const geomtools::subtraction_3d &>(*_block_shape_);
     const geomtools::i_composite_shape_3d::shape_type &sht1 = ref_s3d.get_shape1();
     const geomtools::i_shape_3d &sh1 = sht1.get_shape();
     DT_THROW_IF(sh1.get_shape_name() != "box", std::logic_error,
@@ -718,13 +717,12 @@ void xcalo_locator::_construct() {
     // Example : 'calo_tapered_scin_box_model' case :
     _composite_block_shape_ = true;
 
-    const geomtools::intersection_3d &ref_i3d =
-        dynamic_cast<const geomtools::intersection_3d &>(*_block_shape_);
+    const auto &ref_i3d = dynamic_cast<const geomtools::intersection_3d &>(*_block_shape_);
     const geomtools::i_composite_shape_3d::shape_type &sht1 = ref_i3d.get_shape1();
     const geomtools::i_shape_3d &sh1 = sht1.get_shape();
     DT_THROW_IF(sh1.get_shape_name() != "subtraction_3d", std::logic_error,
                 "Do not support non-subtraction_3d shaped block with ID = " << block_gid << " !");
-    const geomtools::subtraction_3d &ref_s3d = dynamic_cast<const geomtools::subtraction_3d &>(sh1);
+    const auto &ref_s3d = dynamic_cast<const geomtools::subtraction_3d &>(sh1);
     const geomtools::i_composite_shape_3d::shape_type &sht11 = ref_s3d.get_shape1();
     const geomtools::i_shape_3d &sh11 = sht11.get_shape();
     DT_THROW_IF(sh11.get_shape_name() != "box", std::logic_error,
@@ -943,11 +941,11 @@ void xcalo_locator::tree_dump(std::ostream &out_, const std::string &title_,
   }
   out_ << indent << itag << "Module ginfo @             = " << _module_ginfo_ << std::endl;
   out_ << indent << itag << "Module placement : " << std::endl;
-  if (_module_world_placement_ != 0) {
+  if (_module_world_placement_ != nullptr) {
     _module_world_placement_->tree_dump(out_, "", indent + stag);
   }
   out_ << indent << itag << "Module box : " << std::endl;
-  if (_module_box_ != 0) {
+  if (_module_box_ != nullptr) {
     _module_box_->tree_dump(out_, "", indent + stag);
   }
   out_ << indent << itag << "Back  submodule : " << _submodules_[utils::SIDE_BACK] << std::endl;
@@ -955,21 +953,21 @@ void xcalo_locator::tree_dump(std::ostream &out_, const std::string &title_,
   out_ << indent << itag << "Block shape : " << _block_shape_->get_shape_name() << std::endl;
   out_ << indent << itag << "Composite block shape = " << _composite_block_shape_ << std::endl;
   out_ << indent << itag << "Block box : " << std::endl;
-  if (_block_box_ != 0) {
+  if (_block_box_ != nullptr) {
     _block_box_->tree_dump(out_, "", indent + stag);
   }
   for (size_t i = 0; i < NWALLS_PER_SIDE; ++i) {
     const std::string wall_name = (i == (uint32_t)WALL_LEFT) ? "left wall" : "right wall";
     out_ << indent << itag << "Back  block X-pos on " << wall_name << " ["
          << _back_block_x_[i].size() << "] = ";
-    for (size_t j = 0; j < _back_block_x_[i].size(); j++) {
-      out_ << _back_block_x_[i][j] / CLHEP::mm << " ";
+    for (double j : _back_block_x_[i]) {
+      out_ << j / CLHEP::mm << " ";
     }
     out_ << " (mm)" << std::endl;
     out_ << indent << itag << "Front block X-pos on " << wall_name << " ["
          << _front_block_x_[i].size() << "] = ";
-    for (size_t j = 0; j < _front_block_x_[i].size(); j++) {
-      out_ << _front_block_x_[i][j] / CLHEP::mm << " ";
+    for (double j : _front_block_x_[i]) {
+      out_ << j / CLHEP::mm << " ";
     }
     out_ << " (mm)" << std::endl;
     out_ << indent << itag << "Back  block Y-pos on " << wall_name << "  = "
@@ -1121,7 +1119,7 @@ bool xcalo_locator::id_is_valid(uint32_t side_, uint32_t wall_, uint32_t column_
 
 void xcalo_locator::_hack_trace() {
   char *ev = getenv("FLGEOMLOCATOR");
-  if (ev != 0) {
+  if (ev != nullptr) {
     std::string evstr(ev);
     if (evstr == "trace") {
       set_logging_priority(datatools::logger::PRIO_TRACE);
@@ -1207,8 +1205,8 @@ bool xcalo_locator::find_block_geom_id_(const geomtools::vector_3d &in_module_po
       if (delta_y <= the_tolerance) {
         wall_number = WALL_LEFT;
         DT_LOG_TRACE(get_logging_priority(), "  in this block");
-        const std::vector<double> *block_x_ptr = 0;
-        const std::vector<double> *block_z_ptr = 0;
+        const std::vector<double> *block_x_ptr = nullptr;
+        const std::vector<double> *block_z_ptr = nullptr;
         if (_submodules_[utils::SIDE_BACK] && side_number == utils::SIDE_BACK) {
           block_x_ptr = &_back_block_x_[wall_number];
           block_z_ptr = &_back_block_z_[wall_number];
@@ -1237,8 +1235,8 @@ bool xcalo_locator::find_block_geom_id_(const geomtools::vector_3d &in_module_po
       if (delta_y <= the_tolerance) {
         wall_number = WALL_RIGHT;
         DT_LOG_TRACE(get_logging_priority(), "  in this block");
-        const std::vector<double> *block_x_ptr = 0;
-        const std::vector<double> *block_z_ptr = 0;
+        const std::vector<double> *block_x_ptr = nullptr;
+        const std::vector<double> *block_z_ptr = nullptr;
         if (_submodules_[utils::SIDE_BACK] && side_number == utils::SIDE_BACK) {
           block_x_ptr = &_back_block_x_[wall_number];
           block_z_ptr = &_back_block_z_[wall_number];
@@ -1292,7 +1290,7 @@ bool xcalo_locator::find_block_geom_id_(const geomtools::vector_3d &in_module_po
     if (gid.is_valid()) {
       // 2012-05-31 FM : use ginfo from mapping (see below)
       const geomtools::geom_info *ginfo_ptr = _mapping_->get_geom_info_ptr(gid);
-      if (ginfo_ptr == 0) {
+      if (ginfo_ptr == nullptr) {
         DT_LOG_TRACE(get_logging_priority(), "Unmapped gid = " << gid);
         DT_LOG_TRACE(get_logging_priority(), "Not a X-calo!");
         gid.invalidate();

--- a/source/falaise/snemo/processing/event_header_utils_module.cc
+++ b/source/falaise/snemo/processing/event_header_utils_module.cc
@@ -182,7 +182,7 @@ dpp::base_module::process_status event_header_utils_module::process(
 void event_header_utils_module::_process_add_header(datatools::things& data_record_) {
   DT_THROW_IF(_add_header_bank_label_.empty(), std::logic_error,
               "Missing bank label to be enriched !");
-  snemo::datamodel::event_header* ptr_event_header = 0;
+  snemo::datamodel::event_header* ptr_event_header = nullptr;
   if (data_record_.has(_add_header_bank_label_)) {
     DT_THROW_IF(!_add_header_update_, std::logic_error,
                 "Event record already has a header '" << _add_header_bank_label_ << "' !");
@@ -219,8 +219,7 @@ void event_header_utils_module::_process_add_header(datatools::things& data_reco
       const std::string sd_label = snemo::datamodel::data_info::default_simulated_data_label();
       DT_THROW_IF(!data_record_.has(sd_label), std::logic_error,
                   "Event record has no '" << sd_label << "' bank!");
-      const mctools::simulated_data& the_simulated_data =
-          data_record_.get<mctools::simulated_data>(sd_label);
+      const auto& the_simulated_data = data_record_.get<mctools::simulated_data>(sd_label);
 
       if (_add_header_use_genbb_weight_) {
         const double weight = the_simulated_data.get_primary_event().get_genbb_weight();
@@ -313,7 +312,7 @@ DOCD_CLASS_IMPLEMENT_LOAD_BEGIN(snemo::processing::event_header_utils_module, oc
         .set_terse_description("The event generation type")
         .set_traits(datatools::TYPE_STRING)
         .set_mandatory(false)
-        .set_long_description("This is the type of generation (\"real\" or \"simulated\")")
+        .set_long_description(R"(This is the type of generation ("real" or "simulated"))")
         .set_default_value_string(snemo::datamodel::data_info::default_event_header_label())
         .add_example(
             "Indicate simulated event:: \n"

--- a/source/falaise/snemo/processing/event_header_utils_module.cc
+++ b/source/falaise/snemo/processing/event_header_utils_module.cc
@@ -105,7 +105,6 @@ void event_header_utils_module::initialize(const datatools::properties& setup_,
   }
 
   _set_initialized(true);
-  return;
 }
 
 void event_header_utils_module::reset() {
@@ -113,7 +112,6 @@ void event_header_utils_module::reset() {
               "Module '" << get_name() << "' is not initialized !");
   _set_initialized(false);
   _set_defaults();
-  return;
 }
 
 void event_header_utils_module::_set_defaults() {
@@ -132,20 +130,19 @@ void event_header_utils_module::_set_defaults() {
 
   _ah_current_run_number_ = _add_header_run_number_;
   _ah_current_event_number_ = _add_header_event_number_;
-  return;
 }
 
 // Constructor :
 event_header_utils_module::event_header_utils_module(datatools::logger::priority logging_priority_)
     : dpp::base_module(logging_priority_) {
   _set_defaults();
-  return;
 }
 
 // Destructor
 event_header_utils_module::~event_header_utils_module() {
-  if (is_initialized()) event_header_utils_module::reset();
-  return;
+  if (is_initialized()) {
+    event_header_utils_module::reset();
+  }
 }
 
 bool event_header_utils_module::is_add_header_mode() const { return _mode_ == MODE_ADD_HEADER; }
@@ -153,13 +150,11 @@ bool event_header_utils_module::is_add_header_mode() const { return _mode_ == MO
 void event_header_utils_module::ah_increment_run_number(int incr_) {
   DT_THROW_IF(!is_add_header_mode(), std::logic_error, "Invalid mode!");
   _ah_current_run_number_ += incr_;
-  return;
 }
 
 void event_header_utils_module::ah_increment_event_number(int incr_) {
   DT_THROW_IF(!is_add_header_mode(), std::logic_error, "Invalid mode!");
   _ah_current_event_number_ += incr_;
-  return;
 }
 
 bool event_header_utils_module::ah_is_real() const {
@@ -238,8 +233,6 @@ void event_header_utils_module::_process_add_header(datatools::things& data_reco
       }
     }
   }
-
-  return;
 }
 
 }  // end of namespace processing

--- a/source/falaise/snemo/simulation/calorimeter_step_hit_processor.cc
+++ b/source/falaise/snemo/simulation/calorimeter_step_hit_processor.cc
@@ -78,8 +78,6 @@ void calorimeter_step_hit_processor::initialize(const ::datatools::properties& c
                   !geo_mgr.is_plugin_a<snemo::geometry::locator_plugin>(locator_plugin_name),
               std::logic_error, "Found no locator plugin named '" << locator_plugin_name << "'");
   _locator_plugin_ = &geo_mgr.get_plugin<snemo::geometry::locator_plugin>(locator_plugin_name);
-
-  return;
 }
 
 }  // end of namespace simulation

--- a/source/falaise/snemo/simulation/calorimeter_step_hit_processor.cc
+++ b/source/falaise/snemo/simulation/calorimeter_step_hit_processor.cc
@@ -21,31 +21,24 @@ bool calorimeter_step_hit_processor::locate_calorimeter_block(const geomtools::v
   bool located = false;
   if (!located) {
     if (_locator_plugin_->get_calo_locator().find_block_geom_id(position_, gid_)) {
-      DT_LOG_TRACE(get_logging_priority(), "Found step with the main wall calorimeter locator.");
       located = true;
     }
   }
   if (!located) {
     if (_locator_plugin_->get_xcalo_locator().find_block_geom_id(position_, gid_)) {
-      DT_LOG_TRACE(get_logging_priority(), "Found step with the X-wall calorimeter locator.");
       located = true;
     }
   }
   if (!located) {
     if (_locator_plugin_->get_gveto_locator().find_block_geom_id(position_, gid_)) {
-      DT_LOG_TRACE(get_logging_priority(), "Found step with the gamma veto calorimeter locator.");
       located = true;
     }
   }
   if (!located) {
     // Fallback locator from the parent class:
     if (this->mctools::calorimeter_step_hit_processor::locate_calorimeter_block(position_, gid_)) {
-      DT_LOG_TRACE(get_logging_priority(), "Found step with the fallback locator.");
       located = true;
     }
-  }
-  if (!located) {
-    DT_LOG_TRACE(get_logging_priority(), "Cannot locate step with any of the available locators!");
   }
   return located;
 }
@@ -63,9 +56,8 @@ void calorimeter_step_hit_processor::initialize(const ::datatools::properties& c
     // If no locator plugin name is set, then search for the first one available
     // from the geometry manager:
     const geomtools::manager::plugins_dict_type& plugins = geo_mgr.get_plugins();
-    for (geomtools::manager::plugins_dict_type::const_iterator ip = plugins.begin();
-         ip != plugins.end(); ip++) {
-      const std::string& plugin_name = ip->first;
+    for (const auto& plugin : plugins) {
+      const std::string& plugin_name = plugin.first;
       if (geo_mgr.is_plugin_a<snemo::geometry::locator_plugin>(plugin_name)) {
         DT_LOG_DEBUG(get_logging_priority(), "Find locator plugin with name = " << plugin_name);
         locator_plugin_name = plugin_name;

--- a/source/falaise/snemo/simulation/cosmic_muon_generator.cc
+++ b/source/falaise/snemo/simulation/cosmic_muon_generator.cc
@@ -32,7 +32,7 @@ GENBB_PG_REGISTRATION_IMPLEMENT(cosmic_muon_generator, "snemo::simulation::cosmi
 
 struct sea_level_toy_theta_density_function : public mygsl::i_unary_function {
  protected:
-  virtual double _eval(double x_) const;
+  double _eval(double x_) const override;
 };
 
 double sea_level_toy_theta_density_function::_eval(double x_) const {
@@ -45,13 +45,13 @@ double sea_level_toy_theta_density_function::_eval(double x_) const {
 bool cosmic_muon_generator::can_external_random() const { return true; }
 
 void cosmic_muon_generator::sea_level_toy_setup::reset() {
-  if (angular_VNM != 0) {
+  if (angular_VNM != nullptr) {
     delete angular_VNM;
-    angular_VNM = 0;
+    angular_VNM = nullptr;
   }
-  if (theta_density_function != 0) {
+  if (theta_density_function != nullptr) {
     delete theta_density_function;
-    theta_density_function = 0;
+    theta_density_function = nullptr;
   }
   set_defaults();
 }
@@ -61,8 +61,8 @@ void cosmic_muon_generator::sea_level_toy_setup::set_defaults() {
   energy_sigma = 1.0 * CLHEP::GeV;
   maximum_theta = 70. * CLHEP::degree;
   muon_ratio = 1.2;
-  theta_density_function = 0;
-  angular_VNM = 0;
+  theta_density_function = nullptr;
+  angular_VNM = nullptr;
 }
 
 cosmic_muon_generator::sea_level_toy_setup::sea_level_toy_setup() { set_defaults(); }

--- a/source/falaise/snemo/simulation/cosmic_muon_generator.cc
+++ b/source/falaise/snemo/simulation/cosmic_muon_generator.cc
@@ -54,7 +54,6 @@ void cosmic_muon_generator::sea_level_toy_setup::reset() {
     theta_density_function = 0;
   }
   set_defaults();
-  return;
 }
 
 void cosmic_muon_generator::sea_level_toy_setup::set_defaults() {
@@ -64,13 +63,9 @@ void cosmic_muon_generator::sea_level_toy_setup::set_defaults() {
   muon_ratio = 1.2;
   theta_density_function = 0;
   angular_VNM = 0;
-  return;
 }
 
-cosmic_muon_generator::sea_level_toy_setup::sea_level_toy_setup() {
-  set_defaults();
-  return;
-}
+cosmic_muon_generator::sea_level_toy_setup::sea_level_toy_setup() { set_defaults(); }
 
 /* cosmic_muon_generator::sea_level_pdg_setup */
 
@@ -79,36 +74,22 @@ void cosmic_muon_generator::sea_level_pdg_setup::set_defaults() {
    *
    *
    */
-  return;
 }
 
-void cosmic_muon_generator::sea_level_pdg_setup::reset() {
-  set_defaults();
-  return;
-}
+void cosmic_muon_generator::sea_level_pdg_setup::reset() { set_defaults(); }
 
-cosmic_muon_generator::sea_level_pdg_setup::sea_level_pdg_setup() {
-  set_defaults();
-  return;
-}
+cosmic_muon_generator::sea_level_pdg_setup::sea_level_pdg_setup() { set_defaults(); }
 
 /* cosmic_muon_generator::underground_setup */
 
 void cosmic_muon_generator::underground_setup::set_defaults() {
   underground_lab = "lsm";
-  underground_depth = 4800.0;  // m.w.e.
-  return;
+  underground_depth = 4800.0;
 }
 
-void cosmic_muon_generator::underground_setup::reset() {
-  set_defaults();
-  return;
-}
+void cosmic_muon_generator::underground_setup::reset() { set_defaults(); }
 
-cosmic_muon_generator::underground_setup::underground_setup() {
-  set_defaults();
-  return;
-}
+cosmic_muon_generator::underground_setup::underground_setup() { set_defaults(); }
 
 /*** cosmic_muon_generator ***/
 
@@ -119,23 +100,20 @@ int cosmic_muon_generator::get_mode() const { return _mode_; }
 void cosmic_muon_generator::set_mode(int new_value_) {
   DT_THROW_IF(is_initialized(), std::logic_error, "Generator is already initialized !");
   _mode_ = new_value_;
-  return;
 }
 
-cosmic_muon_generator::cosmic_muon_generator() : ::genbb::i_genbb() {
+cosmic_muon_generator::cosmic_muon_generator() {
   _initialized_ = false;
 
   _at_reset_();
 
   _seed_ = 0;
-  return;
 }
 
 cosmic_muon_generator::~cosmic_muon_generator() {
   if (_initialized_) {
     reset();
   }
-  return;
 }
 
 const mygsl::rng& cosmic_muon_generator::get_random() const {
@@ -163,15 +141,14 @@ void cosmic_muon_generator::_at_reset_() {
     _random_.reset();
   }
   _seed_ = 0;
-
-  return;
 }
 
 void cosmic_muon_generator::reset() {
-  if (!_initialized_) return;
+  if (!_initialized_) {
+    return;
+  }
   _initialized_ = false;
   _at_reset_();
-  return;
 }
 
 void cosmic_muon_generator::initialize(const datatools::properties& config_,
@@ -220,20 +197,21 @@ void cosmic_muon_generator::initialize(const datatools::properties& config_,
 
     if (_sea_level_mode_ == SEA_LEVEL_TOY) {
       if (config_.has_key("sea_level_toy.energy_mean")) {
-        _sea_level_toy_setup_.energy_mean
-          = config_.fetch_real_with_explicit_dimension("sea_level_toy.energy_mean", "energy");
+        _sea_level_toy_setup_.energy_mean =
+            config_.fetch_real_with_explicit_dimension("sea_level_toy.energy_mean", "energy");
       }
       if (config_.has_key("sea_level_toy.energy_sigma")) {
-        _sea_level_toy_setup_.energy_sigma
-          = config_.fetch_real_with_explicit_dimension("sea_level_toy.energy_sigma", "energy");
+        _sea_level_toy_setup_.energy_sigma =
+            config_.fetch_real_with_explicit_dimension("sea_level_toy.energy_sigma", "energy");
       }
       if (config_.has_key("sea_level_toy.maximum_theta")) {
-        _sea_level_toy_setup_.maximum_theta
-          = config_.fetch_real_with_explicit_dimension("sea_level_toy.maximum_theta", "angle");
+        _sea_level_toy_setup_.maximum_theta =
+            config_.fetch_real_with_explicit_dimension("sea_level_toy.maximum_theta", "angle");
         DT_THROW_IF(_sea_level_toy_setup_.maximum_theta < 0.0 ||
-                    _sea_level_toy_setup_.maximum_theta > 90.0 * CLHEP::degree,
-                    std::range_error, "Invalid 'sea_level_toy.maximum_theta' value for particle generator '"
-                    << get_name() << "' !");
+                        _sea_level_toy_setup_.maximum_theta > 90.0 * CLHEP::degree,
+                    std::range_error,
+                    "Invalid 'sea_level_toy.maximum_theta' value for particle generator '"
+                        << get_name() << "' !");
       }
       if (config_.has_key("sea_level_toy.muon_ratio")) {
         _sea_level_toy_setup_.muon_ratio = config_.fetch_real("sea_level_toy.muon_ratio");
@@ -253,7 +231,6 @@ void cosmic_muon_generator::initialize(const datatools::properties& config_,
   _at_init_();
 
   _initialized_ = true;
-  return;
 }
 
 void cosmic_muon_generator::_at_init_() {
@@ -270,8 +247,6 @@ void cosmic_muon_generator::_at_init_() {
           mygsl::von_neumann_method::AUTO_FMAX, 100, 100);
     }
   }
-
-  return;
 }
 
 bool cosmic_muon_generator::has_next() { return true; }
@@ -334,7 +309,6 @@ void cosmic_muon_generator::_load_next(::genbb::primary_event& event_,
   }
 
   DT_LOG_DEBUG(get_logging_priority(), "Exiting.");
-  return;
 }
 
 double cosmic_muon_generator::energy_spectrum_at_sea_level_HE(double muon_cos_theta,

--- a/source/falaise/snemo/simulation/gg_step_hit_processor.cc
+++ b/source/falaise/snemo/simulation/gg_step_hit_processor.cc
@@ -32,16 +32,19 @@ void gg_step_hit_processor::set_external_rng(mygsl::rng &rng_) {
   DT_LOG_NOTICE(get_logging_priority(),
                 "Processor '" << get_name() << "' now uses an external PRNG.");
   _external_rng_ = &rng_;
-  return;
 }
 
 const mygsl::rng &gg_step_hit_processor::get_rng() const {
-  if (has_external_rng()) return *_external_rng_;
+  if (has_external_rng()) {
+    return *_external_rng_;
+  }
   return _rng_;
 }
 
 mygsl::rng &gg_step_hit_processor::grab_rng() {
-  if (has_external_rng()) return *_external_rng_;
+  if (has_external_rng()) {
+    return *_external_rng_;
+  }
   return _rng_;
 }
 
@@ -60,13 +63,9 @@ void gg_step_hit_processor::_set_defaults() {
   _module_type_ = geomtools::geom_id::INVALID_TYPE;
   _mapping_category_ = "";
   _module_category_ = "module";
-  return;
 }
 
-void gg_step_hit_processor::reset() {
-  _set_defaults();
-  return;
-}
+void gg_step_hit_processor::reset() { _set_defaults(); }
 
 gg_step_hit_processor::~gg_step_hit_processor() {
   if (_gg_cell_type_ != geomtools::geom_id::INVALID_TYPE) {
@@ -78,13 +77,9 @@ gg_step_hit_processor::~gg_step_hit_processor() {
     _CT2_.tree_dump(std::clog, "", "[debug]: ");
   }
   reset();
-  return;
 }
 
-gg_step_hit_processor::gg_step_hit_processor() : base_step_hit_processor() {
-  _set_defaults();
-  return;
-}
+gg_step_hit_processor::gg_step_hit_processor() { _set_defaults(); }
 
 void gg_step_hit_processor::initialize(const ::datatools::properties &config_,
                                        ::datatools::service_manager &service_mgr_) {
@@ -141,16 +136,19 @@ void gg_step_hit_processor::initialize(const ::datatools::properties &config_,
 
   // set the fiducial drift radius of the Geiger cell:
   if (config_.has_key("fiducial_drift_radius")) {
-    _fiducial_drift_radius_ = config_.fetch_real_with_explicit_dimension("fiducial_drift_radius", "length");
+    _fiducial_drift_radius_ =
+        config_.fetch_real_with_explicit_dimension("fiducial_drift_radius", "length");
   }
   // set the fiducial drift length of the Geiger cell:
   if (config_.has_key("fiducial_drift_length")) {
-    _fiducial_drift_length_ = config_.fetch_real_with_explicit_dimension("fiducial_drift_length", "length");
+    _fiducial_drift_length_ =
+        config_.fetch_real_with_explicit_dimension("fiducial_drift_length", "length");
   }
 
   // set the mean ionization energy in the tracking gas:
   if (config_.has_key("mean_ionization_energy")) {
-    _mean_ionization_energy_ = config_.fetch_real_with_explicit_dimension("mean_ionization_energy", "energy");
+    _mean_ionization_energy_ =
+        config_.fetch_real_with_explicit_dimension("mean_ionization_energy", "energy");
   }
 
   // pickup the ID mapping from the geometry manager:
@@ -215,7 +213,6 @@ void gg_step_hit_processor::initialize(const ::datatools::properties &config_,
       }
     }
   }
-  return;
 }
 
 bool gg_step_hit_processor::match_gg_hit(const mctools::base_step_hit &gg_hit_,
@@ -315,14 +312,12 @@ void gg_step_hit_processor::process(
   _process(the_base_step_hits, (mctools::simulated_data::hit_handle_collection_type *)0,
            &the_plain_gg_hits);
   DT_LOG_TRACE_EXITING(get_logging_priority());
-  return;
 }
 
 void gg_step_hit_processor::process(
     const ::mctools::base_step_hit_processor::step_hit_ptr_collection_type &the_base_step_hits,
     ::mctools::simulated_data::hit_handle_collection_type &the_gg_hits) {
   _process(the_base_step_hits, &the_gg_hits, (mctools::simulated_data::hit_collection_type *)0);
-  return;
 }
 
 void gg_step_hit_processor::_process(
@@ -363,7 +358,9 @@ void gg_step_hit_processor::_process(
     bool process_this_hit = false;
     mctools::base_step_hit &the_step_hit = const_cast<mctools::base_step_hit &>(*(*ihit));
 
-    if (is_debug()) _CT1_.start();
+    if (is_debug()) {
+      _CT1_.start();
+    }
     const double hit_energy_deposit = the_step_hit.get_energy_deposit();
     // XXX
     // if (hit_energy_deposit == 0) continue;
@@ -647,7 +644,9 @@ void gg_step_hit_processor::_process(
           // not in the fiducial drift Z longitudinal region:
           // drop this ion/electron pair which will not
           // produce a Geiger avalanche and thus is sterile.
-          if (std::abs(hit_z) > 0.5 * _fiducial_drift_length_) continue;
+          if (std::abs(hit_z) > 0.5 * _fiducial_drift_length_) {
+            continue;
+          }
         }
 
         if (!datatools::is_valid(min_drift_distance)) {
@@ -893,7 +892,9 @@ void gg_step_hit_processor::_process(
       continue;
     }
 
-    if (is_debug()) _CT1_.stop();
+    if (is_debug()) {
+      _CT1_.stop();
+    }
 
     /* Now we try to merge the current step hit
      * within one of the recorded candidate Geiger hits.
@@ -901,7 +902,9 @@ void gg_step_hit_processor::_process(
      * that matches: same drift cell and compatible times.
      */
 
-    if (is_debug()) _CT2_.start();
+    if (is_debug()) {
+      _CT2_.start();
+    }
     // For efficiency we first search a match with
     // the current Geiger hit (if any):
     mctools::base_step_hit *matching_gg = 0;
@@ -915,7 +918,9 @@ void gg_step_hit_processor::_process(
       if (use_handles) {
         for (mctools::simulated_data::hit_handle_collection_type::iterator igg = gg_hits_->begin();
              igg != gg_hits_->end(); igg++) {
-          if (!igg->has_data()) continue;
+          if (!igg->has_data()) {
+            continue;
+          }
           mctools::base_step_hit &matching_hit = igg->grab();
           if (match_gg_hit(matching_hit, the_step_hit)) {
             // pick up the first matching gg hit :
@@ -1107,7 +1112,9 @@ void gg_step_hit_processor::_process(
         }
       }
     }
-    if (is_debug()) _CT2_.stop();
+    if (is_debug()) {
+      _CT2_.stop();
+    }
   }  // end of the loop : for (i_step_hit_processor::step_hit_ptr_collection_type::const_iterator
      // ihit...
 
@@ -1122,7 +1129,6 @@ void gg_step_hit_processor::_process(
     _purge_gg_hits(gg_hits_, plain_gg_hits_);
   }
   DT_LOG_TRACE(get_logging_priority(), "Exiting.");
-  return;
 }
 
 void gg_step_hit_processor::_purge_gg_hits(
@@ -1187,8 +1193,6 @@ void gg_step_hit_processor::_purge_gg_hits(
       plain_gg_hits_->erase(new_end, plain_gg_hits_->end());
     }
   }
-
-  return;
 }
 
 }  // end of namespace simulation

--- a/source/falaise/version.cc
+++ b/source/falaise/version.cc
@@ -39,7 +39,7 @@ int version::get_patch() { return static_cast<int>(FALAISE_VERSION_PATCH); }
 int version::get_revision() { return static_cast<int>(FALAISE_VERSION_REVISION); }
 
 std::string version::get_commit() {
-  static std::string revision {FALAISE_VERSION_COMMIT};
+  static std::string revision{FALAISE_VERSION_COMMIT};
   return revision;
 }
 
@@ -52,7 +52,7 @@ bool version::is_dirty() {
 }
 
 std::string version::get_version() {
-  static std::string version("");
+  static std::string version;
   if (version.empty()) {
     std::ostringstream stream;
     stream << FALAISE_VERSION_MAJOR << "." << FALAISE_VERSION_MINOR << "." << FALAISE_VERSION_PATCH;
@@ -62,15 +62,25 @@ std::string version::get_version() {
 }
 
 bool version::is_at_least(int major, int minor, int patch) {
-  if (FALAISE_VERSION_MAJOR < major) return false;
-  if (FALAISE_VERSION_MAJOR > major) return true;
-  if (FALAISE_VERSION_MINOR < minor) return false;
-  if (FALAISE_VERSION_MINOR > minor) return true;
-  if (FALAISE_VERSION_PATCH < patch) return false;
+  if (FALAISE_VERSION_MAJOR < major) {
+    return false;
+  }
+  if (FALAISE_VERSION_MAJOR > major) {
+    return true;
+  }
+  if (FALAISE_VERSION_MINOR < minor) {
+    return false;
+  }
+  if (FALAISE_VERSION_MINOR > minor) {
+    return true;
+  }
+  if (FALAISE_VERSION_PATCH < patch) {
+    return false;
+  }
   return true;
 }
 
-bool version::has_feature(const std::string&) {
+bool version::has_feature(const std::string& /*unused*/) {
   /// - If you want to add features, then the following implementation
   ///   provides one example based on string features cached in a set.
   ///

--- a/source/flreconstruct/FLReconstructCommandLine.cc
+++ b/source/flreconstruct/FLReconstructCommandLine.cc
@@ -81,7 +81,7 @@ void do_help(std::ostream& os, const bpo::options_description& od) {
 void do_module_list(std::ostream& os) {
   datatools::library_loader libLoader;
   do_load_plugins(libLoader);
-  typedef std::vector<std::string> ModuleInfo;
+  using ModuleInfo = std::vector<std::string>;
   ModuleInfo mods;
   // Builtin
   DATATOOLS_FACTORY_GET_SYSTEM_REGISTER(dpp::base_module).list_of_factories(mods);
@@ -95,7 +95,7 @@ void do_help_module(std::ostream& os, std::string module) {
   datatools::library_loader libLoader;
   do_load_plugins(libLoader);
   // Is module valid?
-  typedef std::vector<std::string> ModuleInfo;
+  using ModuleInfo = std::vector<std::string>;
   ModuleInfo mods;
   DATATOOLS_FACTORY_GET_SYSTEM_REGISTER(dpp::base_module).list_of_factories(mods);
   std::set<std::string> moduleSet(mods.begin(), mods.end());
@@ -132,8 +132,8 @@ void do_help_pipeline_list(std::ostream& os) {
                                   "(urn:)([^:]*)(:)([^:]*)(:reconstruction:)([^:]*)(:pipeline)",
                                   "recsetup")) {
       std::clog << "List of supported reconstruction pipeline:" << std::endl;
-      for (size_t i = 0; i < flsim_urn_infos.size(); i++) {
-        const datatools::urn_info& ui = dtkUrnQuery.get_urn_info(flsim_urn_infos[i]);
+      for (const auto & flsim_urn_info : flsim_urn_infos) {
+        const datatools::urn_info& ui = dtkUrnQuery.get_urn_info(flsim_urn_info);
         os << ui.get_urn() << " : " << ui.get_description() << std::endl;
       }
     } else {
@@ -182,7 +182,7 @@ FLDialogState do_cldialog(int argc, char* argv[], FLReconstructCommandLine& clAr
       "progress modulo on number of events")
 
     ("user-profile,u", bpo::value<std::string>(&clArgs.userProfile)->value_name("name")->default_value("normal"),
-      "set the user profile (\"expert\", \"normal\", \"production\")")
+      R"(set the user profile ("expert", "normal", "production"))")
 
     ("input-metadata-file,M", bpo::value<std::string>(&clArgs.inputMetadataFile)->value_name("file"),
       "file from which to load metadata")

--- a/source/flreconstruct/FLReconstructCommandLine.cc
+++ b/source/flreconstruct/FLReconstructCommandLine.cc
@@ -85,13 +85,13 @@ void do_module_list(std::ostream& os) {
   ModuleInfo mods;
   // Builtin
   DATATOOLS_FACTORY_GET_SYSTEM_REGISTER(dpp::base_module).list_of_factories(mods);
-  for (ModuleInfo::value_type entry : mods) {
+  for (const ModuleInfo::value_type& entry : mods) {
     os << entry << std::endl;
   }
 }
 
 //! Print OCD help for supplied module name to given ostream
-void do_help_module(std::ostream& os, std::string module) {
+void do_help_module(std::ostream& os, const std::string& module) {
   datatools::library_loader libLoader;
   do_load_plugins(libLoader);
   // Is module valid?
@@ -132,7 +132,7 @@ void do_help_pipeline_list(std::ostream& os) {
                                   "(urn:)([^:]*)(:)([^:]*)(:reconstruction:)([^:]*)(:pipeline)",
                                   "recsetup")) {
       std::clog << "List of supported reconstruction pipeline:" << std::endl;
-      for (const auto & flsim_urn_info : flsim_urn_infos) {
+      for (const auto& flsim_urn_info : flsim_urn_infos) {
         const datatools::urn_info& ui = dtkUrnQuery.get_urn_info(flsim_urn_info);
         os << ui.get_urn() << " : " << ui.get_description() << std::endl;
       }

--- a/source/flreconstruct/FLReconstructCommandLine.cc
+++ b/source/flreconstruct/FLReconstructCommandLine.cc
@@ -50,7 +50,7 @@ FLReconstructCommandLine FLReconstructCommandLine::makeDefault() {
 //! Handle printing of version information to given ostream
 void do_version(std::ostream& os, bool isVerbose) {
   std::string commitInfo{};
-  if (falaise::version::get_commit() != "") {
+  if (!falaise::version::get_commit().empty()) {
     commitInfo = " (" + falaise::version::get_commit();
     commitInfo += falaise::version::is_dirty() ? "-dirty" : "";
     commitInfo += ")";
@@ -147,8 +147,6 @@ void do_help_pipeline_list(std::ostream& os) {
 void do_load_plugins(datatools::library_loader& libLoader) {
   std::string pluginPath = falaise::get_plugin_dir();
   // explicitly list for now...
-  // libLoader.load("Falaise_AnalogSignalBuilder", pluginPath);
-  // libLoader.load("Falaise_Digitization", pluginPath);
   libLoader.load("Falaise_CAT", pluginPath);
   libLoader.load("Falaise_ChargedParticleTracking", pluginPath);
   libLoader.load("Falaise_MockTrackerClusterizer", pluginPath);
@@ -165,68 +163,47 @@ FLDialogState do_cldialog(int argc, char* argv[], FLReconstructCommandLine& clAr
   // Bind command line parser to exposed parameters
   std::string verbosityLabel;
   // Application specific options:
+  // clang-format off
   bpo::options_description optDesc("Options");
   optDesc.add_options()("help,h", "print this help message")
+    ("help-module-list", "list available modules and exit")
 
-      ("help-module-list", "list available modules and exit")
+    ("help-module", bpo::value<std::string>()->value_name("name"),
+      "print help for a single module and exit")
 
-          ("help-module", bpo::value<std::string>()->value_name("name"),
-           "print help for a single module and exit")
+    ("help-pipeline-list", "list available pipeline configurations and exit")
 
-              ("help-pipeline-list", "list available pipeline configurations and exit")
+    ("version", "print version number")
 
-                  ("version", "print version number")
-
-      // ("verbosity,v",
-      //  bpo::value<datatools::logger::priority>(&clArgs.logLevel)
-      //  ->default_value(datatools::logger::PRIO_FATAL)
-      //  ->value_name("level"),
-      //  "set verbosity level of logging")
-
-      ("verbosity,V", bpo::value<std::string>(&verbosityLabel)->value_name("level"),
+    ("verbosity,V", bpo::value<std::string>(&verbosityLabel)->value_name("level"),
        "set the verbosity level")
 
-          ("modulo,P",
-           bpo::value<uint32_t>(&clArgs.moduloEvents)->default_value(0)->value_name("period"),
-           "progress modulo on number of events")
+    ("modulo,P", bpo::value<uint32_t>(&clArgs.moduloEvents)->default_value(0)->value_name("period"),
+      "progress modulo on number of events")
 
-              ("user-profile,u",
-               bpo::value<std::string>(&clArgs.userProfile)
-                   ->value_name("name")
-                   ->default_value("normal"),
-               "set the user profile (\"expert\", \"normal\", \"production\")")
+    ("user-profile,u", bpo::value<std::string>(&clArgs.userProfile)->value_name("name")->default_value("normal"),
+      "set the user profile (\"expert\", \"normal\", \"production\")")
 
-                  ("input-metadata-file,M",
-                   bpo::value<std::string>(&clArgs.inputMetadataFile)->value_name("file"),
-                   "file from which to load metadata")
+    ("input-metadata-file,M", bpo::value<std::string>(&clArgs.inputMetadataFile)->value_name("file"),
+      "file from which to load metadata")
 
-                      ("output-metadata-file,m",
-                       bpo::value<std::string>(&clArgs.outputMetadataFile)->value_name("file"),
-                       "file in which to store metadata")
+    ("output-metadata-file,m", bpo::value<std::string>(&clArgs.outputMetadataFile)->value_name("file"),
+      "file in which to store metadata")
 
-                          ("embedded-metadata,E",
-                           bpo::value<bool>(&clArgs.embeddedMetadata)
-                               ->value_name("flag")
-                               ->default_value(true),
-                           "flag to (de)activate recording of metadata in the reconstruction "
-                           "results output file")
+    ("embedded-metadata,E", bpo::value<bool>(&clArgs.embeddedMetadata)->value_name("flag")->default_value(true),
+      "flag to (de)activate recording of metadata in the reconstruction "
+      "results output file")
 
-                              ("pipeline,p",
-                               bpo::value<std::string>(&clArgs.pipelineScript)->value_name("file"),
-                               "pipeline script")
+    ("pipeline,p", bpo::value<std::string>(&clArgs.pipelineScript)->value_name("file"),
+      "pipeline script")
 
-                                  ("input-file,i",
-                                   bpo::value<std::string>(&clArgs.inputFile)
-                                       ->required()
-                                       ->value_name("file"),
-                                   "file from which to read input data (simulation, real)")
+    ("input-file,i", bpo::value<std::string>(&clArgs.inputFile)->required()->value_name("file"),
+      "file from which to read input data (simulation, real)")
 
-                                      ("output-file,o",
-                                       bpo::value<std::string>(&clArgs.outputFile)
-                                           ->value_name("file"),
-                                       "file in which to store reconstruction results")
-
-      ;
+    ("output-file,o", bpo::value<std::string>(&clArgs.outputFile)->value_name("file"),
+      "file in which to store reconstruction results")
+    ;
+  // clang-format on
 
   // - Store first, handling parse errors
   bpo::variables_map vMap;
@@ -235,8 +212,9 @@ FLDialogState do_cldialog(int argc, char* argv[], FLReconstructCommandLine& clAr
     bpo::notify(vMap);
   } catch (const bpo::required_option& e) {
     // We need to handle help/version even if required_option thrown
-    if (!vMap.count("help") && !vMap.count("version") && !vMap.count("help-module-list") &&
-        !vMap.count("help-module") && !vMap.count("help-pipeline-list")) {
+    if ((vMap.count("help") == 0u) && (vMap.count("version") == 0u) &&
+        (vMap.count("help-module-list") == 0u) && (vMap.count("help-module") == 0u) &&
+        (vMap.count("help-pipeline-list") == 0u)) {
       do_error(std::cerr, e.what());
       return DIALOG_ERROR;
     }
@@ -246,32 +224,32 @@ FLDialogState do_cldialog(int argc, char* argv[], FLReconstructCommandLine& clAr
   }
 
   // Handle any non-bound options
-  if (vMap.count("help")) {
+  if (vMap.count("help") != 0u) {
     do_help(std::cout, optDesc);
     return DIALOG_QUERY;
   }
 
-  if (vMap.count("version")) {
+  if (vMap.count("version") != 0u) {
     do_version(std::cout, true);
     return DIALOG_QUERY;
   }
 
-  if (vMap.count("help-module-list")) {
+  if (vMap.count("help-module-list") != 0u) {
     do_module_list(std::cout);
     return DIALOG_QUERY;
   }
 
-  if (vMap.count("help-module")) {
+  if (vMap.count("help-module") != 0u) {
     do_help_module(std::cout, vMap["help-module"].as<std::string>());
     return DIALOG_QUERY;
   }
 
-  if (vMap.count("help-pipeline-list")) {
+  if (vMap.count("help-pipeline-list") != 0u) {
     do_help_pipeline_list(std::cout);
     return DIALOG_QUERY;
   }
 
-  if (vMap.count("verbosity")) {
+  if (vMap.count("verbosity") != 0u) {
     clArgs.logLevel = datatools::logger::get_priority(verbosityLabel);
     if (clArgs.logLevel == datatools::logger::PRIO_UNDEFINED) {
       do_error(std::cerr, "Invalid verbosity level '" + verbosityLabel + "'!");
@@ -279,7 +257,7 @@ FLDialogState do_cldialog(int argc, char* argv[], FLReconstructCommandLine& clAr
     }
   }
 
-  if (!falaise::common::supported_user_profiles().count(clArgs.userProfile)) {
+  if (falaise::common::supported_user_profiles().count(clArgs.userProfile) == 0u) {
     do_error(std::cerr, "Invalid user profile '" + clArgs.userProfile + "'!");
     return DIALOG_ERROR;
   }

--- a/source/flreconstruct/FLReconstructCommandLine.h
+++ b/source/flreconstruct/FLReconstructCommandLine.h
@@ -60,7 +60,7 @@ void do_help(std::ostream& os, const boost::program_options::options_description
 void do_module_list(std::ostream& os);
 
 //! Print OCD help for supplied module name to given ostream
-void do_help_module(std::ostream& os, std::string module);
+void do_help_module(std::ostream& os, const std::string& module);
 
 //! Print list of standard pipeline configurations to supplied ostream
 void do_help_pipeline_list(std::ostream& os);

--- a/source/flreconstruct/FLReconstructImpl.cc
+++ b/source/flreconstruct/FLReconstructImpl.cc
@@ -41,15 +41,11 @@ void do_configure(int argc, char* argv[], FLReconstructParams& flRecParameters) 
   FLDialogState clDialogRet = DIALOG_OK;
   try {
     clDialogRet = do_cldialog(argc, argv, clArgs);
-    // DT_LOG_DEBUG(datatools::logger::PRIO_ALWAYS, "Command line dialog end with exit code=" <<
-    // clDialogRet);
 
     if (clDialogRet == DIALOG_ERROR) {
-      // DT_LOG_DEBUG(datatools::logger::PRIO_ALWAYS, "Detected a dialog error!");
       throw FLConfigUserError{"bad command line input"};
     }
     if (clDialogRet == DIALOG_QUERY) {
-      // DT_LOG_DEBUG(datatools::logger::PRIO_ALWAYS, "Detected a dialog query!");
       throw FLConfigHelpHandled();
     }
   } catch (FLConfigHelpHandled& e) {
@@ -61,7 +57,6 @@ void do_configure(int argc, char* argv[], FLReconstructParams& flRecParameters) 
   } catch (std::exception& e) {
     throw FLConfigUserError{"bad command line input"};
   }
-  DT_LOG_DEBUG(clArgs.logLevel, "Configuring...");
 
   // Import parameters from the command line:
   flRecParameters.logLevel = clArgs.logLevel;
@@ -247,11 +242,11 @@ void do_configure(int argc, char* argv[], FLReconstructParams& flRecParameters) 
     // Clean the flRecConfig from unused sections of type "flreconstruct::section":
     std::vector<std::string> section_keys = flRecConfig.keys();
     std::vector<std::string> unused_section_keys;
-    for (std::size_t i = 0; i < section_keys.size(); i++) {
-      if (flRecConfig.has_key_with_meta(section_keys[i], "flreconstruct::section")) {
+    for (const auto & section_key : section_keys) {
+      if (flRecConfig.has_key_with_meta(section_key, "flreconstruct::section")) {
         DT_LOG_ERROR(flRecParameters.logLevel, "Found an unused flreconstruct section named '"
-                                                   << section_keys[i] << "'! We will discard it!");
-        unused_section_keys.push_back(section_keys[i]);
+                                                   << section_key << "'! We will discard it!");
+        unused_section_keys.push_back(section_key);
       }
     }
     for (std::size_t i = 0; i < unused_section_keys.size(); i++) {
@@ -276,8 +271,6 @@ void do_configure(int argc, char* argv[], FLReconstructParams& flRecParameters) 
 }
 
 void do_postprocess_input_metadata(FLReconstructParams& flRecParameters) {
-  DT_LOG_TRACE_ENTERING(flRecParameters.logLevel);
-
   // Collect input metadata from input files:
   // we first try from some input metadata companion file, if provided,
   // then from the input data file itself, in the hope it contains metadata records.
@@ -285,13 +278,10 @@ void do_postprocess_input_metadata(FLReconstructParams& flRecParameters) {
   falaise::app::metadata_collector mc;
   if (!flRecParameters.inputMetadataFile.empty()) {
     // Fetch the metadata from the companion input metadata file, if any:
-    DT_LOG_NOTICE(flRecParameters.logLevel,
-                  "Fetching input metadata from input metadata companion file...");
     mc.set_input_metadata_file(flRecParameters.inputMetadataFile);
     flRecParameters.inputMetadata = mc.get_metadata_from_metadata_file();
   } else if (!flRecParameters.inputFile.empty()) {
     // Fetch the metadata from the input data file:
-    DT_LOG_NOTICE(flRecParameters.logLevel, "Fetching input metadata from input data file...");
     mc.set_input_data_file(flRecParameters.inputFile);
     flRecParameters.inputMetadata = mc.get_metadata_from_data_file();
   } else {
@@ -308,13 +298,13 @@ void do_postprocess_input_metadata(FLReconstructParams& flRecParameters) {
   // Extract input metadata of interest:
   if (!flRecParameters.inputMetadata.empty()) {
     // Try to extract informations from the metadata:
-    DT_LOG_DEBUG(flRecParameters.logLevel, "Found input metadata");
     iMeta.scan(flRecParameters.inputMetadata);
     if (datatools::logger::is_notice(flRecParameters.logLevel)) {
       iMeta.print(std::cerr);
     }
   }  // End of using input metadata
 
+  // TODO: Is this an error?
   if (!iMeta.experimentalSetupUrn.empty()) {
     DT_LOG_NOTICE(flRecParameters.logLevel,
                   "Input metadata from the experimental setup identifier (URN) is '"
@@ -363,12 +353,9 @@ void do_postprocess_input_metadata(FLReconstructParams& flRecParameters) {
                                                   << "' from input metadata.");
     }
   }  // End of settings.
-
-  DT_LOG_TRACE_EXITING(flRecParameters.logLevel);
 }
 
 void do_postprocess(FLReconstructParams& flRecParameters) {
-  DT_LOG_TRACE_ENTERING(flRecParameters.logLevel);
   datatools::kernel& dtk = datatools::kernel::instance();
   const datatools::urn_query_service& dtkUrnQuery = dtk.get_urn_query();
 
@@ -551,7 +538,6 @@ void do_postprocess(FLReconstructParams& flRecParameters) {
     flRecParameters.print(std::cerr);
   }
 
-  DT_LOG_TRACE_EXITING(flRecParameters.logLevel);
 }
 
 falaise::exit_code do_metadata(const FLReconstructParams& flRecParameters,

--- a/source/flreconstruct/FLReconstructImpl.cc
+++ b/source/flreconstruct/FLReconstructImpl.cc
@@ -47,7 +47,8 @@ void do_configure(int argc, char* argv[], FLReconstructParams& flRecParameters) 
     if (clDialogRet == DIALOG_ERROR) {
       // DT_LOG_DEBUG(datatools::logger::PRIO_ALWAYS, "Detected a dialog error!");
       throw FLConfigUserError{"bad command line input"};
-    } else if (clDialogRet == DIALOG_QUERY) {
+    }
+    if (clDialogRet == DIALOG_QUERY) {
       // DT_LOG_DEBUG(datatools::logger::PRIO_ALWAYS, "Detected a dialog query!");
       throw FLConfigHelpHandled();
     }
@@ -183,7 +184,7 @@ void do_configure(int argc, char* argv[], FLReconstructParams& flRecParameters) 
       std::vector<std::string> pList;
       userFLPlugins.fetch("plugins", pList);
       for (std::string plugin_name : pList) {
-        static const std::string no_explicit_plugin_file = "";
+        static const std::string no_explicit_plugin_file;
         datatools::properties& pSection =
             flRecParameters.userLibConfig.add_section(plugin_name, no_explicit_plugin_file);
         userFLPlugins.export_and_rename_starting_with(pSection, plugin_name + ".", "");
@@ -261,7 +262,7 @@ void do_configure(int argc, char* argv[], FLReconstructParams& flRecParameters) 
   }
 
   // Check for allowed inline modules:
-  if (flRecParameters.userProfile == "production" && flRecConfig.size()) {
+  if (flRecParameters.userProfile == "production" && !flRecConfig.empty()) {
     DT_THROW(FLConfigUserError, "User profile '"
                                     << flRecParameters.userProfile << "' "
                                     << "does not allow the definitions of inline modules!");
@@ -272,7 +273,6 @@ void do_configure(int argc, char* argv[], FLReconstructParams& flRecParameters) 
   flRecParameters.modulesConfig = flRecConfig;
 
   do_postprocess(flRecParameters);
-  return;
 }
 
 void do_postprocess_input_metadata(FLReconstructParams& flRecParameters) {
@@ -365,7 +365,6 @@ void do_postprocess_input_metadata(FLReconstructParams& flRecParameters) {
   }  // End of settings.
 
   DT_LOG_TRACE_EXITING(flRecParameters.logLevel);
-  return;
 }
 
 void do_postprocess(FLReconstructParams& flRecParameters) {
@@ -553,7 +552,6 @@ void do_postprocess(FLReconstructParams& flRecParameters) {
   }
 
   DT_LOG_TRACE_EXITING(flRecParameters.logLevel);
-  return;
 }
 
 falaise::exit_code do_metadata(const FLReconstructParams& flRecParameters,
@@ -619,7 +617,7 @@ falaise::exit_code do_metadata(const FLReconstructParams& flRecParameters,
                                 "Variants profile path");
     }
 
-    if (flRecParameters.variantSubsystemParams.settings.size()) {
+    if (!flRecParameters.variantSubsystemParams.settings.empty()) {
       // Not with "production" user profile:
       variants_props.store("settings", flRecParameters.variantSubsystemParams.settings,
                            "Variants settings");

--- a/source/flreconstruct/FLReconstructImpl.cc
+++ b/source/flreconstruct/FLReconstructImpl.cc
@@ -178,7 +178,7 @@ void do_configure(int argc, char* argv[], FLReconstructParams& flRecParameters) 
       flRecConfig.remove("flreconstruct.plugins");
       std::vector<std::string> pList;
       userFLPlugins.fetch("plugins", pList);
-      for (std::string plugin_name : pList) {
+      for (const std::string& plugin_name : pList) {
         static const std::string no_explicit_plugin_file;
         datatools::properties& pSection =
             flRecParameters.userLibConfig.add_section(plugin_name, no_explicit_plugin_file);
@@ -242,7 +242,7 @@ void do_configure(int argc, char* argv[], FLReconstructParams& flRecParameters) 
     // Clean the flRecConfig from unused sections of type "flreconstruct::section":
     std::vector<std::string> section_keys = flRecConfig.keys();
     std::vector<std::string> unused_section_keys;
-    for (const auto & section_key : section_keys) {
+    for (const auto& section_key : section_keys) {
       if (flRecConfig.has_key_with_meta(section_key, "flreconstruct::section")) {
         DT_LOG_ERROR(flRecParameters.logLevel, "Found an unused flreconstruct section named '"
                                                    << section_key << "'! We will discard it!");
@@ -418,7 +418,7 @@ void do_postprocess(FLReconstructParams& flRecParameters) {
   if (!flRecParameters.experimentalSetupUrn.empty()) {
     // Check URN registration from the system URN query service:
     {
-      std::string conf_category = falaise::tags::experimental_setup_category();
+      const std::string& conf_category = falaise::tags::experimental_setup_category();
       DT_THROW_IF(!dtkUrnQuery.check_urn_info(flRecParameters.experimentalSetupUrn, conf_category),
                   std::logic_error,
                   "Cannot query URN='" << flRecParameters.experimentalSetupUrn << "'!");
@@ -537,7 +537,6 @@ void do_postprocess(FLReconstructParams& flRecParameters) {
   if (datatools::logger::is_debug(flRecParameters.logLevel)) {
     flRecParameters.print(std::cerr);
   }
-
 }
 
 falaise::exit_code do_metadata(const FLReconstructParams& flRecParameters,

--- a/source/flreconstruct/FLReconstructParams.cc
+++ b/source/flreconstruct/FLReconstructParams.cc
@@ -94,7 +94,6 @@ void FLReconstructParams::print(std::ostream& out_) const {
   out_ << tag << "embeddedMetadata             = " << std::boolalpha << embeddedMetadata
        << std::endl;
   out_ << last_tag << "outputFile                   = " << outputFile << std::endl;
-  return;
 }
 
 }  // namespace FLReconstruct

--- a/source/flreconstruct/FLReconstructPipeline.cc
+++ b/source/flreconstruct/FLReconstructPipeline.cc
@@ -192,7 +192,9 @@ falaise::exit_code do_pipeline(const FLReconstructParams& flRecParameters) {
     while (true) {
       // Prepare and read work
       workItem.clear();
-      if (recInput->is_terminated()) break;
+      if (recInput->is_terminated()) {
+        break;
+      }
       if (recInput->process(workItem) != dpp::base_module::PROCESS_OK) {
         DT_LOG_FATAL(flRecParameters.logLevel, "Failed to read data record from input source");
         break;
@@ -209,18 +211,26 @@ falaise::exit_code do_pipeline(const FLReconstructParams& flRecParameters) {
       // FATAL, ERROR and ERROR_STOP status triggers the abortion of the processing loop.
       // This is a very conservative approach, but it is compatible with the default behaviour of
       // the bxdpp_processing executable.
-      if (pStatus == dpp::base_module::PROCESS_FATAL) break;
-      if (pStatus == dpp::base_module::PROCESS_ERROR) break;
-      if (pStatus == dpp::base_module::PROCESS_ERROR_STOP) break;
+      if (pStatus == dpp::base_module::PROCESS_FATAL) {
+        break;
+      }
+      if (pStatus == dpp::base_module::PROCESS_ERROR) {
+        break;
+      }
+      if (pStatus == dpp::base_module::PROCESS_ERROR_STOP) {
+        break;
+      }
 
       // STOP means the current event should not be processed anymore nor saved
       // but the loop can continue with other items
-      if (pStatus == dpp::base_module::PROCESS_STOP) continue;
+      if (pStatus == dpp::base_module::PROCESS_STOP) {
+        continue;
+      }
 
       // Check post-conditions on event model (expectedOutputBanks) ?
 
       // Write item
-      if (recOutputHandle) {
+      if (recOutputHandle != nullptr) {
         pStatus = recOutputHandle->process(workItem);
         if (pStatus != dpp::base_module::PROCESS_OK) {
           DT_LOG_FATAL(flRecParameters.logLevel, "Failed to write data record to output sink");
@@ -241,7 +251,7 @@ falaise::exit_code do_pipeline(const FLReconstructParams& flRecParameters) {
 
     // - MUST delete the module manager BEFORE the library loader clears
     // in case the manager is holding resources created from a shared lib
-    if (moduleManager.get() != nullptr) {
+    if (moduleManager != nullptr) {
       if (moduleManager->is_initialized()) {
         moduleManager->reset();
       }

--- a/source/flreconstruct/FLReconstructPipeline.h
+++ b/source/flreconstruct/FLReconstructPipeline.h
@@ -26,7 +26,7 @@
 namespace FLReconstruct {
 
 //! Run the pipeline after configuration step
-falaise::exit_code do_pipeline(const FLReconstructParams& recParams);
+falaise::exit_code do_pipeline(const FLReconstructParams& flRecParameters);
 
 //! Ensure some critical services are setup
 falaise::exit_code ensure_core_services(const FLReconstructParams& recParams,

--- a/source/flreconstruct/FLReconstructResources.cc
+++ b/source/flreconstruct/FLReconstructResources.cc
@@ -68,13 +68,10 @@ ExperimentLookup::Table constructLookupPipelineTable() {
 //! Construct lookup table
 ExperimentLookup::Table constructLookupVariantsConfigTable() {
   ExperimentLookup::Table a;
-  boost::assign::insert(a)(
-      "", "snemo/demonstrator/geant4_control/Geant4VariantRepository.conf")(
-      "default",
-      "snemo/demonstrator/geant4_control/Geant4VariantRepository.conf")(
-      "demonstrator",
-      "snemo/demonstrator/geant4_control/Geant4VariantRepository.conf")("bipo3",
-                                                                                          "");
+  boost::assign::insert(a)("", "snemo/demonstrator/geant4_control/Geant4VariantRepository.conf")(
+      "default", "snemo/demonstrator/geant4_control/Geant4VariantRepository.conf")(
+      "demonstrator", "snemo/demonstrator/geant4_control/Geant4VariantRepository.conf")("bipo3",
+                                                                                        "");
   ;
   return a;
 }
@@ -82,14 +79,9 @@ ExperimentLookup::Table constructLookupVariantsConfigTable() {
 //! Construct lookup table
 ExperimentLookup::Table constructLookupVariantsDefaultProfileTable() {
   ExperimentLookup::Table a;
-  boost::assign::insert(a)(
-      "",
-      "snemo/demonstrator/profiles/demonstrator-simulation.profile")(
-      "default",
-      "snemo/demonstrator/profiles/demonstrator-simulation.profile")(
-      "demonstrator",
-      "snemo/demonstrator/profiles/demonstrator-simulation.profile")(
-      "bipo3", "");
+  boost::assign::insert(a)("", "snemo/demonstrator/profiles/demonstrator-simulation.profile")(
+      "default", "snemo/demonstrator/profiles/demonstrator-simulation.profile")(
+      "demonstrator", "snemo/demonstrator/profiles/demonstrator-simulation.profile")("bipo3", "");
   ;
   return a;
 }
@@ -97,7 +89,9 @@ ExperimentLookup::Table constructLookupVariantsDefaultProfileTable() {
 std::string getPipelineDefaultControlFile(const std::string& experiment,
                                           const std::string& /*versionID*/) {
   static ExperimentLookup::Table a;
-  if (a.empty()) a = constructLookupPipelineTable();
+  if (a.empty()) {
+    a = constructLookupPipelineTable();
+  }
 
   std::string path = ExperimentLookup::findPathInTable(a, experiment);
 
@@ -110,7 +104,9 @@ std::string getPipelineDefaultControlFile(const std::string& experiment,
 
 std::string getVariantsConfigFile(const std::string& experiment, const std::string& /*versionID*/) {
   static ExperimentLookup::Table a;
-  if (a.empty()) a = constructLookupVariantsConfigTable();
+  if (a.empty()) {
+    a = constructLookupVariantsConfigTable();
+  }
 
   std::string path = ExperimentLookup::findPathInTable(a, experiment);
 
@@ -124,7 +120,9 @@ std::string getVariantsConfigFile(const std::string& experiment, const std::stri
 std::string getVariantsDefaultProfile(const std::string& experiment,
                                       const std::string& /*versionID*/) {
   static ExperimentLookup::Table a;
-  if (a.empty()) a = constructLookupVariantsDefaultProfileTable();
+  if (a.empty()) {
+    a = constructLookupVariantsDefaultProfileTable();
+  }
 
   std::string path = ExperimentLookup::findPathInTable(a, experiment);
 

--- a/source/flreconstruct/FLReconstructUtils.cc
+++ b/source/flreconstruct/FLReconstructUtils.cc
@@ -10,14 +10,22 @@
 namespace FLReconstruct {
 
 std::string get_data_type_label(data_type dt_) {
-  if (dt_ == DATA_REAL) return "Real";
-  if (dt_ == DATA_MC) return "MC";
+  if (dt_ == DATA_REAL) {
+    return "Real";
+  }
+  if (dt_ == DATA_MC) {
+    return "MC";
+  }
   return "";
 }
 
 data_type get_data_type(const std::string& label_) {
-  if (label_ == get_data_type_label(DATA_REAL)) return DATA_REAL;
-  if (label_ == get_data_type_label(DATA_MC)) return DATA_MC;
+  if (label_ == get_data_type_label(DATA_REAL)) {
+    return DATA_REAL;
+  }
+  if (label_ == get_data_type_label(DATA_MC)) {
+    return DATA_MC;
+  }
   return DATA_UNKNOWN;
 }
 
@@ -38,7 +46,7 @@ std::istream& operator>>(std::istream& in, datatools::logger::priority& p) {
 
 //! validate logging argument
 void validate(boost::any& v, std::vector<std::string> const& values,
-              datatools::logger::priority* /*target_type*/, int) {
+              datatools::logger::priority* /*target_type*/, int /*unused*/) {
   namespace bpo = boost::program_options;
   // Make sure no previous assignment to v was made
   bpo::validators::check_first_occurrence(v);

--- a/source/flsimulate/FLSimulateArgs.cc
+++ b/source/flsimulate/FLSimulateArgs.cc
@@ -110,7 +110,7 @@ void do_configure(int argc, char* argv[], FLSimulateArgs& flSimParameters) {
   flSimParameters.outputFile = args.outputFile;
   flSimParameters.mountPoints = args.mountPoints;
 
-  if (flSimParameters.mountPoints.size()) {
+  if (static_cast<unsigned int>(!flSimParameters.mountPoints.empty()) != 0u) {
     // Apply mount points as soon as possible, because manually set file path below
     // may use this mechanism to locate files:
     datatools::kernel& dtk = datatools::kernel::instance();
@@ -359,7 +359,6 @@ void do_configure(int argc, char* argv[], FLSimulateArgs& flSimParameters) {
   }  // !args.configScript.empty()
 
   do_postprocess(flSimParameters);
-  return;
 }
 
 void do_postprocess(FLSimulateArgs& flSimParameters) {
@@ -569,7 +568,6 @@ void do_postprocess(FLSimulateArgs& flSimParameters) {
   }
 
   DT_LOG_TRACE_EXITING(flSimParameters.logLevel);
-  return;
 }
 
 void FLSimulateArgs::print(std::ostream& out_) const {
@@ -602,7 +600,6 @@ void FLSimulateArgs::print(std::ostream& out_) const {
   out_ << tag << "outputMetadataFile         = " << outputMetadataFile << std::endl;
   out_ << tag << "embeddedMetadata           = " << std::boolalpha << embeddedMetadata << std::endl;
   out_ << last_tag << "outputFile                 = " << outputFile << std::endl;
-  return;
 }
 
 }  // namespace FLSimulate

--- a/source/flsimulate/FLSimulateArgs.h
+++ b/source/flsimulate/FLSimulateArgs.h
@@ -81,7 +81,7 @@ struct FLSimulateArgs {
 };
 
 //! Parse command line arguments to configure the simulation parameters
-void do_configure(int argc, char *argv[], FLSimulateArgs &params);
+void do_configure(int argc, char *argv[], FLSimulateArgs &flSimParameters);
 
 }  // namespace FLSimulate
 

--- a/source/flsimulate/FLSimulateCommandLine.cc
+++ b/source/flsimulate/FLSimulateCommandLine.cc
@@ -33,7 +33,7 @@ FLSimulateCommandLine FLSimulateCommandLine::makeDefault() {
 
 void do_version(std::ostream& os, bool isVerbose) {
   std::string commitInfo{};
-  if (falaise::version::get_commit() != "") {
+  if (!falaise::version::get_commit().empty()) {
     commitInfo = " (" + falaise::version::get_commit();
     commitInfo += falaise::version::is_dirty() ? "-dirty" : "";
     commitInfo += ")";
@@ -52,7 +52,6 @@ void do_version(std::ostream& os, bool isVerbose) {
        << "\n"
        << "\n\n";
   }
-  return;
 }
 
 void do_help(const bpo::options_description& od) {
@@ -61,7 +60,6 @@ void do_help(const bpo::options_description& od) {
   std::cout << "Usage:\n"
             << "  flsimulate [options]\n"
             << od << "\n";
-  return;
 }
 
 void do_help_scripting(std::ostream& os) {
@@ -94,13 +92,14 @@ void do_help_scripting(std::ostream& os) {
      << "All sections and parameters are optional, and flsimulate will supply sensible\n"
      << "default values when only some are set.\n"
      << std::endl;
-  return;
 }
 
 void do_help_simulation_setup(std::ostream& os) {
   std::map<std::string, std::string> m = ::FLSimulate::list_of_simulation_setups();
   std::clog << "List of supported simulation setups: ";
-  if (m.empty()) std::clog << "<empty>";
+  if (m.empty()) {
+    std::clog << "<empty>";
+  }
   std::clog << std::endl;
   for (const auto& entry : m) {
     os << entry.first << " : ";
@@ -111,7 +110,6 @@ void do_help_simulation_setup(std::ostream& os) {
     }
     os << std::endl;
   }
-  return;
 }
 
 void do_cldialog(int argc, char* argv[], FLSimulateCommandLine& clArgs) {
@@ -188,8 +186,8 @@ void do_cldialog(int argc, char* argv[], FLSimulateCommandLine& clArgs) {
     bpo::notify(vMap);
   } catch (const bpo::required_option& e) {
     // We need to handle help/version even if required_option thrown
-    if (!vMap.count("help") && !vMap.count("version") && !vMap.count("help-scripting") &&
-        !vMap.count("help-simulation-setup")) {
+    if ((vMap.count("help") == 0u) && (vMap.count("version") == 0u) &&
+        (vMap.count("help-scripting") == 0u) && (vMap.count("help-simulation-setup") == 0u)) {
       std::cerr << "[OptionsException] " << e.what() << std::endl;
       throw FLDialogOptionsError();
     }
@@ -199,38 +197,36 @@ void do_cldialog(int argc, char* argv[], FLSimulateCommandLine& clArgs) {
   }
 
   // Handle any non-bound options
-  if (vMap.count("help")) {
+  if (vMap.count("help") != 0u) {
     do_help(optDesc);
     throw FLDialogHelpRequested();
   }
 
-  if (vMap.count("version")) {
+  if (vMap.count("version") != 0u) {
     do_version(std::cout, true);
     throw FLDialogHelpRequested();
   }
 
-  if (vMap.count("help-scripting")) {
+  if (vMap.count("help-scripting") != 0u) {
     do_help_scripting(std::cout);
     throw FLDialogHelpRequested();
   }
 
-  if (vMap.count("help-simulation-setup")) {
+  if (vMap.count("help-simulation-setup") != 0u) {
     do_help_simulation_setup(std::cout);
     throw FLDialogHelpRequested();
   }
 
-  if (vMap.count("verbosity")) {
+  if (vMap.count("verbosity") != 0u) {
     clArgs.logLevel = datatools::logger::get_priority(verbosityLabel);
     if (clArgs.logLevel == datatools::logger::PRIO_UNDEFINED) {
       throw FLDialogOptionsError();
     }
   }
 
-  if (!falaise::common::supported_user_profiles().count(clArgs.userProfile)) {
+  if (falaise::common::supported_user_profiles().count(clArgs.userProfile) == 0u) {
     DT_THROW(FLDialogOptionsError, "Invalid user profile '" << clArgs.userProfile << "'");
   }
-
-  return;
 }
 
 }  // namespace FLSimulate

--- a/source/flsimulate/FLSimulateCommandLine.cc
+++ b/source/flsimulate/FLSimulateCommandLine.cc
@@ -120,64 +120,48 @@ void do_cldialog(int argc, char* argv[], FLSimulateCommandLine& clArgs) {
   std::string verbosityLabel;
   // Application specific options:
   bpo::options_description optDesc("Options");
+  // clang-format off
   optDesc.add_options()("help,h", "print this help message")
+    ("help-scripting", "print help on input script format and schema")
+    ("help-simulation-setup", "print help on simulation setup")
+    ("version", "print version number")
 
-      ("help-scripting", "print help on input script format and schema")
+    ("verbosity,V", bpo::value<std::string>(&verbosityLabel)->value_name("level"),
+      "set the verbosity level\n"
+      "Example: \n"
+      "  -V \"debug\" ")
 
-          ("help-simulation-setup", "print help on simulation setup")
+    ("user-profile,u", bpo::value<std::string>(&clArgs.userProfile)->value_name("name")->default_value("normal"),
+        R"(set the user profile ("expert", "normal", "production"))")
 
-              ("version", "print version number")
+    ("mount-directory,d", bpo::value<std::vector<std::string>>(&clArgs.mountPoints)->value_name("rule"),
+      "register directories' mount points\n"
+      "Example: \n"
+      "  -d \"nemoprod@/etc/nemoprod/config\" \n"
+      "  -d \"nemoprod.data@/data/nemoprod/runs\"")
+    
+    ("config,c", bpo::value<std::string>(&clArgs.configScript)->value_name("file"),
+      "configuration script for simulation\n"
+      "Examples: \n"
+      "  -c \"simu.conf\" \n"
+      "  -c \"${WORKER_DIR}/config/simu1.conf\"")
 
-                  ("verbosity,V", bpo::value<std::string>(&verbosityLabel)->value_name("level"),
-                   "set the verbosity level\n"
-                   "Example: \n"
-                   "  -V \"debug\" ")
+    ("output-metadata-file,m", bpo::value<std::string>(&clArgs.outputMetadataFile)->value_name("file"),
+      "file in which to store metadata\n"
+      "Example:\n"
+      "  -m \"simu.meta\"")
 
-                      ("user-profile,u",
-                       bpo::value<std::string>(&clArgs.userProfile)
-                           ->value_name("name")
-                           ->default_value("normal"),
-                       "set the user profile (\"expert\", \"normal\", \"production\")")
+    ("embedded-metadata,E", bpo::value<bool>(&clArgs.embeddedMetadata)->value_name("flag")->default_value(true),
+      "flag to (de)activate recording of metadata in the "
+      "simulation results output file")
 
-                          ("mount-directory,d",
-                           bpo::value<std::vector<std::string>>(&clArgs.mountPoints)
-                               ->value_name("rule"),
-                           "register directories' mount points\n"
-                           "Example: \n"
-                           "  -d \"nemoprod@/etc/nemoprod/config\" \n"
-                           "  -d \"nemoprod.data@/data/nemoprod/runs\"")
-
-                              ("config,c",
-                               bpo::value<std::string>(&clArgs.configScript)->value_name("file"),
-                               "configuration script for simulation\n"
-                               "Examples: \n"
-                               "  -c \"simu.conf\" \n"
-                               "  -c \"${WORKER_DIR}/config/simu1.conf\"")
-
-                                  ("output-metadata-file,m",
-                                   bpo::value<std::string>(&clArgs.outputMetadataFile)
-                                       ->value_name("file"),
-                                   "file in which to store metadata\n"
-                                   "Example:\n"
-                                   "  -m \"simu.meta\"")
-
-                                      ("embedded-metadata,E",
-                                       bpo::value<bool>(&clArgs.embeddedMetadata)
-                                           ->value_name("flag")
-                                           ->default_value(true),
-                                       "flag to (de)activate recording of metadata in the "
-                                       "simulation results output file")
-
-                                          ("output-file,o",
-                                           bpo::value<std::string>(&clArgs.outputFile)
-                                               ->required()
-                                               ->value_name("file"),
-                                           "file in which to store simulation results\n"
-                                           "Examples:\n"
-                                           "  -o \"example.brio\" \n"
-                                           "  -o \"${WORKER_DIR}/data/run_1.xml\"")
-
-      ;
+    ("output-file,o", bpo::value<std::string>(&clArgs.outputFile)->required()->value_name("file"),
+      "file in which to store simulation results\n"
+      "Examples:\n"
+      "  -o \"example.brio\" \n"
+      "  -o \"${WORKER_DIR}/data/run_1.xml\"")
+    ;
+  // clang-format on
 
   // - Parse...
   bpo::variables_map vMap;

--- a/source/flsimulate/FLSimulateUtils.cc
+++ b/source/flsimulate/FLSimulateUtils.cc
@@ -27,8 +27,8 @@ std::map<std::string, std::string> list_of_simulation_setups() {
     if (dtkUrnQuery.find_urn_info(flsim_urn_infos, falaise::detail::falaise_sys::fl_setup_db_name(),
                                   // Format : "urn:{namespace}:{experiment}:simulation:{version}"
                                   "(urn:)([^:]*)(:)([^:]*)(:simulation:)([^:]*)", "simsetup")) {
-      for (size_t i = 0; i < flsim_urn_infos.size(); i++) {
-        const datatools::urn_info& ui = dtkUrnQuery.get_urn_info(flsim_urn_infos[i]);
+      for (const auto& flsim_urn_info : flsim_urn_infos) {
+        const datatools::urn_info& ui = dtkUrnQuery.get_urn_info(flsim_urn_info);
         m[ui.get_urn()] = ui.get_description();
       }
     }

--- a/source/flsimulate/flsimulatemain.cc
+++ b/source/flsimulate/flsimulatemain.cc
@@ -83,7 +83,8 @@ namespace FLSimulate {
 falaise::exit_code do_flsimulate(int argc, char *argv[]);
 
 //! Populate the metadata container with various informations classified in several categories
-falaise::exit_code do_metadata(const FLSimulateArgs &, datatools::multi_properties &);
+falaise::exit_code do_metadata(const FLSimulateArgs & /*flSimParameters*/,
+                               datatools::multi_properties & /*flSimMetadata*/);
 
 }  // end of namespace FLSimulate
 
@@ -213,7 +214,7 @@ falaise::exit_code do_metadata(const FLSimulateArgs &flSimParameters,
   }
 
   if (flSimParameters.saveVariantSettings &&
-      flSimParameters.variantSubsystemParams.settings.size()) {
+      !flSimParameters.variantSubsystemParams.settings.empty()) {
     // Saving effective list of variant settings:
     variants_props.store("settings", flSimParameters.variantSubsystemParams.settings,
                          "Effective variants settings");
@@ -264,7 +265,7 @@ falaise::exit_code do_flsimulate(int argc, char *argv[]) {
       variantService.start();
       // From this point, all other services and/or processing modules can
       // benefit of the variant service during their configuration steps.
-      if (flSimParameters.variantSubsystemParams.settings.size()) {
+      if (!flSimParameters.variantSubsystemParams.settings.empty()) {
         // The Variant service uses explicit settings:
         // Make sure we know the full list of effective variant settings corresponding to user
         // choice:

--- a/source/fltags/FLTags.cc
+++ b/source/fltags/FLTags.cc
@@ -3,15 +3,15 @@
 
 // Standard Library:
 #include <fstream>
-#include <sstream>
 #include <memory>
+#include <sstream>
 
 // Third Party:
 // - Bayeux:
-#include "bayeux/datatools/kernel.h"
-#include "bayeux/datatools/utils.h"
-#include "bayeux/datatools/urn_query_service.h"
 #include "bayeux/datatools/dependency_graph.h"
+#include "bayeux/datatools/kernel.h"
+#include "bayeux/datatools/urn_query_service.h"
+#include "bayeux/datatools/utils.h"
 
 // This project:
 #include <falaise/version.h>
@@ -22,145 +22,137 @@
 
 namespace FLTags {
 
-  // static
-  const std::string & fltags::default_action()
-  {
-    static const std::string _a("list");
-    return _a;
+// static
+const std::string& fltags::default_action() {
+  static const std::string _a("list");
+  return _a;
+}
+
+fltags::fltags(const FLTags::FLTagsArgs& args_) : _args_(args_) {}
+
+void fltags::run() {
+  if (datatools::logger::is_debug(_args_.logLevel)) {
+    DT_LOG_DEBUG(_args_.logLevel, "FLArgs parameters:");
+    _args_.print(std::cerr);
+  }
+  if (_args_.action == "list") {
+    _run_print_list_();
+  }
+  if (_args_.action == "graph") {
+    _run_generate_graph_();
+  }
+}
+
+void fltags::_run_print_list_() {
+  DT_LOG_DEBUG(_args_.logLevel, "Building the list of registered tags...");
+  datatools::kernel& dtk = datatools::kernel::instance();
+  datatools::urn_query_service& dtkUrnQuery = dtk.grab_urn_query();
+
+  std::string output_file = _args_.outputFile;
+  std::ostream* out = nullptr;
+  std::unique_ptr<std::ofstream> hfout;
+  if (output_file == "-") {
+    out = &std::cout;
+  } else {
+    if (output_file.empty()) {
+      output_file = FLTags::default_list_filename();
+    }
+    datatools::fetch_path_with_env(output_file);
+    hfout.reset(new std::ofstream(output_file.c_str()));
+    out = hfout.get();
   }
 
-  fltags::fltags(const FLTags::FLTagsArgs & args_)
-    : _args_(args_)
-  {
-     }
-
-  void fltags::run()
-  {
-    if (datatools::logger::is_debug(_args_.logLevel)) {
-      DT_LOG_DEBUG(_args_.logLevel, "FLArgs parameters:");
-      _args_.print(std::cerr);
+  std::vector<std::string> all_urns;
+  std::string urn_db_regex = "(.*)";
+  std::string urn_regex = "(.*)";
+  std::string category_regex = "(.*)";
+  if (dtkUrnQuery.find_urn_info(all_urns, urn_db_regex, urn_regex, category_regex, true)) {
+    if (_args_.list_with_tree) {
+      *out << "List of registered tags in Falaise " << falaise::version::get_version() << " : "
+           << std::endl;
     }
-    if (_args_.action == "list") {
-      _run_print_list_();
-    }
-    if (_args_.action == "graph") {
-      _run_generate_graph_();
-    }
-     }
-
-  void fltags::_run_print_list_()
-  {
-    DT_LOG_DEBUG(_args_.logLevel,"Building the list of registered tags...");
-    datatools::kernel & dtk = datatools::kernel::instance();
-    datatools::urn_query_service & dtkUrnQuery = dtk.grab_urn_query();
-
-    std::string output_file = _args_.outputFile;
-    std::ostream * out = nullptr;
-    std::unique_ptr<std::ofstream> hfout;
-    if (output_file == "-") {
-      out = &std::cout;
-    } else {
-      if (output_file.empty()) {
-        output_file = FLTags::default_list_filename();
-      }
-      datatools::fetch_path_with_env(output_file);
-      hfout.reset(new std::ofstream(output_file.c_str()));
-      out = hfout.get();
-    }
-
-    std::vector<std::string> all_urns;
-    std::string urn_db_regex = "(.*)";
-    std::string urn_regex = "(.*)";
-    std::string category_regex = "(.*)";
-    if (dtkUrnQuery.find_urn_info(all_urns, urn_db_regex, urn_regex, category_regex, true)) {
+    for (std::size_t i = 0; i < all_urns.size(); i++) {
+      const std::string& urn = all_urns[i];
+      const datatools::urn_info& urnInfo = dtkUrnQuery.get_urn_info(urn);
       if (_args_.list_with_tree) {
-        *out << "List of registered tags in Falaise " << falaise::version::get_version() << " : " << std::endl;
-      }
-      for (std::size_t i = 0; i < all_urns.size(); i++) {
-        const std::string & urn = all_urns[i];
-        datatools::urn_info urnInfo = dtkUrnQuery.get_urn_info(urn);
-        if (_args_.list_with_tree) {
-          std::ostringstream indentss;
-          if ((i+1) == all_urns.size()) {
-            *out << datatools::i_tree_dumpable::last_tag;
-            indentss << datatools::i_tree_dumpable::last_skip_tag;
-          } else {
-            *out << datatools::i_tree_dumpable::tag;
-            indentss << datatools::i_tree_dumpable::skip_tag;
-          }
-          *out << "Tag : " << std::endl;
-          urnInfo.tree_dump(*out, "", indentss.str());
+        std::ostringstream indentss;
+        if ((i + 1) == all_urns.size()) {
+          *out << datatools::i_tree_dumpable::last_tag;
+          indentss << datatools::i_tree_dumpable::last_skip_tag;
         } else {
-          *out << urn
-               << ";" << urnInfo.get_category()
-               << ";" << urnInfo.get_description()
-               << std::endl;
+          *out << datatools::i_tree_dumpable::tag;
+          indentss << datatools::i_tree_dumpable::skip_tag;
         }
+        *out << "Tag : " << std::endl;
+        urnInfo.tree_dump(*out, "", indentss.str());
+      } else {
+        *out << urn << ";" << urnInfo.get_category() << ";" << urnInfo.get_description()
+             << std::endl;
       }
     }
+  }
 
-    out = nullptr;
-    hfout.reset();
- }
+  out = nullptr;
+  hfout.reset();
+}
 
-  void fltags::_run_generate_graph_()
-  {
-    DT_LOG_DEBUG(_args_.logLevel,"Building the dependency graph of registered tags...");
-    datatools::kernel & dtk = datatools::kernel::instance();
-    datatools::urn_query_service & dtkUrnQuery = dtk.grab_urn_query();
-    const datatools::dependency_graph & dg = dtkUrnQuery.get_dependency_graph();
-    std::string output_file = _args_.outputFile;
-    std::ostream * out = nullptr;
-    std::unique_ptr<std::ofstream> hfout;
-    if (output_file == "-") {
-      out = &std::cout;
-    } else {
-      if (output_file.empty()) {
-        output_file = FLTags::default_dot_filename();
-      }
-      datatools::fetch_path_with_env(output_file);
-      hfout.reset(new std::ofstream(output_file.c_str()));
-      out = hfout.get();
+void fltags::_run_generate_graph_() {
+  DT_LOG_DEBUG(_args_.logLevel, "Building the dependency graph of registered tags...");
+  datatools::kernel& dtk = datatools::kernel::instance();
+  datatools::urn_query_service& dtkUrnQuery = dtk.grab_urn_query();
+  const datatools::dependency_graph& dg = dtkUrnQuery.get_dependency_graph();
+  std::string output_file = _args_.outputFile;
+  std::ostream* out = nullptr;
+  std::unique_ptr<std::ofstream> hfout;
+  if (output_file == "-") {
+    out = &std::cout;
+  } else {
+    if (output_file.empty()) {
+      output_file = FLTags::default_dot_filename();
     }
-    uint32_t xgv_options = 0;
-    if (_args_.dot_with_vertex_index) {
-      xgv_options |= datatools::dependency_graph::XGV_WITH_VERTEX_INDEX;
-    }
-    if (!_args_.dot_without_vertex_category) {
-      xgv_options |= datatools::dependency_graph::XGV_WITH_VERTEX_CATEGORY;
-    }
-    if (!_args_.dot_without_edge_topic) {
-      xgv_options |= datatools::dependency_graph::XGV_WITH_EDGE_TOPIC;
-    }
-    dg.export_graphviz(*out, xgv_options);
+    datatools::fetch_path_with_env(output_file);
+    hfout.reset(new std::ofstream(output_file.c_str()));
+    out = hfout.get();
+  }
+  uint32_t xgv_options = 0;
+  if (_args_.dot_with_vertex_index) {
+    xgv_options |= datatools::dependency_graph::XGV_WITH_VERTEX_INDEX;
+  }
+  if (!_args_.dot_without_vertex_category) {
+    xgv_options |= datatools::dependency_graph::XGV_WITH_VERTEX_CATEGORY;
+  }
+  if (!_args_.dot_without_edge_topic) {
+    xgv_options |= datatools::dependency_graph::XGV_WITH_EDGE_TOPIC;
+  }
+  dg.export_graphviz(*out, xgv_options);
 
-    out = nullptr;
-    hfout.reset();
+  out = nullptr;
+  hfout.reset();
 
-    if (output_file != "-") {
-      std::clog << std::endl;
-      std::clog << "***********************************************" << std::endl;
-      std::clog << "The DOT file '" << output_file << "' has been generated. " << std::endl;
-      std::clog << "Please use a graphviz-like tool to render the graph." << std::endl;
-      std::clog << "Examples: " << std::endl;
-      std::clog << std::endl;
-      std::clog << " 1) Using xdot :" << std::endl;
-      std::clog << std::endl;
-      std::clog << "    $ xdot " << output_file << " &" << std::endl;
-      std::clog << std::endl;
-      std::clog << " 2) Using Python graphviz module :" << std::endl;
-      std::clog << std::endl;
-      std::clog << "    $ python " << std::endl;
-      std::clog << "    >>> import pygraphviz as pgv " << std::endl;
-      std::clog << "    >>> B=pgv.AGraph('" << output_file << "')" << std::endl;
-      std::clog << "    >>> B.layout('dot')" << std::endl;
-      std::clog << "    >>> B.draw('fltags.png')" << std::endl;
-      std::clog << "    >>> ^D" << std::endl;
-      std::clog << "    $ xdg-open fltags.png & " << std::endl;
-      std::clog << std::endl;
-      std::clog << "***********************************************" << std::endl;
-      std::clog << std::endl;
-    }
-     }
+  if (output_file != "-") {
+    std::clog << std::endl;
+    std::clog << "***********************************************" << std::endl;
+    std::clog << "The DOT file '" << output_file << "' has been generated. " << std::endl;
+    std::clog << "Please use a graphviz-like tool to render the graph." << std::endl;
+    std::clog << "Examples: " << std::endl;
+    std::clog << std::endl;
+    std::clog << " 1) Using xdot :" << std::endl;
+    std::clog << std::endl;
+    std::clog << "    $ xdot " << output_file << " &" << std::endl;
+    std::clog << std::endl;
+    std::clog << " 2) Using Python graphviz module :" << std::endl;
+    std::clog << std::endl;
+    std::clog << "    $ python " << std::endl;
+    std::clog << "    >>> import pygraphviz as pgv " << std::endl;
+    std::clog << "    >>> B=pgv.AGraph('" << output_file << "')" << std::endl;
+    std::clog << "    >>> B.layout('dot')" << std::endl;
+    std::clog << "    >>> B.draw('fltags.png')" << std::endl;
+    std::clog << "    >>> ^D" << std::endl;
+    std::clog << "    $ xdg-open fltags.png & " << std::endl;
+    std::clog << std::endl;
+    std::clog << "***********************************************" << std::endl;
+    std::clog << std::endl;
+  }
+}
 
 }  // namespace FLTags

--- a/source/fltags/FLTags.cc
+++ b/source/fltags/FLTags.cc
@@ -32,8 +32,7 @@ namespace FLTags {
   fltags::fltags(const FLTags::FLTagsArgs & args_)
     : _args_(args_)
   {
-    return;
-  }
+     }
 
   void fltags::run()
   {
@@ -47,8 +46,7 @@ namespace FLTags {
     if (_args_.action == "graph") {
       _run_generate_graph_();
     }
-    return;
-  }
+     }
 
   void fltags::_run_print_list_()
   {
@@ -103,8 +101,7 @@ namespace FLTags {
 
     out = nullptr;
     hfout.reset();
-    return;
-  }
+ }
 
   void fltags::_run_generate_graph_()
   {
@@ -164,7 +161,6 @@ namespace FLTags {
       std::clog << "***********************************************" << std::endl;
       std::clog << std::endl;
     }
-    return;
-  }
+     }
 
 }  // namespace FLTags

--- a/source/fltags/FLTagsArgs.cc
+++ b/source/fltags/FLTagsArgs.cc
@@ -20,7 +20,7 @@
 
 namespace FLTags {
 
-void do_postprocess(FLTagsArgs& flTagParameters);
+void do_postprocess(FLTagsArgs& flTagsParameters);
 
 // static
 FLTagsArgs FLTagsArgs::makeDefault() {
@@ -65,7 +65,6 @@ void do_configure(int argc, char* argv[], FLTagsArgs& flTagsParameters) {
   flTagsParameters.outputFile = args.outputFile;
 
   do_postprocess(flTagsParameters);
-  return;
 }
 
 void do_postprocess(FLTagsArgs& flTagsParameters) {
@@ -97,8 +96,7 @@ void do_postprocess(FLTagsArgs& flTagsParameters) {
   }
 
   DT_LOG_TRACE_EXITING(flTagsParameters.logLevel);
-  return;
-}
+  }
 
 void FLTagsArgs::print(std::ostream& out_) const {
   static const std::string tag("|-- ");
@@ -120,7 +118,6 @@ void FLTagsArgs::print(std::ostream& out_) const {
          << std::endl;
   }
   out_ << last_tag << "outputFile                  = '" << outputFile << "'" << std::endl;
-  return;
 }
 
 }  // namespace FLTags

--- a/source/fltags/FLTagsArgs.h
+++ b/source/fltags/FLTagsArgs.h
@@ -22,31 +22,30 @@
 
 namespace FLTags {
 
-  //! Collect all needed configuration parameters in one data structure
-  struct FLTagsArgs
-  {
-    // Application specific parameters:
-    datatools::logger::priority logLevel = datatools::logger::PRIO_FATAL; //!< Logging priority threshold
-    std::string action               = "";
-    bool list_with_tree              = false;
-    bool dot_with_vertex_index       = false;
-    bool dot_without_vertex_category = false;
-    bool dot_without_edge_topic      = false;
-    bool dot_without_checks          = false;
-    std::string outputFile; //!< Path for the output file
+//! Collect all needed configuration parameters in one data structure
+struct FLTagsArgs {
+  // Application specific parameters:
+  datatools::logger::priority logLevel =
+      datatools::logger::PRIO_FATAL;  //!< Logging priority threshold
+  std::string action = "";
+  bool list_with_tree = false;
+  bool dot_with_vertex_index = false;
+  bool dot_without_vertex_category = false;
+  bool dot_without_edge_topic = false;
+  bool dot_without_checks = false;
+  std::string outputFile;  //!< Path for the output file
 
-    //! Construct and return the default configuration object
-    // Equally, could be supplied in a .application file, though note
-    // how some parameters are derived (i.e. there's a postprocessing step)
-    static FLTagsArgs makeDefault();
+  //! Construct and return the default configuration object
+  // Equally, could be supplied in a .application file, though note
+  // how some parameters are derived (i.e. there's a postprocessing step)
+  static FLTagsArgs makeDefault();
 
-    // Print:
-    void print(std::ostream &) const;
+  // Print:
+  void print(std::ostream &) const;
+};
 
-  };
-
-  //! Parse command line arguments to configure the simulation parameters
-  void do_configure(int argc, char *argv[], FLTagsArgs &params);
+//! Parse command line arguments to configure the simulation parameters
+void do_configure(int argc, char *argv[], FLTagsArgs &flTagsParameters);
 
 }  // namespace FLTags
 

--- a/source/fltags/FLTagsCommandLine.cc
+++ b/source/fltags/FLTagsCommandLine.cc
@@ -16,115 +16,89 @@
 
 namespace FLTags {
 
-  namespace bpo = boost::program_options;
+namespace bpo = boost::program_options;
 
-  // static
-  FLTagsCommandLine FLTagsCommandLine::makeDefault()
-  {
-    FLTagsCommandLine flClarg;
-    flClarg.logLevel = datatools::logger::PRIO_FATAL;
-    flClarg.action = "";
-    flClarg.list_with_tree = false;
-    flClarg.dot_with_vertex_index = false;
-    flClarg.dot_without_vertex_category = false;
-    flClarg.dot_without_edge_topic = false;
-    flClarg.dot_without_checks = false;
-    flClarg.outputFile = "";
-    return flClarg;
+// static
+FLTagsCommandLine FLTagsCommandLine::makeDefault() {
+  FLTagsCommandLine flClarg;
+  flClarg.logLevel = datatools::logger::PRIO_FATAL;
+  flClarg.action = "";
+  flClarg.list_with_tree = false;
+  flClarg.dot_with_vertex_index = false;
+  flClarg.dot_without_vertex_category = false;
+  flClarg.dot_without_edge_topic = false;
+  flClarg.dot_without_checks = false;
+  flClarg.outputFile = "";
+  return flClarg;
+}
+
+void do_version(std::ostream& os, bool isVerbose) {
+  os << "fltags " << falaise::version::get_version() << "\n";
+  if (isVerbose) {
+    os << "\n"
+       << "Copyright (C) 2018 SuperNEMO Collaboration\n\n"
+       << "fltags uses the following external libraries:\n"
+       << "* Falaise : " << falaise::version::get_version() << "\n"
+       << "* Bayeux  : " << bayeux::version::get_version() << "\n"
+       << "* Boost   : " << BOOST_VERSION << "\n"
+       << "\n\n";
   }
+}
 
-  void do_version(std::ostream & os, bool isVerbose)
-  {
-    os << "fltags " << falaise::version::get_version() << "\n";
-    if (isVerbose) {
-      os << "\n"
-         << "Copyright (C) 2018 SuperNEMO Collaboration\n\n"
-         << "fltags uses the following external libraries:\n"
-         << "* Falaise : " << falaise::version::get_version() << "\n"
-         << "* Bayeux  : " << bayeux::version::get_version() << "\n"
-         << "* Boost   : " << BOOST_VERSION << "\n"
-         << "\n\n";
-    }
-    return;
-  }
+void do_help(const bpo::options_description& od) {
+  std::cout << "fltags (" << falaise::version::get_version() << ") : SuperNEMO tag viewer\n";
+  std::cout << "Usage:\n"
+            << "  fltags [options]\n"
+            << od << "\n";
+}
 
-  void do_help(const bpo::options_description & od)
-  {
-    std::cout << "fltags (" << falaise::version::get_version()
-              << ") : SuperNEMO tag viewer\n";
-    std::cout << "Usage:\n"
-              << "  fltags [options]\n"
-              << od << "\n";
-    return;
-  }
+void do_cldialog(int argc, char* argv[], FLTagsCommandLine& clArgs) {
+  // - Default Command Line
+  clArgs = FLTagsCommandLine::makeDefault();
 
-  void do_cldialog(int argc, char * argv[], FLTagsCommandLine & clArgs)
-  {
-    // - Default Command Line
-    clArgs = FLTagsCommandLine::makeDefault();
-
-    // Bind command line parser to exposed parameters
-    std::string verbosityLabel;
-    // Application specific options:
-    bpo::options_description optDesc("Options");
+  // Bind command line parser to exposed parameters
+  std::string verbosityLabel;
+  // Application specific options:
+  bpo::options_description optDesc("Options");
+  // clang-format off
     optDesc.add_options()
       ("help,h", "print this help message")
 
       ("version", "print version number")
 
-      ("verbosity,V",
-       bpo::value<std::string>(&verbosityLabel)
-       ->value_name("level"),
-       "set the verbosity level\n"
-       "Example: \n"
-       "  -V \"debug\" ")
+      ("verbosity,V", bpo::value<std::string>(&verbosityLabel)->value_name("level"),
+        "set the verbosity level\n"
+        "Example: \n"
+        "  -V \"debug\" ")
 
       ("list", "print the list of registered tags (default format: CSV)")
 
-      ("list-with-tree,t",
-       bpo::value<bool>(&clArgs.list_with_tree)
-       ->zero_tokens()
-       ->default_value(false),
-       "flag to print the list of registered tags with a tree layout (list only)")
+      ("list-with-tree,t", bpo::value<bool>(&clArgs.list_with_tree)->zero_tokens()->default_value(false),
+        "flag to print the list of registered tags with a tree layout (list only)")
 
       ("graph", "generate a DOT graph of registered tags")
 
-      ("dot-without-vertex-category,C",
-       bpo::value<bool>(&clArgs.dot_without_vertex_category)
-       ->zero_tokens()
-       ->default_value(false),
-       "flag to inhibit the printing of the category of each URN vertex (DOT graph only)")
+      ("dot-without-vertex-category,C", bpo::value<bool>(&clArgs.dot_without_vertex_category)->zero_tokens()->default_value(false),
+        "flag to inhibit the printing of the category of each URN vertex (DOT graph only)")
 
-      ("dot-without-edge-topic,T",
-       bpo::value<bool>(&clArgs.dot_without_edge_topic)
-       ->zero_tokens()
-       ->default_value(false),
-       "flag to inhibit the printing of the topic of each URN edge (DOT graph only)")
+      ("dot-without-edge-topic,T", bpo::value<bool>(&clArgs.dot_without_edge_topic)->zero_tokens()->default_value(false),
+        "flag to inhibit the printing of the topic of each URN edge (DOT graph only)")
 
-      ("dot-without-checks,K",
-       bpo::value<bool>(&clArgs.dot_without_checks)
-       ->zero_tokens()
-       ->default_value(false),
-       "flag to skip some checks on DOT output (DOT graph only)")
+      ("dot-without-checks,K", bpo::value<bool>(&clArgs.dot_without_checks)->zero_tokens()->default_value(false),
+        "flag to skip some checks on DOT output (DOT graph only)")
 
-      ("dot-with-vertex-index,i",
-       bpo::value<bool>(&clArgs.dot_with_vertex_index)
-       ->zero_tokens()
-       ->default_value(false),
-       "flag to print the index of each URN vertex index (DOT graph only, expert mode)")
+      ("dot-with-vertex-index,i", bpo::value<bool>(&clArgs.dot_with_vertex_index)->zero_tokens()->default_value(false),
+        "flag to print the index of each URN vertex index (DOT graph only, expert mode)")
 
-      ("output-file,o",
-       bpo::value<std::string>(&clArgs.outputFile)
-       // ->required()
-       ->value_name("file"),
-       //->default_value(FLTags::default_dot_filename()),
+      ("output-file,o", bpo::value<std::string>(&clArgs.outputFile)->value_name("file"),
         "file in which to export the graph in DOT format or print the list of registered tags\n"
-       "Examples:\n"
-       "  --graph -o \"fltags.dot\" \n"
-       "  --list -o \"fltags.lis\" \n"
-      "To print on the standard output:\n"
-       "  -o \"-\" ")
+        "Examples:\n"
+        "  --graph -o \"fltags.dot\" \n"
+        "  --list -o \"fltags.lis\" \n"
+        "To print on the standard output:\n"
+        "  -o \"-\" ")
      ;
+     // clang-format off
 
     // - Parse...
     bpo::variables_map vMap;
@@ -133,7 +107,7 @@ namespace FLTags {
       bpo::notify(vMap);
     } catch (const bpo::required_option& e) {
       // We need to handle help/version even if required_option thrown
-      if (!vMap.count("help") && !vMap.count("version")) {
+      if ((vMap.count("help") == 0u) && (vMap.count("version") == 0u)) {
         std::cerr << "[OptionsException] " << e.what() << std::endl;
         throw FLDialogOptionsError();
       }
@@ -143,32 +117,31 @@ namespace FLTags {
     }
 
     // Handle any non-bound options
-    if (vMap.count("help")) {
+    if (vMap.count("help") != 0u) {
       do_help(optDesc);
       throw FLDialogHelpRequested();
     }
 
-    if (vMap.count("version")) {
+    if (vMap.count("version") != 0u) {
       do_version(std::cout, true);
       throw FLDialogHelpRequested();
     }
 
-    if (vMap.count("verbosity")) {
+    if (vMap.count("verbosity") != 0u) {
       clArgs.logLevel = datatools::logger::get_priority(verbosityLabel);
       if (clArgs.logLevel == datatools::logger::PRIO_UNDEFINED) {
         throw FLDialogOptionsError();
       }
     }
 
-    if (vMap.count("list")) {
+    if (vMap.count("list") != 0u) {
       clArgs.action = "list";
     }
 
-    if (vMap.count("graph")) {
+    if (vMap.count("graph") != 0u) {
       clArgs.action = "graph";
     }
 
-    return;
-  }
+     }
 
 }  // namespace FLTags


### PR DESCRIPTION
Following usefulness in modernising the modules apply clang-tidy fixes for

- readability
- modernise
- performance

to libFalaise and the three applications. Also update formatting where needed, and remove extraneous logging and comments.