### PR TITLE
Correct unit conversions in property_set

### DIFF
--- a/source/falaise/config/property_set.h
+++ b/source/falaise/config/property_set.h
@@ -523,14 +523,14 @@ inline void property_set::put_impl_(std::string const& key, falaise::config::pat
 template <>
 inline void property_set::put_impl_(std::string const& key,
                                     falaise::config::quantity const& value) {
-  ps_.store_with_explicit_unit(key, value.value());
+  ps_.store_with_explicit_unit(key, value());
   ps_.set_unit_symbol(key, value.unit());
 }
 
 //! Private overload of put_impl_ for @ref quantity_t
 template <typename T>
 void property_set::put_impl_(std::string const& key, falaise::config::quantity_t<T> const& value) {
-  ps_.store_with_explicit_unit(key, value.value());
+  ps_.store_with_explicit_unit(key, value());
   ps_.set_unit_symbol(key, value.unit());
 }
 
@@ -550,13 +550,21 @@ inline void property_set::get_impl_(std::string const& key, falaise::config::pat
 template <>
 inline void property_set::get_impl_(std::string const& key,
                                     falaise::config::quantity& result) const {
-  result = {ps_.fetch_real_with_explicit_unit(key), ps_.get_unit_symbol(key)};
+  // Fetch with explicit unit gives value in CLHEP scale, so must
+  // divide by the scaling factor for the symbol
+  double rescaledValue =
+      ps_.fetch_real_with_explicit_unit(key) / datatools::units::get_unit(ps_.get_unit_symbol(key));
+  result = {rescaledValue, ps_.get_unit_symbol(key)};
 }
 
 // Overload for explicitly dimensioned quantities
 template <typename T>
 void property_set::get_impl_(std::string const& key, falaise::config::quantity_t<T>& result) const {
-  result = {ps_.fetch_real_with_explicit_unit(key), ps_.get_unit_symbol(key)};
+  // fetch with explicit unit gives value in CLHEP scale, so must
+  // divide it by the scaling factor for the symbol
+  double rescaledValue =
+      ps_.fetch_real_with_explicit_unit(key) / datatools::units::get_unit(ps_.get_unit_symbol(key));
+  result = {rescaledValue, ps_.get_unit_symbol(key)};
 }
 
 //! Construct a property_set from an input datatools::properties file

--- a/source/falaise/config/quantity.h
+++ b/source/falaise/config/quantity.h
@@ -97,7 +97,7 @@ class quantity {
 
   //! Construct a quantity from a value and unit
   /*!
-   * \param[in] value Numeric value
+   * \param[in] value Numeric value in units of unit
    * \param[in] unit @ref datatools::units::unit tag
    * \throws falaise::config::unknown_unit_error if unit is not supported by @ref datatools::units
    */

--- a/source/falaise/test/test_property_set.cxx
+++ b/source/falaise/test/test_property_set.cxx
@@ -23,8 +23,8 @@ datatools::properties makeTableLikeProperties() {
 
   test.store("myprop", "a property");
 
-  test.store("myseq_i", std::vector<int>{1,2,3,4});
-  test.store("myseq_d", std::vector<double>{1.,2.,3.,4.});
+  test.store("myseq_i", std::vector<int>{1, 2, 3, 4});
+  test.store("myseq_d", std::vector<double>{1., 2., 3., 4.});
   test.store("myseq_s", std::vector<std::string>{"hello", "world"});
 
   test.store("mix_table", 1);
@@ -42,22 +42,21 @@ datatools::properties makeTableLikeProperties() {
   return test;
 }
 
-
 TEST_CASE("property_set default construction works", "") {
   falaise::config::property_set ps;
-  REQUIRE( ps.is_empty() );
-  REQUIRE( ps.get_names() == std::vector<std::string>{} );
+  REQUIRE(ps.is_empty());
+  REQUIRE(ps.get_names() == std::vector<std::string>{});
 }
 
 TEST_CASE("property_set construction from datatools work", "") {
   falaise::config::property_set ps{makeSampleProperties()};
-  REQUIRE_FALSE( ps.is_empty() );
+  REQUIRE_FALSE(ps.is_empty());
 
   auto names = ps.get_names();
-  REQUIRE( names.size() == 6 );
+  REQUIRE(names.size() == 6);
 
   for (auto& n : names) {
-    REQUIRE( ps.has_key(n) );
+    REQUIRE(ps.has_key(n));
   }
 
   std::cout << ps.to_string() << std::endl;
@@ -66,54 +65,54 @@ TEST_CASE("property_set construction from datatools work", "") {
 TEST_CASE("Observer interfaces work", "") {
   falaise::config::property_set ps{makeTableLikeProperties()};
 
-  REQUIRE( ps.get_names().size() == 13 );
+  REQUIRE(ps.get_names().size() == 13);
 
   SECTION("properties are correctly identified") {
-    REQUIRE( ps.has_key("myprop") );
-    REQUIRE( ps.is_key_to_property("myprop") );
-    REQUIRE_FALSE( ps.is_key_to_property("notpresent") );
-    REQUIRE_FALSE( ps.is_key_to_sequence("myprop") );
+    REQUIRE(ps.has_key("myprop"));
+    REQUIRE(ps.is_key_to_property("myprop"));
+    REQUIRE_FALSE(ps.is_key_to_property("notpresent"));
+    REQUIRE_FALSE(ps.is_key_to_sequence("myprop"));
   }
 
   SECTION("sequences are correctly identified") {
-    REQUIRE( ps.has_key("myseq_i") );
-    REQUIRE( ps.is_key_to_sequence("myseq_i") );
-    REQUIRE_FALSE( ps.is_key_to_sequence("notpresent") );
-    REQUIRE_FALSE( ps.is_key_to_property("myseq_i") );
+    REQUIRE(ps.has_key("myseq_i"));
+    REQUIRE(ps.is_key_to_sequence("myseq_i"));
+    REQUIRE_FALSE(ps.is_key_to_sequence("notpresent"));
+    REQUIRE_FALSE(ps.is_key_to_property("myseq_i"));
   }
 
   SECTION("mixed property/table keys are identified") {
-    REQUIRE( ps.has_key("mix_table") );
-    REQUIRE( ps.is_key_to_property("mix_table") );
-    REQUIRE_FALSE( ps.is_key_to_property_set("mix_table") );
-    REQUIRE_FALSE( ps.is_key_to_sequence("mix_table") );
+    REQUIRE(ps.has_key("mix_table"));
+    REQUIRE(ps.is_key_to_property("mix_table"));
+    REQUIRE_FALSE(ps.is_key_to_property_set("mix_table"));
+    REQUIRE_FALSE(ps.is_key_to_sequence("mix_table"));
   }
 
   SECTION("pure tables are correctly identified") {
-    REQUIRE_FALSE( ps.has_key("pure_table") );
-    REQUIRE( ps.is_key_to_property_set("pure_table") );
-    REQUIRE_FALSE( ps.is_key_to_property_set("notpresent") );
-    REQUIRE_FALSE( ps.is_key_to_property("pure_table") );
-    REQUIRE_FALSE( ps.is_key_to_sequence("pure_table") );
+    REQUIRE_FALSE(ps.has_key("pure_table"));
+    REQUIRE(ps.is_key_to_property_set("pure_table"));
+    REQUIRE_FALSE(ps.is_key_to_property_set("notpresent"));
+    REQUIRE_FALSE(ps.is_key_to_property("pure_table"));
+    REQUIRE_FALSE(ps.is_key_to_sequence("pure_table"));
 
-    REQUIRE( ps.has_key("pure_table.x") );
-    REQUIRE( ps.has_key("pure_table.sub_table.y") );
+    REQUIRE(ps.has_key("pure_table.x"));
+    REQUIRE(ps.has_key("pure_table.sub_table.y"));
   }
 }
 
 TEST_CASE("Retriever interfaces work", "") {
   falaise::config::property_set ps{makeSampleProperties()};
 
-  REQUIRE( ps.get<int>("foo") == 1 );
-  REQUIRE_THROWS( ps.get<double>("foo") );
+  REQUIRE(ps.get<int>("foo") == 1);
+  REQUIRE_THROWS(ps.get<double>("foo"));
 
-  REQUIRE( ps.get<int>("foo", 42) == 1 );
-  REQUIRE( ps.get<int>("off", 42) == 42 );
+  REQUIRE(ps.get<int>("foo", 42) == 1);
+  REQUIRE(ps.get<int>("off", 42) == 42);
 
-  REQUIRE( ps.get<double>("table.x") == Approx(4.13) );
+  REQUIRE(ps.get<double>("table.x") == Approx(4.13));
 
-  REQUIRE_THROWS_AS( ps.get<falaise::config::path>("flatstring"), falaise::config::wrong_type_error );
-  REQUIRE_NOTHROW( ps.get<falaise::config::path>("apath") );
+  REQUIRE_THROWS_AS(ps.get<falaise::config::path>("flatstring"), falaise::config::wrong_type_error);
+  REQUIRE_NOTHROW(ps.get<falaise::config::path>("apath"));
 }
 
 TEST_CASE("Insertion/Erase interfaces work", "") {
@@ -121,31 +120,31 @@ TEST_CASE("Insertion/Erase interfaces work", "") {
   ps.put("foo", 1);
 
   SECTION("putting the same key throws existing_key_error") {
-    REQUIRE_THROWS_AS( ps.put("foo", 1), falaise::config::existing_key_error );
+    REQUIRE_THROWS_AS(ps.put("foo", 1), falaise::config::existing_key_error);
   }
 
   SECTION("replacing an existing key/value works") {
-    REQUIRE_NOTHROW( ps.put_or_replace("foo", 2) );
-    REQUIRE( ps.get<int>("foo") == 2 );
+    REQUIRE_NOTHROW(ps.put_or_replace("foo", 2));
+    REQUIRE(ps.get<int>("foo") == 2);
 
-    REQUIRE_NOTHROW( ps.put_or_replace("foo", std::string{"foo"}) );
-    REQUIRE( ps.get<std::string>("foo") == "foo" );
+    REQUIRE_NOTHROW(ps.put_or_replace("foo", std::string{"foo"}));
+    REQUIRE(ps.get<std::string>("foo") == "foo");
   }
 
   SECTION("putting/retriving explicit scalar/vector types works") {
     ps.put("ascalar", 1234);
     ps.put("avector", std::vector<int>{1, 2, 3, 4});
 
-    REQUIRE_THROWS_AS( ps.get<std::vector<int>>("ascalar"), falaise::config::wrong_type_error );
-    REQUIRE_THROWS_AS( ps.get<int>("avector"), falaise::config::wrong_type_error );
+    REQUIRE_THROWS_AS(ps.get<std::vector<int>>("ascalar"), falaise::config::wrong_type_error);
+    REQUIRE_THROWS_AS(ps.get<int>("avector"), falaise::config::wrong_type_error);
   }
 
   SECTION("putting values as subkeys works") {
     ps.put("table.x", 42);
     ps.put("table.y", 24);
 
-    REQUIRE( ps.get<int>("table.x") == 42 );
-    REQUIRE( ps.get<int>("table.y") == 24 );
+    REQUIRE(ps.get<int>("table.x") == 42);
+    REQUIRE(ps.get<int>("table.y") == 24);
   }
 }
 
@@ -159,16 +158,16 @@ TEST_CASE("Path type put/get specialization works", "") {
     ps.put("my_relpath", relpth);
     ps.put("my_abspath", abspth);
 
-    REQUIRE( ps.get<falaise::config::path>("my_relpath") == relpth );
-    REQUIRE_THROWS_AS( ps.get<std::string>("my_relpath"), falaise::config::wrong_type_error );
+    REQUIRE(ps.get<falaise::config::path>("my_relpath") == relpth);
+    REQUIRE_THROWS_AS(ps.get<std::string>("my_relpath"), falaise::config::wrong_type_error);
 
-    REQUIRE( ps.get<falaise::config::path>("my_abspath") == abspth );
-    REQUIRE_THROWS_AS( ps.get<std::string>("my_abspath"), falaise::config::wrong_type_error );
+    REQUIRE(ps.get<falaise::config::path>("my_abspath") == abspth);
+    REQUIRE_THROWS_AS(ps.get<std::string>("my_abspath"), falaise::config::wrong_type_error);
   }
 
   SECTION("env vars are expanded on get") {
     ps.put("home", falaise::config::path{"$HOME"});
-    REQUIRE( ps.get<falaise::config::path>("home") == getenv("HOME") );
+    REQUIRE(ps.get<falaise::config::path>("home") == getenv("HOME"));
   }
 }
 
@@ -178,79 +177,86 @@ TEST_CASE("Quantity type put/get specialization works", "") {
   ps.put("quantity", falaise::config::quantity{4.13, "m"});
   ps.put("amass", falaise::config::mass_t{4.13, "kg"});
 
-  REQUIRE_THROWS_AS( ps.get<falaise::config::quantity>("number"), falaise::config::wrong_type_error );
-  REQUIRE_THROWS_AS( ps.get<double>("quantity"), falaise::config::wrong_type_error );
+  REQUIRE_THROWS_AS(ps.get<falaise::config::quantity>("number"), falaise::config::wrong_type_error);
+  REQUIRE_THROWS_AS(ps.get<double>("quantity"), falaise::config::wrong_type_error);
 
-  REQUIRE( ps.get<falaise::config::quantity>("quantity").value() == Approx(4.13) );
-  REQUIRE( ps.get<falaise::config::quantity>("quantity").unit() == "m" );
+  REQUIRE(ps.get<falaise::config::quantity>("quantity").value() == Approx(4.13));
+  REQUIRE(ps.get<falaise::config::quantity>("quantity").unit() == "m");
 
   falaise::config::length_t q;
-  REQUIRE_NOTHROW( q = ps.get<falaise::config::length_t>("quantity") );
-  REQUIRE( q.value() == Approx(4.13) );
-  REQUIRE( q.unit() == "m" );
-  REQUIRE( q.dimension() == "length" );
-  REQUIRE( q() == Approx(4.13 * CLHEP::m) );
+  SECTION("Check valid extraction") {
+    REQUIRE_NOTHROW(q = ps.get<falaise::config::length_t>("quantity"));
+    REQUIRE(q.value() == Approx(4.13));
+    REQUIRE(q.unit() == "m");
+    REQUIRE(q.dimension() == "length"); 
+    REQUIRE(q() == Approx(4.13 * CLHEP::m));
+  }
+
+  SECTION("Check mismatched quantities throws") {
+    REQUIRE_THROWS_AS(q = ps.get<falaise::config::length_t>("amass"), falaise::config::wrong_dimension_error);
+  }
 }
 
 TEST_CASE("property_set type put/get specialization works", "") {
   falaise::config::property_set ps{makeTableLikeProperties()};
 
   SECTION("can only create table from pure tables") {
-    REQUIRE_THROWS_AS( auto notATable = ps.get<falaise::config::property_set>("myprop"), falaise::config::wrong_type_error );
-    REQUIRE_THROWS_AS( auto badTable = ps.get<falaise::config::property_set>("mix_table"), falaise::config::wrong_type_error );
+    REQUIRE_THROWS_AS(auto notATable = ps.get<falaise::config::property_set>("myprop"),
+                      falaise::config::wrong_type_error);
+    REQUIRE_THROWS_AS(auto badTable = ps.get<falaise::config::property_set>("mix_table"),
+                      falaise::config::wrong_type_error);
   }
 
   SECTION("tables must have correct size") {
     falaise::config::property_set goodTable = ps.get<falaise::config::property_set>("pure_table");
-    REQUIRE( goodTable.get_names().size() == 6 );
-    REQUIRE( ps.has_key("pure_table.x") );
+    REQUIRE(goodTable.get_names().size() == 6);
+    REQUIRE(ps.has_key("pure_table.x"));
   }
 
   SECTION("subtables can be extracted directly") {
     auto subTable = ps.get<falaise::config::property_set>("pure_table.sub_table");
-    REQUIRE( subTable.get_names().size() == 3 );
-    REQUIRE( subTable.get<int>("x") == 111 );
-    REQUIRE( subTable.get<int>("y") == 222 );
-    REQUIRE( subTable.get<int>("z") == 333 );
+    REQUIRE(subTable.get_names().size() == 3);
+    REQUIRE(subTable.get<int>("x") == 111);
+    REQUIRE(subTable.get<int>("y") == 222);
+    REQUIRE(subTable.get<int>("z") == 333);
   }
 
   SECTION("subtables can be extracted indirectly") {
     auto firstTable = ps.get<falaise::config::property_set>("pure_table");
     auto secondTable = firstTable.get<falaise::config::property_set>("sub_table");
-    REQUIRE( secondTable.get_names().size() == 3 );
-    REQUIRE( secondTable.get<int>("x") == 111 );
-    REQUIRE( secondTable.get<int>("y") == 222 );
-    REQUIRE( secondTable.get<int>("z") == 333 );
+    REQUIRE(secondTable.get_names().size() == 3);
+    REQUIRE(secondTable.get<int>("x") == 111);
+    REQUIRE(secondTable.get<int>("y") == 222);
+    REQUIRE(secondTable.get<int>("z") == 333);
   }
 
   SECTION("Can put property_set into another") {
     falaise::config::property_set sub{};
     sub.put("bar", 1);
 
-    REQUIRE_NOTHROW( ps.put("sub",sub) );
-    REQUIRE( ps.is_key_to_property_set("sub") );
-    REQUIRE( ps.has_key("sub.bar") );
-    REQUIRE( ps.is_key_to_property("sub.bar") );
+    REQUIRE_NOTHROW(ps.put("sub", sub));
+    REQUIRE(ps.is_key_to_property_set("sub"));
+    REQUIRE(ps.has_key("sub.bar"));
+    REQUIRE(ps.is_key_to_property("sub.bar"));
 
     falaise::config::property_set newSub{};
     newSub.put("baz", std::string("hello world"));
     newSub.put("bob", 3.14);
-    REQUIRE_NOTHROW( ps.put_or_replace("sub", newSub) );
-    REQUIRE( ps.has_key("sub.baz") );
-    REQUIRE( ps.has_key("sub.bob") );
+    REQUIRE_NOTHROW(ps.put_or_replace("sub", newSub));
+    REQUIRE(ps.has_key("sub.baz"));
+    REQUIRE(ps.has_key("sub.bob"));
 
-    REQUIRE_THROWS_AS( ps.put("pure_table", newSub), falaise::config::existing_key_error );
-    REQUIRE_NOTHROW( ps.put_or_replace("pure_table", newSub) );
+    REQUIRE_THROWS_AS(ps.put("pure_table", newSub), falaise::config::existing_key_error);
+    REQUIRE_NOTHROW(ps.put_or_replace("pure_table", newSub));
 
     auto newPs = ps.get<falaise::config::property_set>("pure_table");
-    REQUIRE_FALSE( newPs.has_key("x") );
-    REQUIRE_FALSE( newPs.is_key_to_property_set("sub_table") );
-    REQUIRE( newPs.has_key("baz") );
-    REQUIRE( newPs.has_key("bob") );
-    REQUIRE( newPs.get<double>("bob") == Approx(3.14) );
+    REQUIRE_FALSE(newPs.has_key("x"));
+    REQUIRE_FALSE(newPs.is_key_to_property_set("sub_table"));
+    REQUIRE(newPs.has_key("baz"));
+    REQUIRE(newPs.has_key("bob"));
+    REQUIRE(newPs.get<double>("bob") == Approx(3.14));
   }
 }
-
 
 TEST_CASE("Creation from file works", "") {
   std::string fname{"kakhjbfdkb.conf"};
@@ -258,19 +264,18 @@ TEST_CASE("Creation from file works", "") {
   datatools::properties::write_config(fname, tmp);
 
   falaise::config::property_set ps;
-  REQUIRE_NOTHROW( make_property_set(fname, ps) );
-  REQUIRE_FALSE( ps.is_empty() );
+  REQUIRE_NOTHROW(make_property_set(fname, ps));
+  REQUIRE_FALSE(ps.is_empty());
 
   auto names = ps.get_names();
-  REQUIRE( names.size() == 6 );
+  REQUIRE(names.size() == 6);
 
   for (auto& n : names) {
-    REQUIRE( ps.has_key(n) );
+    REQUIRE(ps.has_key(n));
   }
 
   remove(fname.c_str());
 }
-
 
 // Use the below as examples of how datatools::properties
 // units work, and how to extract info we may need for property_set
@@ -279,44 +284,81 @@ TEST_CASE("Check datatools::properties interface", "") {
   datatools::properties ps;
   std::string myprops{
       "bar : real as velocity = 3.14 m/s \n"
-      "foo : real as length = 2.0\n"};
+      "alength : real as length = 2.0 cm\n"};
 
   std::istringstream iput{myprops};
   datatools::properties::config reader;
   reader.read(iput, ps);
 
-  ps.store_with_explicit_unit("weight", 1.2 * CLHEP::kg);
-  // Ugh, have to set unit symbol explicitly in code...
-  ps.set_unit_symbol("weight", "g");
-
-  //ps.tree_dump(std::cout);
-  //std::cout << "weight: x" << ps.get_unit_symbol("weight") << "x\n";
+  // ps.tree_dump(std::cout);
+  std::cout << ps.get_unit_symbol("alength") << "x\n";
   double val{0.0};
 
   // Gives the raw value in internal units (CLHEP) system
-  ps.fetch("weight", val);
-  // so must be converted
-  //std::cout << val / CLHEP::g << std::endl;
-
+  ps.fetch("alength", val);
+  std::cout << "raw fetch: " << val << std::endl;
   // This is the same, but checks that value has explicit unit (though
   // as above, this just marks it as dimensioned)
-  val = ps.fetch_real_with_explicit_unit("weight");
-  //std::cout << val << std::endl;
+  val = ps.fetch_real_with_explicit_unit("alength");
+  std::cout << "via explicit unit : " << val << std::endl;
 
   // If we have a unit symbol, then we can get the "label"
   std::string unit_label{};
   double cFactor{0.0};
-  bool hasLabel = datatools::units::find_unit(ps.get_unit_symbol("weight"), cFactor, unit_label);
-  //if (hasLabel) {
-    //std::cout << "weight has label" << unit_label << std::endl;
-  //}
+  bool hasLabel = datatools::units::find_unit(ps.get_unit_symbol("alength"), cFactor, unit_label);
+  if (hasLabel) {
+   std::cout << "length has label: " << unit_label << std::endl;
+  }
 
   // All dimensions known
   std::vector<std::string> dims{};
   size_t N = datatools::units::registered_unit_dimension_labels(dims);
-  //for (auto& d : dims) {
-    //std::cout << d << "\n";
+  // for (auto& d : dims) {
+  // std::cout << d << "\n";
   //}
+
+  // Now in code...
+  ps.store_with_explicit_unit("mylength", 1.2 * CLHEP::cm);
+  ps.set_unit_symbol("mylength", "m");
+
+  ps.fetch("mylength", val);
+  std::cout << "mylength raw fetch: " << val << std::endl;
+  val = ps.fetch_real_with_explicit_unit("mylength");
+  std::cout << "mylength via explicit unit : " << val << std::endl;
+  std::cout << "conversion from: " << datatools::units::get_unit(ps.get_unit_symbol("mylength")) << std::endl;
+  std::cout << "so would be: " << val / datatools::units::get_unit(ps.get_unit_symbol("mylength")) << ps.get_unit_symbol("mylength") << std::endl; 
 }
 
+TEST_CASE("Check units are read correctly", "") {
+  std::string myprops{
+      "aLength : real as length = 3.14 km \n"
+      "anEnergy : real as energy = 50 eV\n"};
 
+  std::istringstream iput{myprops};
+  datatools::properties dps;
+  datatools::properties::config reader;
+  reader.read(iput, dps);
+  falaise::config::property_set ps{dps};
+
+  SECTION("Check Length unit conversion") {
+    double myLength = ps.get<falaise::config::length_t>("aLength")();
+    REQUIRE(myLength == Approx(3.14 * CLHEP::km));
+  }
+
+  SECTION("Check Energy unit conversion") {
+    double myEnergy = ps.get<falaise::config::energy_t>("anEnergy")();
+    REQUIRE(myEnergy == Approx(50 * CLHEP::eV));
+  }
+
+  SECTION("Check output") {
+    falaise::config::property_set ops;
+    ops.put<falaise::config::length_t>("foo", {3.14, "um"});
+    ops.put<falaise::config::energy_t>("bar", {4.13, "GeV"});
+
+    datatools::properties dOPS = ops;
+    REQUIRE(dOPS.fetch_real("foo") == Approx(3.14*CLHEP::um));
+    REQUIRE(dOPS.get_unit_symbol("foo") == "um");
+    REQUIRE(dOPS.fetch_real("bar") == Approx(4.13*CLHEP::GeV));
+    REQUIRE(dOPS.get_unit_symbol("bar") == "GeV");
+  }
+}


### PR DESCRIPTION
Identified through work on modernizing Falaise. Put/Get of dimensioned
quantities used direct value from "fetch_real_with_explicit_dimension"
member function. This returns the value on the CLHEP scale, e.g.

- 1.2 cm returns a value of "1.2*CLHEP::cm" and a unit symbol of "cm"

This resulted in the conversions performing an additional multiplication
by the scaling factor, resulting in incorrect values.

Update put/get implementations for quantities to divide input values
by the correct unit factor, and multiply output values by it. Add
tests to explicitly check these conversions.

Needed by #149, and should also be applied in a patch release of Falaise 4


