### PR TITLE
Modernize SuperNEMO Datamodel

### DIFF
--- a/modules/CAT/CAT/cat_driver.cc
+++ b/modules/CAT/CAT/cat_driver.cc
@@ -257,11 +257,11 @@ int cat_driver::_process_algo(const base_tracker_clusterizer::hit_collection_typ
   size_t ihit = 0;
 
   // Hit accounting :
-  std::map<int, sdm::calibrated_data::tracker_hit_handle_type> hits_mapping;
+  std::map<int, sdm::TrackerHitHdl> hits_mapping;
   std::map<int, int> hits_status;
 
   // GG hit loop :
-  BOOST_FOREACH (const sdm::calibrated_data::tracker_hit_handle_type& gg_handle, gg_hits_) {
+  BOOST_FOREACH (const sdm::TrackerHitHdl& gg_handle, gg_hits_) {
     // Skip NULL handle :
     if (!gg_handle) {
       continue;
@@ -344,7 +344,7 @@ int cat_driver::_process_algo(const base_tracker_clusterizer::hit_collection_typ
   // Take into account calo hits:
   _CAT_input_.calo_cells.clear();
   // Calo hit accounting :
-  std::map<int, sdm::calibrated_data::calorimeter_hit_handle_type> calo_hits_mapping;
+  std::map<int, sdm::CalorimeterHitHdl> calo_hits_mapping;
   if (_process_calo_hits_) {
     if (_CAT_input_.calo_cells.capacity() < calo_hits_.size()) {
       _CAT_input_.calo_cells.reserve(calo_hits_.size());
@@ -353,8 +353,7 @@ int cat_driver::_process_algo(const base_tracker_clusterizer::hit_collection_typ
     size_t jhit = 0;
 
     // CALO hit loop :
-    BOOST_FOREACH (const sdm::calibrated_data::calorimeter_hit_handle_type& calo_handle,
-                   calo_hits_) {
+    BOOST_FOREACH (const sdm::CalorimeterHitHdl& calo_handle, calo_hits_) {
       // Skip NULL handle :
       if (!calo_handle.has_data()) {
         continue;

--- a/modules/CAT/CAT/cat_driver.cc
+++ b/modules/CAT/CAT/cat_driver.cc
@@ -457,12 +457,10 @@ int cat_driver::_process_algo(const base_tracker_clusterizer::hit_collection_typ
       ihs.second = 0;
     }
 
-    sdm::TrackerClusteringSolutionHdl htcs(new sdm::tracker_clustering_solution);
-    clustering_.add_solution(htcs, true);
-    clustering_.get_default_solution().set_solution_id(clustering_.get_number_of_solutions() - 1);
-    sdm::tracker_clustering_solution& clustering_solution = clustering_.get_default_solution();
-    clustering_solution.get_auxiliaries().update_string(
-        sdm::tracker_clustering_data::clusterizer_id_key(), CAT_ID);
+    auto htcs = datatools::make_handle<sdm::TrackerClusteringSolution>();
+    clustering_.push_back(htcs, true);
+    clustering_.get_default().set_solution_id(clustering_.size() - 1);
+    sdm::tracker_clustering_solution& clustering_solution = clustering_.get_default();
 
     // Analyse the sequentiator output :
     const std::vector<CAT::topology::sequence>& the_sequences = iscenario.sequences();
@@ -672,7 +670,7 @@ int cat_driver::_process_algo(const base_tracker_clusterizer::hit_collection_typ
         for (int i = 0; i < (int)seqsz; i++) {
           const CAT::topology::node& a_node = a_sequence.nodes()[i];
           const int hit_id = a_node.c().id();
-          cluster_handle->get_hits().push_back(hits_mapping[hit_id]);
+          cluster_handle->hits().push_back(hits_mapping[hit_id]);
           hits_status[hit_id] = 1;
 
           if (_store_result_as_properties_) {

--- a/modules/CAT/CAT/cat_driver.cc
+++ b/modules/CAT/CAT/cat_driver.cc
@@ -242,8 +242,6 @@ void cat_driver::initialize(const datatools::properties& setup_) {
   _set_initialized(true);
 }
 
-
-
 /// Main clustering method
 int cat_driver::_process_algo(const base_tracker_clusterizer::hit_collection_type& gg_hits_,
                               const base_tracker_clusterizer::calo_hit_collection_type& calo_hits_,
@@ -460,7 +458,7 @@ int cat_driver::_process_algo(const base_tracker_clusterizer::hit_collection_typ
       ihs.second = 0;
     }
 
-    sdm::tracker_clustering_solution::handle_type htcs(new sdm::tracker_clustering_solution);
+    sdm::TrackerClusteringSolutionHdl htcs(new sdm::tracker_clustering_solution);
     clustering_.add_solution(htcs, true);
     clustering_.get_default_solution().set_solution_id(clustering_.get_number_of_solutions() - 1);
     sdm::tracker_clustering_solution& clustering_solution = clustering_.get_default_solution();
@@ -481,11 +479,10 @@ int cat_driver::_process_algo(const base_tracker_clusterizer::hit_collection_typ
         // A CAT cluster with more than one hit/cell(node) :
         {
           // Append a new cluster :
-          sdm::tracker_cluster::handle_type tch(new sdm::tracker_cluster);
+          sdm::TrackerClusterHdl tch(new sdm::tracker_cluster);
           clustering_solution.get_clusters().push_back(tch);
         }
-        sdm::tracker_cluster::handle_type& cluster_handle =
-            clustering_solution.get_clusters().back();
+        sdm::TrackerClusterHdl& cluster_handle = clustering_solution.get_clusters().back();
         cluster_handle->set_cluster_id(clustering_solution.get_clusters().size() - 1);
         if (_store_result_as_properties_) {
           // 2012/06/28 XG : Adding

--- a/modules/CAT/CAT/cat_tracker_clustering_module.cc
+++ b/modules/CAT/CAT/cat_tracker_clustering_module.cc
@@ -153,7 +153,7 @@ void cat_tracker_clustering_module::_process(
     const snemo::datamodel::calibrated_data& calib_data,
     snemo::datamodel::tracker_clustering_data& clustering_data) {
   // Process the clusterizer driver :
-  catAlgo_->process(calib_data.calibrated_tracker_hits(), calib_data.calibrated_calorimeter_hits(),
+  catAlgo_->process(calib_data.tracker_hits(), calib_data.calorimeter_hits(),
                     clustering_data);
 }
 

--- a/modules/CAT/CAT/cat_tracker_clustering_module.cc
+++ b/modules/CAT/CAT/cat_tracker_clustering_module.cc
@@ -106,13 +106,10 @@ void cat_tracker_clustering_module::initialize(const datatools::properties& conf
               "Module '" << get_name() << "' is already initialized ! ");
   dpp::base_module::_common_initialize(config);
 
-  namespace snedm = snemo::datamodel;
-
   falaise::property_set ps{config};
 
-  CDTag_ = ps.get<std::string>("CD_label", snedm::data_info::default_calibrated_data_label());
-  TCDTag_ =
-      ps.get<std::string>("TCD_label", snedm::data_info::default_tracker_clustering_data_label());
+  CDTag_ = ps.get<std::string>("CD_label", snedm::labels::calibrated_data());
+  TCDTag_ = ps.get<std::string>("TCD_label", snedm::labels::tracker_clustering_data());
 
   // Geometry manager :
   if (geoManager_ == nullptr) {
@@ -143,7 +140,7 @@ dpp::base_module::process_status cat_tracker_clustering_module::process(datatool
   const auto& calibratedData = event.get<snedm::calibrated_data>(CDTag_);
 
   // Get or create output data
-  auto& clusteringData = snedm::getOrAddToEvent<snedm::tracker_clustering_data>(TCDTag_, event);
+  auto& clusteringData = ::snedm::getOrAddToEvent<snedm::tracker_clustering_data>(TCDTag_, event);
 
   if (clusteringData.has_solutions()) {
     DT_LOG_WARNING(get_logging_priority(),
@@ -193,7 +190,7 @@ DOCD_CLASS_IMPLEMENT_LOAD_BEGIN(snemo::reconstruction::cat_tracker_clustering_mo
         .set_long_description(
             "This is the name of the bank to be used \n"
             "as the source of input tracker hits.    \n")
-        .set_default_value_string(snemo::datamodel::data_info::default_calibrated_data_label())
+        .set_default_value_string(snedm::labels::calibrated_data())
         .add_example(
             "Use an alternative name for the 'calibrated data' bank:: \n"
             "                                \n"
@@ -211,8 +208,7 @@ DOCD_CLASS_IMPLEMENT_LOAD_BEGIN(snemo::reconstruction::cat_tracker_clustering_mo
         .set_long_description(
             "This is the name of the bank to be used as   \n"
             "the sink of output clusters of tracker hits. \n")
-        .set_default_value_string(
-            snemo::datamodel::data_info::default_tracker_clustering_data_label())
+        .set_default_value_string(snedm::labels::tracker_clustering_data())
         .add_example(
             "Use an alternative name for the 'tracker clustering data' bank:: \n"
             "                                  \n"

--- a/modules/CAT/CAT/cat_tracker_clustering_module.cc
+++ b/modules/CAT/CAT/cat_tracker_clustering_module.cc
@@ -141,12 +141,7 @@ dpp::base_module::process_status cat_tracker_clustering_module::process(datatool
 
   // Get or create output data
   auto& clusteringData = ::snedm::getOrAddToEvent<snedm::tracker_clustering_data>(TCDTag_, event);
-
-  if (clusteringData.has_solutions()) {
-    DT_LOG_WARNING(get_logging_priority(),
-                   "Module " << get_name() << " resetting solutions in bank " << TCDTag_)
-    clusteringData.reset();
-  }
+  clusteringData.clear();
 
   // Main processing method :
   _process(calibratedData, clusteringData);

--- a/modules/CAT/CAT/sultan_driver.cc
+++ b/modules/CAT/CAT/sultan_driver.cc
@@ -269,8 +269,8 @@ void sultan_driver::initialize(const datatools::properties& setup_) {
     _xcalo_locator_ = &(lp.xcaloLocator());
     _gveto_locator_ = &(lp.gvetoLocator());
   }
- 
-   // Geometry description :
+
+  // Geometry description :
   _SULTAN_setup_.num_blocks = 1;
   _SULTAN_setup_.planes_per_block.clear();
   _SULTAN_setup_.planes_per_block.push_back(_SULTAN_setup_.num_blocks);
@@ -304,8 +304,6 @@ void sultan_driver::initialize(const datatools::properties& setup_) {
 
   _set_initialized(true);
 }
-
-
 
 // Main clustering method
 int sultan_driver::_process_algo(
@@ -517,7 +515,7 @@ int sultan_driver::_process_algo(
 
   for (const auto& ts : tss) {
     // Add a new solution :
-    sdm::tracker_clustering_solution::handle_type htcs(new sdm::tracker_clustering_solution);
+    sdm::TrackerClusteringSolutionHdl htcs(new sdm::tracker_clustering_solution);
     clustering_.add_solution(htcs, true);
     clustering_.get_default_solution().set_solution_id(clustering_.get_number_of_solutions() - 1);
     sdm::tracker_clustering_solution& clustering_solution = clustering_.get_default_solution();
@@ -534,9 +532,9 @@ int sultan_driver::_process_algo(
         continue;
       }
       // Append a new cluster :
-      sdm::tracker_cluster::handle_type tch(new sdm::tracker_cluster);
+      sdm::TrackerClusterHdl tch(new sdm::tracker_cluster);
       clustering_solution.get_clusters().push_back(tch);
-      sdm::tracker_cluster::handle_type& cluster_handle = clustering_solution.get_clusters().back();
+      sdm::TrackerClusterHdl& cluster_handle = clustering_solution.get_clusters().back();
       cluster_handle.grab().set_cluster_id(clustering_solution.get_clusters().size() - 1);
       const st::experimental_helix& seq_helix = the_sequence.get_helix();
 

--- a/modules/CAT/CAT/sultan_driver.cc
+++ b/modules/CAT/CAT/sultan_driver.cc
@@ -514,12 +514,10 @@ int sultan_driver::_process_algo(
 
   for (const auto& ts : tss) {
     // Add a new solution :
-    sdm::TrackerClusteringSolutionHdl htcs(new sdm::tracker_clustering_solution);
-    clustering_.add_solution(htcs, true);
-    clustering_.get_default_solution().set_solution_id(clustering_.get_number_of_solutions() - 1);
-    sdm::tracker_clustering_solution& clustering_solution = clustering_.get_default_solution();
-    clustering_solution.get_auxiliaries().update_string(
-        sdm::tracker_clustering_data::clusterizer_id_key(), SULTAN_ID);
+    auto htcs = datatools::make_handle<sdm::TrackerClusteringSolution>();
+    clustering_.push_back(htcs, true);
+    clustering_.get_default().set_solution_id(clustering_.size() - 1);
+    sdm::tracker_clustering_solution& clustering_solution = clustering_.get_default();
 
     const std::vector<st::sequence>& the_sequences = ts.sequences();
 
@@ -552,7 +550,7 @@ int sultan_driver::_process_algo(
       for (size_t i = 0; i < seqsz; i++) {
         const st::node& a_node = a_sequence.nodes()[i];
         int hit_id = a_node.c().id();
-        cluster_handle->get_hits().push_back(gg_hits_mapping[hit_id]);
+        cluster_handle->hits().push_back(gg_hits_mapping[hit_id]);
         DT_LOG_DEBUG(get_logging_priority(), "Add tracker hit with id #" << hit_id);
 
         const double xt = a_node.ep().x().value();

--- a/modules/CAT/CAT/sultan_driver.cc
+++ b/modules/CAT/CAT/sultan_driver.cc
@@ -322,10 +322,10 @@ int sultan_driver::_process_algo(
   size_t ihit = 0;
 
   // Hit accounting :
-  std::map<int, sdm::calibrated_data::tracker_hit_handle_type> gg_hits_mapping;
+  std::map<int, sdm::TrackerHitHdl> gg_hits_mapping;
 
   // GG hit loop :
-  BOOST_FOREACH (const sdm::calibrated_data::tracker_hit_handle_type& gg_handle, gg_hits_) {
+  BOOST_FOREACH (const sdm::TrackerHitHdl& gg_handle, gg_hits_) {
     // Skip NULL handle :
     if (!gg_handle.has_data()) {
       continue;
@@ -406,7 +406,7 @@ int sultan_driver::_process_algo(
   // Take into account calo hits:
   _SULTAN_input_.calo_cells.clear();
   // Calo hit accounting :
-  std::map<int, sdm::calibrated_data::calorimeter_hit_handle_type> calo_hits_mapping;
+  std::map<int, sdm::CalorimeterHitHdl> calo_hits_mapping;
   if (_process_calo_hits_) {
     if (_SULTAN_input_.calo_cells.capacity() < calo_hits_.size()) {
       _SULTAN_input_.calo_cells.reserve(calo_hits_.size());
@@ -415,8 +415,7 @@ int sultan_driver::_process_algo(
 
     size_t jhit = 0;
     // CALO hit loop :
-    BOOST_FOREACH (const sdm::calibrated_data::calorimeter_hit_handle_type& calo_handle,
-                   calo_hits_) {
+    BOOST_FOREACH (const sdm::CalorimeterHitHdl& calo_handle, calo_hits_) {
       // Skip NULL handle :
       if (!calo_handle.has_data()) {
         continue;

--- a/modules/CAT/CAT/sultan_then_cat_driver.cc
+++ b/modules/CAT/CAT/sultan_then_cat_driver.cc
@@ -662,10 +662,10 @@ int sultan_then_cat_driver::_process_algo(
   size_t ihit = 0;
 
   // Hit accounting :
-  std::map<int, sdm::calibrated_data::tracker_hit_handle_type> gg_hits_mapping;
+  std::map<int, sdm::TrackerHitHdl> gg_hits_mapping;
 
   // GG hit loop :
-  BOOST_FOREACH (const sdm::calibrated_data::tracker_hit_handle_type& gg_handle, gg_hits_) {
+  BOOST_FOREACH (const sdm::TrackerHitHdl& gg_handle, gg_hits_) {
     // Skip NULL handle :
     if (!gg_handle.has_data()) {
       continue;
@@ -751,7 +751,7 @@ int sultan_then_cat_driver::_process_algo(
   // Take into account calo hits:
   _SULTAN_input_.calo_cells.clear();
   // Calo hit accounting :
-  std::map<int, sdm::calibrated_data::calorimeter_hit_handle_type> calo_hits_mapping;
+  std::map<int, sdm::CalorimeterHitHdl> calo_hits_mapping;
   std::map<int, int> gg_hits_status;
   bool conserve_clustering_from_removal_of_cells = true;
   if (_process_calo_hits_) {
@@ -762,8 +762,7 @@ int sultan_then_cat_driver::_process_algo(
     size_t jhit = 0;
 
     // CALO hit loop :
-    BOOST_FOREACH (const sdm::calibrated_data::calorimeter_hit_handle_type& calo_handle,
-                   calo_hits_) {
+    BOOST_FOREACH (const sdm::CalorimeterHitHdl& calo_handle, calo_hits_) {
       // Skip NULL handle :
       if (!calo_handle.has_data()) {
         continue;

--- a/modules/CAT/CAT/sultan_then_cat_driver.cc
+++ b/modules/CAT/CAT/sultan_then_cat_driver.cc
@@ -354,7 +354,6 @@ void sultan_then_cat_driver::initialize(const datatools::properties& setup_) {
   _set_initialized(true);
 }
 
-
 CAT::topology::cell sultan_then_cat_driver::fill_CAT_hit_from_SULTAN_hit(
     SULTAN::topology::cell sc) {
   ///   SULTAN coordinate system ----->   CAT coordinate system
@@ -899,7 +898,7 @@ int sultan_then_cat_driver::_process_algo(
 
   for (const auto& ts : tss) {
     // Add a new solution :
-    sdm::tracker_clustering_solution::handle_type htcs(new sdm::tracker_clustering_solution);
+    sdm::TrackerClusteringSolutionHdl htcs(new sdm::tracker_clustering_solution);
     clustering_.add_solution(htcs, true);
     clustering_.get_default_solution().set_solution_id(clustering_.get_number_of_solutions() - 1);
     sdm::tracker_clustering_solution& clustering_solution = clustering_.get_default_solution();
@@ -931,11 +930,10 @@ int sultan_then_cat_driver::_process_algo(
         // A CAT cluster with more than one hit/cell (node) :
         {
           // Append a new cluster :
-          sdm::tracker_cluster::handle_type tch(new sdm::tracker_cluster);
+          sdm::TrackerClusterHdl tch(new sdm::tracker_cluster);
           clustering_solution.get_clusters().push_back(tch);
         }
-        sdm::tracker_cluster::handle_type& cluster_handle =
-            clustering_solution.get_clusters().back();
+        sdm::TrackerClusterHdl& cluster_handle = clustering_solution.get_clusters().back();
         cluster_handle.grab().set_cluster_id(clustering_solution.get_clusters().size() - 1);
         const ct::helix& seq_helix = isequence->get_helix();
 

--- a/modules/CAT/CAT/sultan_then_cat_driver.cc
+++ b/modules/CAT/CAT/sultan_then_cat_driver.cc
@@ -897,13 +897,10 @@ int sultan_then_cat_driver::_process_algo(
 
   for (const auto& ts : tss) {
     // Add a new solution :
-    sdm::TrackerClusteringSolutionHdl htcs(new sdm::tracker_clustering_solution);
-    clustering_.add_solution(htcs, true);
-    clustering_.get_default_solution().set_solution_id(clustering_.get_number_of_solutions() - 1);
-    sdm::tracker_clustering_solution& clustering_solution = clustering_.get_default_solution();
-    clustering_solution.get_auxiliaries().update_string(
-        sdm::tracker_clustering_data::clusterizer_id_key(), SULTAN_THEN_CAT_ID);
-
+    auto htcs = datatools::make_handle<sdm::TrackerClusteringSolution>();
+    clustering_.push_back(htcs, true);
+    clustering_.get_default().set_solution_id(clustering_.size() - 1);
+    sdm::tracker_clustering_solution& clustering_solution = clustering_.get_default();
     clustering_solution.get_auxiliaries().update_string("TRACKER", "CAT");
 
     // Analyse the sequentiator output :
@@ -1161,7 +1158,7 @@ int sultan_then_cat_driver::_process_algo(
         for (int i = 0; i < (int)seqsz; i++) {
           const ct::node& a_node = a_sequence.nodes()[i];
           int hit_id = a_node.c().id();
-          cluster_handle->get_hits().push_back(gg_hits_mapping[hit_id]);
+          cluster_handle->hits().push_back(gg_hits_mapping[hit_id]);
           gg_hits_status[hit_id] = 1;
 
           const double xt = a_node.ep().x().value();

--- a/modules/CAT/CAT/sultan_tracker_clustering_module.cc
+++ b/modules/CAT/CAT/sultan_tracker_clustering_module.cc
@@ -159,8 +159,8 @@ void sultan_tracker_clustering_module::_process(
     const snemo::datamodel::calibrated_data& calib_data,
     snemo::datamodel::tracker_clustering_data& clustering_data) {
   // Process the clusterizer driver :
-  sultanAlgo_->process(calib_data.calibrated_tracker_hits(),
-                       calib_data.calibrated_calorimeter_hits(), clustering_data);
+  sultanAlgo_->process(calib_data.tracker_hits(),
+                       calib_data.calorimeter_hits(), clustering_data);
 }
 
 }  // end of namespace reconstruction

--- a/modules/CAT/CAT/sultan_tracker_clustering_module.cc
+++ b/modules/CAT/CAT/sultan_tracker_clustering_module.cc
@@ -70,7 +70,6 @@ void sultan_tracker_clustering_module::reset() {
   _set_defaults();
 }
 
-
 void sultan_tracker_clustering_module::set_cd_label(const std::string& cdl_) {
   DT_THROW_IF(is_initialized(), std::logic_error,
               "Module '" << get_name() << "' is already initialized ! ");
@@ -102,22 +101,18 @@ void sultan_tracker_clustering_module::set_geometry_manager(const geomtools::man
               std::logic_error, "Setup label '" << setup_label << "' is not supported !");
 }
 
-
-void sultan_tracker_clustering_module::initialize(
-    const datatools::properties& config, datatools::service_manager& services,
-    dpp::module_handle_dict_type& /* unused */) {
+void sultan_tracker_clustering_module::initialize(const datatools::properties& config,
+                                                  datatools::service_manager& services,
+                                                  dpp::module_handle_dict_type& /* unused */) {
   DT_THROW_IF(is_initialized(), std::logic_error,
               "Module '" << get_name() << "' is already initialized ! ");
 
   dpp::base_module::_common_initialize(config);
 
-  namespace snedm = snemo::datamodel;
-
   falaise::property_set ps{config};
 
-  CDTag_ = ps.get<std::string>("CD_label", snedm::data_info::default_calibrated_data_label());
-  TCDTag_ =
-      ps.get<std::string>("TCD_label", snedm::data_info::default_tracker_clustering_data_label());
+  CDTag_ = ps.get<std::string>("CD_label", snedm::labels::calibrated_data());
+  TCDTag_ = ps.get<std::string>("TCD_label", snedm::labels::tracker_clustering_data());
 
   // Geometry manager :
   if (geoManager_ == nullptr) {
@@ -128,8 +123,8 @@ void sultan_tracker_clustering_module::initialize(
   // Clustering algorithm :
   sultanAlgo_.reset(new sultan_driver);
   DT_THROW_IF(!sultanAlgo_, std::logic_error,
-              "Module '" << get_name() << "' could not instantiate the '" << sultan_driver::SULTAN_ID
-                         << "' tracker clusterizer algorithm !");
+              "Module '" << get_name() << "' could not instantiate the '"
+                         << sultan_driver::SULTAN_ID << "' tracker clusterizer algorithm !");
 
   // Initialize the clustering driver :
   sultanAlgo_->set_geometry_manager(get_geometry_manager());
@@ -137,8 +132,6 @@ void sultan_tracker_clustering_module::initialize(
 
   _set_initialized(true);
 }
-
-
 
 // Processing :
 dpp::base_module::process_status sultan_tracker_clustering_module::process(
@@ -154,7 +147,7 @@ dpp::base_module::process_status sultan_tracker_clustering_module::process(
   const auto& calibratedData = event.get<snedm::calibrated_data>(CDTag_);
 
   // Get or create output data
-  auto& clusteringData = snedm::getOrAddToEvent<snedm::tracker_clustering_data>(TCDTag_, event);
+  auto& clusteringData = ::snedm::getOrAddToEvent<snedm::tracker_clustering_data>(TCDTag_, event);
 
   if (clusteringData.has_solutions()) {
     DT_LOG_WARNING(get_logging_priority(),
@@ -197,7 +190,7 @@ DOCD_CLASS_IMPLEMENT_LOAD_BEGIN(snemo::reconstruction::sultan_tracker_clustering
     std::ostringstream ldesc;
     ldesc << "This is the name of the bank to be used \n"
           << "as the source of input tracker hits.    \n"
-          << "Default value is: \"" << snemo::datamodel::data_info::default_calibrated_data_label()
+          << "Default value is: \"" << snedm::labels::calibrated_data()
           << "\".  \n";
     // Description of the 'CD_label' configuration property :
     datatools::configuration_property_description& cpd = ocd_.add_property_info();
@@ -206,7 +199,7 @@ DOCD_CLASS_IMPLEMENT_LOAD_BEGIN(snemo::reconstruction::sultan_tracker_clustering
         .set_traits(datatools::TYPE_STRING)
         .set_mandatory(false)
         .set_long_description(ldesc.str())
-        .set_default_value_string(snemo::datamodel::data_info::default_calibrated_data_label())
+        .set_default_value_string(snedm::labels::calibrated_data())
         .add_example(
             "Use an alternative name for the 'calibrated data' bank:: \n"
             "                                \n"
@@ -219,7 +212,7 @@ DOCD_CLASS_IMPLEMENT_LOAD_BEGIN(snemo::reconstruction::sultan_tracker_clustering
     ldesc << "This is the name of the bank to be used \n"
           << "as the sink of output clusters of tracker hits.    \n"
           << "Default value is: \""
-          << snemo::datamodel::data_info::default_tracker_clustering_data_label() << "\".  \n";
+          << snedm::labels::tracker_clustering_data() << "\".  \n";
     // Description of the 'TCD_label' configuration property :
     datatools::configuration_property_description& cpd = ocd_.add_property_info();
     cpd.set_name_pattern("TCD_label")
@@ -228,7 +221,7 @@ DOCD_CLASS_IMPLEMENT_LOAD_BEGIN(snemo::reconstruction::sultan_tracker_clustering
         .set_mandatory(false)
         .set_long_description(ldesc.str())
         .set_default_value_string(
-            snemo::datamodel::data_info::default_tracker_clustering_data_label())
+            snedm::labels::tracker_clustering_data())
         .add_example(
             "Use an alternative name for the 'tracker clustering data' bank:: \n"
             "                                  \n"

--- a/modules/CAT/CAT/sultan_tracker_clustering_module.cc
+++ b/modules/CAT/CAT/sultan_tracker_clustering_module.cc
@@ -148,12 +148,7 @@ dpp::base_module::process_status sultan_tracker_clustering_module::process(
 
   // Get or create output data
   auto& clusteringData = ::snedm::getOrAddToEvent<snedm::tracker_clustering_data>(TCDTag_, event);
-
-  if (clusteringData.has_solutions()) {
-    DT_LOG_WARNING(get_logging_priority(),
-                   "Module " << get_name() << " resetting solutions in bank " << TCDTag_)
-    clusteringData.reset();
-  }
+  clusteringData.clear();
 
   // Main processing method :
   _process(calibratedData, clusteringData);

--- a/modules/CAT/CAT/test/test_cat_tracker_clustering_module.cxx
+++ b/modules/CAT/CAT/test/test_cat_tracker_clustering_module.cxx
@@ -98,8 +98,7 @@ int main(int argc_, char** argv_) {
       datatools::things eventRecord;
       snemo::datamodel::calibrated_data& CD =
           eventRecord.add<snemo::datamodel::calibrated_data>("CD");
-      snemo::datamodel::calibrated_data::tracker_hit_collection_type& gghits =
-          CD.calibrated_tracker_hits();
+      snemo::datamodel::TrackerHitHdlCollection& gghits = CD.calibrated_tracker_hits();
       generate_gg_hits(*gg_locator, gghits);
       dpp::base_module::process_status status = CATmod.process(eventRecord);
       if (status != 0) {

--- a/modules/CAT/CAT/test/test_cat_tracker_clustering_module.cxx
+++ b/modules/CAT/CAT/test/test_cat_tracker_clustering_module.cxx
@@ -98,7 +98,7 @@ int main(int argc_, char** argv_) {
       datatools::things eventRecord;
       snemo::datamodel::calibrated_data& CD =
           eventRecord.add<snemo::datamodel::calibrated_data>("CD");
-      snemo::datamodel::TrackerHitHdlCollection& gghits = CD.calibrated_tracker_hits();
+      snemo::datamodel::TrackerHitHdlCollection& gghits = CD.tracker_hits();
       generate_gg_hits(*gg_locator, gghits);
       dpp::base_module::process_status status = CATmod.process(eventRecord);
       if (status != 0) {

--- a/modules/CAT/CAT/test/test_sultan_tracker_clustering_module.cxx
+++ b/modules/CAT/CAT/test/test_sultan_tracker_clustering_module.cxx
@@ -106,8 +106,7 @@ int main(int argc_, char** argv_) {
       datatools::things eventRecord;
       snemo::datamodel::calibrated_data& CD =
           eventRecord.add<snemo::datamodel::calibrated_data>("CD");
-      snemo::datamodel::calibrated_data::tracker_hit_collection_type& gghits =
-          CD.calibrated_tracker_hits();
+      snemo::datamodel::TrackerHitHdlCollection& gghits = CD.calibrated_tracker_hits();
       generate_gg_hits(*gg_locator, gghits);
       dpp::base_module::process_status status = SULTANmod.process(eventRecord);
       if (status != 0) {

--- a/modules/CAT/CAT/test/test_sultan_tracker_clustering_module.cxx
+++ b/modules/CAT/CAT/test/test_sultan_tracker_clustering_module.cxx
@@ -104,9 +104,8 @@ int main(int argc_, char** argv_) {
     for (int i = 0; i < 3; i++) {
       std::clog << "Processing event #" << i << "\n";
       datatools::things eventRecord;
-      snemo::datamodel::calibrated_data& CD =
-          eventRecord.add<snemo::datamodel::calibrated_data>("CD");
-      snemo::datamodel::TrackerHitHdlCollection& gghits = CD.calibrated_tracker_hits();
+      auto& CD = eventRecord.add<snemo::datamodel::calibrated_data>("CD");
+      snemo::datamodel::TrackerHitHdlCollection& gghits = CD.tracker_hits();
       generate_gg_hits(*gg_locator, gghits);
       dpp::base_module::process_status status = SULTANmod.process(eventRecord);
       if (status != 0) {

--- a/modules/CAT/CAT/test/utilities.cc
+++ b/modules/CAT/CAT/test/utilities.cc
@@ -165,11 +165,10 @@ void display_event(const snemo::geometry::gg_locator& ggloc_,
     const sdm::tracker_clustering_solution& tcd_sol = tcd_.get_default_solution();
     tcd_sol.tree_dump(std::cerr, "Clustering solution: ", "DEVEL: ");
     for (int i = 0; i < (int)tcd_sol.get_clusters().size(); i++) {
-      const sdm::tracker_clustering_solution::cluster_handle_type& hcluster =
-          tcd_sol.get_clusters()[i];
+      const sdm::TrackerClusterHdl& hcluster = tcd_sol.get_clusters()[i];
       const sdm::tracker_cluster& cluster = hcluster.get();
       // cluster.tree_dump(std::cerr, "Cluster: ", "DEVEL: ");
-      const sdm::calibrated_tracker_hit::collection_type& clhits = cluster.get_hits();
+      const sdm::TrackerHitHdlCollection& clhits = cluster.get_hits();
       if (i == 0) CC.set_color_code(geomtools::color::COLOR_RED);
       if (i == 1) CC.set_color_code(geomtools::color::COLOR_GREEN);
       if (i == 2) CC.set_color_code(geomtools::color::COLOR_MAGENTA);
@@ -186,9 +185,8 @@ void display_event(const snemo::geometry::gg_locator& ggloc_,
         // double r  = clhit.get_r();
         // double er = clhit.get_sigma_r();
         geomtools::vector_3d hit_pos(x, y, z);
-        geomtools::gnuplot_draw::draw_box(tmp_file.out(), hit_pos, identity,
-                                          ggloc_.cellDiameter(), ggloc_.cellDiameter(),
-                                          2 * ez);
+        geomtools::gnuplot_draw::draw_box(tmp_file.out(), hit_pos, identity, ggloc_.cellDiameter(),
+                                          ggloc_.cellDiameter(), 2 * ez);
       }
     }
     CC.set_color_code(geomtools::color::COLOR_BLACK);
@@ -203,9 +201,8 @@ void display_event(const snemo::geometry::gg_locator& ggloc_,
       // double r  = uclhit.get_r();
       // double er = uclhit.get_sigma_r();
       geomtools::vector_3d hit_pos(x, y, z);
-      geomtools::gnuplot_draw::draw_box(tmp_file.out(), hit_pos, identity,
-                                        ggloc_.cellDiameter(), ggloc_.cellDiameter(),
-                                        2 * ez);
+      geomtools::gnuplot_draw::draw_box(tmp_file.out(), hit_pos, identity, ggloc_.cellDiameter(),
+                                        ggloc_.cellDiameter(), 2 * ez);
     }
   }
 

--- a/modules/CAT/CAT/test/utilities.cc
+++ b/modules/CAT/CAT/test/utilities.cc
@@ -156,14 +156,14 @@ void display_event(const snemo::geometry::gg_locator& ggloc_,
                                        hit_pos + geomtools::vector_3d(0, 0, -ez));
   }
 
-  if (tcd_.has_default_solution()) {
-    const sdm::tracker_clustering_solution& tcd_sol = tcd_.get_default_solution();
+  if (tcd_.has_default()) {
+    const sdm::tracker_clustering_solution& tcd_sol = tcd_.get_default();
     tcd_sol.tree_dump(std::cerr, "Clustering solution: ", "DEVEL: ");
     for (int i = 0; i < (int)tcd_sol.get_clusters().size(); i++) {
       const sdm::TrackerClusterHdl& hcluster = tcd_sol.get_clusters()[i];
       const sdm::tracker_cluster& cluster = hcluster.get();
       // cluster.tree_dump(std::cerr, "Cluster: ", "DEVEL: ");
-      const sdm::TrackerHitHdlCollection& clhits = cluster.get_hits();
+      const sdm::TrackerHitHdlCollection& clhits = cluster.hits();
       if (i == 0) CC.set_color_code(geomtools::color::COLOR_RED);
       if (i == 1) CC.set_color_code(geomtools::color::COLOR_GREEN);
       if (i == 2) CC.set_color_code(geomtools::color::COLOR_MAGENTA);

--- a/modules/CAT/CAT/test/utilities.cc
+++ b/modules/CAT/CAT/test/utilities.cc
@@ -13,11 +13,10 @@
 #include <geomtools/manager.h>
 
 void generate_gg_hits(const snemo::geometry::gg_locator& ggloc_,
-                      snemo::datamodel::calibrated_data::tracker_hit_collection_type& gghits_) {
+                      snemo::datamodel::TrackerHitHdlCollection& gghits_) {
   // A fake track:
   for (int i = 0; i < 9; i++) {
-    snemo::datamodel::calibrated_data::tracker_hit_handle_type hgghit(
-        new snemo::datamodel::calibrated_tracker_hit);
+    snemo::datamodel::TrackerHitHdl hgghit(new snemo::datamodel::calibrated_tracker_hit);
     snemo::datamodel::calibrated_tracker_hit& gghit = hgghit.grab();
     gghit.set_hit_id(i);
     gghit.grab_geom_id().set_type(1204);
@@ -38,8 +37,7 @@ void generate_gg_hits(const snemo::geometry::gg_locator& ggloc_,
 
   // A fake track:
   for (int i = 0; i < 4; i++) {
-    snemo::datamodel::calibrated_data::tracker_hit_handle_type hgghit(
-        new snemo::datamodel::calibrated_tracker_hit);
+    snemo::datamodel::TrackerHitHdl hgghit(new snemo::datamodel::calibrated_tracker_hit);
     snemo::datamodel::calibrated_tracker_hit& gghit = hgghit.grab();
     gghit.set_hit_id(i);
     gghit.grab_geom_id().set_type(1204);
@@ -60,8 +58,7 @@ void generate_gg_hits(const snemo::geometry::gg_locator& ggloc_,
 
   // A fake track:
   for (int i = 0; i < 3; i++) {
-    snemo::datamodel::calibrated_data::tracker_hit_handle_type hgghit(
-        new snemo::datamodel::calibrated_tracker_hit);
+    snemo::datamodel::TrackerHitHdl hgghit(new snemo::datamodel::calibrated_tracker_hit);
     snemo::datamodel::calibrated_tracker_hit& gghit = hgghit.grab();
     gghit.set_hit_id(i);
     gghit.grab_geom_id().set_type(1204);
@@ -82,8 +79,7 @@ void generate_gg_hits(const snemo::geometry::gg_locator& ggloc_,
 
   // A fake track:
   for (int i = 0; i < 6; i++) {
-    snemo::datamodel::calibrated_data::tracker_hit_handle_type hgghit(
-        new snemo::datamodel::calibrated_tracker_hit);
+    snemo::datamodel::TrackerHitHdl hgghit(new snemo::datamodel::calibrated_tracker_hit);
     snemo::datamodel::calibrated_tracker_hit& gghit = hgghit.grab();
     gghit.set_hit_id(i);
     gghit.grab_geom_id().set_type(1204);
@@ -104,8 +100,7 @@ void generate_gg_hits(const snemo::geometry::gg_locator& ggloc_,
 
   // Add random fake hits
   for (int i = 0; i < 3; i++) {
-    snemo::datamodel::calibrated_data::tracker_hit_handle_type hgghit(
-        new snemo::datamodel::calibrated_tracker_hit);
+    snemo::datamodel::TrackerHitHdl hgghit(new snemo::datamodel::calibrated_tracker_hit);
     snemo::datamodel::calibrated_tracker_hit& gghit = hgghit.grab();
     gghit.set_hit_id(i);
     gghit.grab_geom_id().set_type(1204);
@@ -127,7 +122,7 @@ void generate_gg_hits(const snemo::geometry::gg_locator& ggloc_,
 }
 
 void display_event(const snemo::geometry::gg_locator& ggloc_,
-                   const snemo::datamodel::calibrated_data::tracker_hit_collection_type& gghits_,
+                   const snemo::datamodel::TrackerHitHdlCollection& gghits_,
                    const snemo::datamodel::tracker_clustering_data& tcd_) {
   namespace sdm = snemo::datamodel;
   datatools::temp_file tmp_file;
@@ -145,7 +140,7 @@ void display_event(const snemo::geometry::gg_locator& ggloc_,
   geomtools::color::context& CC = geomtools::gnuplot_draw::color_context();
 
   for (int i = 0; i < (int)gghits_.size(); i++) {
-    const sdm::calibrated_data::tracker_hit_handle_type& hgghit = gghits_[i];
+    const sdm::TrackerHitHdl& hgghit = gghits_[i];
     const sdm::calibrated_tracker_hit& gghit = hgghit.get();
     double x = gghit.get_x();
     double y = gghit.get_y();
@@ -176,7 +171,7 @@ void display_event(const snemo::geometry::gg_locator& ggloc_,
       if (i == 4) CC.set_color_code(geomtools::color::COLOR_ORANGE);
       if (i > 4) CC.set_color_code(geomtools::color::COLOR_BLUE);
       for (int j = 0; j < (int)clhits.size(); j++) {
-        const sdm::calibrated_data::tracker_hit_handle_type& hclhit = clhits[j];
+        const sdm::TrackerHitHdl& hclhit = clhits[j];
         const sdm::calibrated_tracker_hit& clhit = hclhit.get();
         double x = clhit.get_x();
         double y = clhit.get_y();
@@ -191,8 +186,7 @@ void display_event(const snemo::geometry::gg_locator& ggloc_,
     }
     CC.set_color_code(geomtools::color::COLOR_BLACK);
     for (int j = 0; j < (int)tcd_sol.get_unclustered_hits().size(); j++) {
-      const sdm::calibrated_data::tracker_hit_handle_type& huclhit =
-          tcd_sol.get_unclustered_hits()[j];
+      const sdm::TrackerHitHdl& huclhit = tcd_sol.get_unclustered_hits()[j];
       const sdm::calibrated_tracker_hit& uclhit = huclhit.get();
       double x = uclhit.get_x();
       double y = uclhit.get_y();

--- a/modules/CAT/CAT/test/utilities.h
+++ b/modules/CAT/CAT/test/utilities.h
@@ -7,10 +7,10 @@
 #include <falaise/snemo/geometry/gg_locator.h>
 
 void generate_gg_hits(const snemo::geometry::gg_locator& ggloc_,
-                      snemo::datamodel::calibrated_data::tracker_hit_collection_type& gghits_);
+                      snemo::datamodel::TrackerHitHdlCollection& gghits_);
 
 void display_event(const snemo::geometry::gg_locator& ggloc_,
-                   const snemo::datamodel::calibrated_data::tracker_hit_collection_type& gghits_,
+                   const snemo::datamodel::TrackerHitHdlCollection& gghits_,
                    const snemo::datamodel::tracker_clustering_data& tcd_);
 
 #endif  // FALAISE_CAT_PLUGIN_UTILITIES_H

--- a/modules/ChargedParticleTracking/ChargedParticleTracking/alpha_finder_driver.cc
+++ b/modules/ChargedParticleTracking/ChargedParticleTracking/alpha_finder_driver.cc
@@ -106,9 +106,8 @@ void alpha_finder_driver::_find_delayed_unfitted_cluster_(
     this->_find_short_track_(delayed_gg_hits, a_solution, particle_track_data_);
 
     // Add tracker cluster handle to trajectory
-    if (particle_track_data_.has_particles()) {
-      snedm::particle_track_data::particle_collection_type &particles =
-          particle_track_data_.grab_particles();
+    if (particle_track_data_.hasParticles()) {
+      snedm::ParticleHdlCollection &particles = particle_track_data_.particles();
       datatools::handle<snedm::particle_track> &a_particle = particles.back();
       const datatools::properties &aux = a_particle->get_auxiliaries();
       if (aux.has_flag(alpha_finder_driver::short_alpha_key()) && a_particle->has_trajectory()) {
@@ -284,8 +283,7 @@ void alpha_finder_driver::_find_short_track_(
       this->_build_alpha_particle_track_(hits, associated_vertex, particle_track_data_);
 
       // Add special tracker cluster handle to trajectory
-      snedm::particle_track_data::particle_collection_type &particles =
-          particle_track_data_.grab_particles();
+      snedm::ParticleHdlCollection &particles = particle_track_data_.particles();
       snedm::particle_track &a_particle = particles.back().grab();
       const datatools::properties &aux = a_particle.get_auxiliaries();
       if (aux.has_flag(alpha_finder_driver::short_alpha_key()) && a_particle.has_trajectory()) {
@@ -322,12 +320,12 @@ void alpha_finder_driver::_build_alpha_particle_track_(
 
   // Add short alpha particle track
   auto a_short_alpha = datatools::make_handle<snedm::particle_track>();
-  a_short_alpha->set_track_id(particle_track_data_.get_number_of_particles());
+  a_short_alpha->set_track_id(particle_track_data_.numberOfParticles());
   a_short_alpha->set_charge(snedm::particle_track::undefined);
 
   a_short_alpha->grab_auxiliaries().store_flag(alpha_finder_driver::short_alpha_key());
 
-  particle_track_data_.add_particle(a_short_alpha);
+  particle_track_data_.insertParticle(a_short_alpha);
 
   // "Fit" short alpha trajectory
   geomtools::vector_3d last_vertex = geomtools::invalid_vector_3d();

--- a/modules/ChargedParticleTracking/ChargedParticleTracking/alpha_finder_driver.cc
+++ b/modules/ChargedParticleTracking/ChargedParticleTracking/alpha_finder_driver.cc
@@ -89,7 +89,7 @@ void alpha_finder_driver::_find_delayed_unfitted_cluster_(
   if (!a_solution.has_unfitted_clusters()) {
     return;
   }
-  const snedm::tracker_trajectory_solution::cluster_col_type &the_unfitted_clusters =
+  const snedm::TrackerClusterHdlCollection &the_unfitted_clusters =
       a_solution.get_unfitted_clusters();
   // Loop on all the unfitted cluster
   for (const datatools::handle<snedm::tracker_cluster> a_delayed_cluster : the_unfitted_clusters) {
@@ -98,8 +98,7 @@ void alpha_finder_driver::_find_delayed_unfitted_cluster_(
       return;
     }
 
-    const snedm::calibrated_tracker_hit::collection_type &delayed_gg_hits =
-        a_delayed_cluster->get_hits();
+    const snedm::TrackerHitHdlCollection &delayed_gg_hits = a_delayed_cluster->get_hits();
 
     geomtools::vector_3d associated_vertex = geomtools::invalid_vector_3d();
 
@@ -139,14 +138,14 @@ void alpha_finder_driver::_find_delayed_unclustered_hit_(
   if (!a_clustering_solution.has_unclustered_hits()) {
     return;
   }
-  const snedm::calibrated_tracker_hit::collection_type &unclustered_gg_hits =
+  const snedm::TrackerHitHdlCollection &unclustered_gg_hits =
       a_clustering_solution.get_unclustered_hits();
 
   this->_find_short_track_(unclustered_gg_hits, a_solution, particle_track_data_, false);
 }
 
 void alpha_finder_driver::_find_short_track_(
-    const snemo::datamodel::calibrated_tracker_hit::collection_type &hits_,
+    const snemo::datamodel::TrackerHitHdlCollection &hits_,
     const snemo::datamodel::tracker_trajectory_solution &solution_,
     snemo::datamodel::particle_track_data &particle_track_data_, const bool hits_from_cluster) {
   namespace snedm = snemo::datamodel;
@@ -174,8 +173,7 @@ void alpha_finder_driver::_find_short_track_(
     if (!solution_.has_trajectories()) {
       return;
     }
-    const snedm::tracker_trajectory_solution::trajectory_col_type &the_trajectories =
-        solution_.get_trajectories();
+    const snedm::TrackerTrajectoryHdlCollection &the_trajectories = solution_.get_trajectories();
     // Loop on all the trajectories
     for (const datatools::handle<snedm::tracker_trajectory> &a_trajectory : the_trajectories) {
       // Look into properties to find the default trajectory. Here,
@@ -194,8 +192,7 @@ void alpha_finder_driver::_find_short_track_(
         continue;
       }
 
-      const snedm::calibrated_tracker_hit::collection_type &prompt_gg_hits =
-          a_prompt_cluster.get_hits();
+      const snedm::TrackerHitHdlCollection &prompt_gg_hits = a_prompt_cluster.get_hits();
       for (const datatools::handle<snedm::calibrated_tracker_hit> &a_prompt_gg_hit :
            prompt_gg_hits) {
         const geomtools::vector_2d a_prompt_position(a_prompt_gg_hit->get_x(),
@@ -294,9 +291,9 @@ void alpha_finder_driver::_find_short_track_(
   }  // end of delayed hits
 }
 
-void alpha_finder_driver::_fit_short_track_(
-    const snemo::datamodel::calibrated_tracker_hit::collection_type &hits_,
-    const geomtools::vector_3d &first_vertex_, geomtools::vector_3d &last_vertex_) {
+void alpha_finder_driver::_fit_short_track_(const snemo::datamodel::TrackerHitHdlCollection &hits_,
+                                            const geomtools::vector_3d &first_vertex_,
+                                            geomtools::vector_3d &last_vertex_) {
   namespace snedm = snemo::datamodel;
 
   double max_distance = 0.0 * CLHEP::cm;
@@ -313,7 +310,7 @@ void alpha_finder_driver::_fit_short_track_(
 }
 
 void alpha_finder_driver::_build_alpha_particle_track_(
-    const snemo::datamodel::calibrated_tracker_hit::collection_type &hits_,
+    const snemo::datamodel::TrackerHitHdlCollection &hits_,
     const geomtools::vector_3d &first_vertex_,
     snemo::datamodel::particle_track_data &particle_track_data_) {
   namespace snedm = snemo::datamodel;

--- a/modules/ChargedParticleTracking/ChargedParticleTracking/alpha_finder_driver.cc
+++ b/modules/ChargedParticleTracking/ChargedParticleTracking/alpha_finder_driver.cc
@@ -98,7 +98,7 @@ void alpha_finder_driver::_find_delayed_unfitted_cluster_(
       return;
     }
 
-    const snedm::TrackerHitHdlCollection &delayed_gg_hits = a_delayed_cluster->get_hits();
+    const snedm::TrackerHitHdlCollection &delayed_gg_hits = a_delayed_cluster->hits();
 
     geomtools::vector_3d associated_vertex = geomtools::invalid_vector_3d();
 
@@ -192,7 +192,7 @@ void alpha_finder_driver::_find_short_track_(
         continue;
       }
 
-      const snedm::TrackerHitHdlCollection &prompt_gg_hits = a_prompt_cluster.get_hits();
+      const snedm::TrackerHitHdlCollection &prompt_gg_hits = a_prompt_cluster.hits();
       for (const datatools::handle<snedm::calibrated_tracker_hit> &a_prompt_gg_hit :
            prompt_gg_hits) {
         const geomtools::vector_2d a_prompt_position(a_prompt_gg_hit->get_x(),
@@ -273,7 +273,7 @@ void alpha_finder_driver::_find_short_track_(
       // to the particle track trajectory
       auto a_cluster = datatools::make_handle<snedm::tracker_cluster>();
       a_cluster->make_delayed();
-      auto &hits = a_cluster->get_hits();
+      auto &hits = a_cluster->hits();
       hits.push_back(*ihit);
 
       // Build a new particle track
@@ -318,7 +318,7 @@ void alpha_finder_driver::_build_alpha_particle_track_(
   // Add short alpha particle track
   auto a_short_alpha = datatools::make_handle<snedm::particle_track>();
   a_short_alpha->set_track_id(particle_track_data_.numberOfParticles());
-  a_short_alpha->set_charge(snedm::particle_track::undefined);
+  a_short_alpha->set_charge(snedm::particle_track::UNDEFINED);
 
   a_short_alpha->grab_auxiliaries().store_flag(alpha_finder_driver::short_alpha_key());
 

--- a/modules/ChargedParticleTracking/ChargedParticleTracking/alpha_finder_driver.h
+++ b/modules/ChargedParticleTracking/ChargedParticleTracking/alpha_finder_driver.h
@@ -109,21 +109,20 @@ class alpha_finder_driver {
       snemo::datamodel::particle_track_data& particle_track_data_);
 
   /// Dedicated method to find short track
-  void _find_short_track_(const snemo::datamodel::calibrated_tracker_hit::collection_type& hits_,
+  void _find_short_track_(const snemo::datamodel::TrackerHitHdlCollection& hits_,
                           const snemo::datamodel::tracker_trajectory_solution& solution_,
                           snemo::datamodel::particle_track_data& particle_track_data_,
                           const bool hits_from_cluster = true);
 
   /// Dedicated method to "fit" short track
-  void _fit_short_track_(const snemo::datamodel::calibrated_tracker_hit::collection_type& hits_,
+  void _fit_short_track_(const snemo::datamodel::TrackerHitHdlCollection& hits_,
                          const geomtools::vector_3d& first_vertex_,
                          geomtools::vector_3d& last_vertex_);
 
   /// Add a new short alpha particle track
-  void _build_alpha_particle_track_(
-      const snemo::datamodel::calibrated_tracker_hit::collection_type& hits_,
-      const geomtools::vector_3d& first_vertex_,
-      snemo::datamodel::particle_track_data& particle_track_data_);
+  void _build_alpha_particle_track_(const snemo::datamodel::TrackerHitHdlCollection& hits_,
+                                    const geomtools::vector_3d& first_vertex_,
+                                    snemo::datamodel::particle_track_data& particle_track_data_);
 
  private:
   datatools::logger::priority logPriority_ = datatools::logger::PRIO_WARNING;  //<! Logging flag

--- a/modules/ChargedParticleTracking/ChargedParticleTracking/calorimeter_association_driver.cc
+++ b/modules/ChargedParticleTracking/ChargedParticleTracking/calorimeter_association_driver.cc
@@ -75,13 +75,13 @@ calorimeter_association_driver::calorimeter_association_driver(const falaise::pr
 }
 
 void calorimeter_association_driver::process(
-    const snemo::datamodel::calibrated_data::calorimeter_hit_collection_type& calorimeter_hits_,
+    const snemo::datamodel::CalorimeterHitHdlCollection& calorimeter_hits_,
     snemo::datamodel::particle_track& particle_) {
   this->_measure_matching_calorimeters_(calorimeter_hits_, particle_);
 }
 
 void calorimeter_association_driver::_measure_matching_calorimeters_(
-    const snemo::datamodel::calibrated_data::calorimeter_hit_collection_type& calorimeter_hits_,
+    const snemo::datamodel::CalorimeterHitHdlCollection& calorimeter_hits_,
     snemo::datamodel::particle_track& particle_) {
   namespace snedm = snemo::datamodel;
 

--- a/modules/ChargedParticleTracking/ChargedParticleTracking/calorimeter_association_driver.cc
+++ b/modules/ChargedParticleTracking/ChargedParticleTracking/calorimeter_association_driver.cc
@@ -19,9 +19,9 @@
 #include <falaise/snemo/datamodels/particle_track.h>
 #include <falaise/snemo/geometry/calo_locator.h>
 #include <falaise/snemo/geometry/gveto_locator.h>
+#include <falaise/snemo/geometry/locator_helpers.h>
 #include <falaise/snemo/geometry/locator_plugin.h>
 #include <falaise/snemo/geometry/xcalo_locator.h>
-#include <falaise/snemo/geometry/locator_helpers.h>
 
 namespace snemo {
 
@@ -64,8 +64,8 @@ const geomtools::manager& calorimeter_association_driver::geoManager() const {
 }
 
 /// Initialize the driver through configuration properties
-calorimeter_association_driver::calorimeter_association_driver(
-    const falaise::property_set& ps, const geomtools::manager* gm) {
+calorimeter_association_driver::calorimeter_association_driver(const falaise::property_set& ps,
+                                                               const geomtools::manager* gm) {
   logPriority_ =
       datatools::logger::get_priority(ps.get<std::string>("logging.priority", "warning"));
   geoManager_ = gm;
@@ -150,7 +150,7 @@ void calorimeter_association_driver::_measure_matching_calorimeters_(
     }
 
     // Look for matching calorimeters
-    using calo_collection_type = std::map<double, snedm::calibrated_calorimeter_hit::handle_type>;
+    using calo_collection_type = std::map<double, snedm::CalorimeterHitHdl>;
 
     calo_collection_type calo_collection;
 

--- a/modules/ChargedParticleTracking/ChargedParticleTracking/calorimeter_association_driver.h
+++ b/modules/ChargedParticleTracking/ChargedParticleTracking/calorimeter_association_driver.h
@@ -86,8 +86,7 @@ class calorimeter_association_driver {
   calorimeter_association_driver() = default;
 
   /// Construct from configuration and geometry
-  calorimeter_association_driver(const falaise::property_set& ps,
-                                 const geomtools::manager* gm);
+  calorimeter_association_driver(const falaise::property_set& ps, const geomtools::manager* gm);
 
   /// Destructor
   ~calorimeter_association_driver() = default;
@@ -105,9 +104,8 @@ class calorimeter_association_driver {
   calorimeter_association_driver& operator=(calorimeter_association_driver&&) = default;
 
   /// Main driver method
-  void process(
-      const snemo::datamodel::calibrated_data::calorimeter_hit_collection_type& calorimeter_hits_,
-      snemo::datamodel::particle_track& particle_);
+  void process(const snemo::datamodel::CalorimeterHitHdlCollection& calorimeter_hits_,
+               snemo::datamodel::particle_track& particle_);
 
   /// OCD support:
   static void init_ocd(datatools::object_configuration_description& ocd_);
@@ -118,7 +116,7 @@ class calorimeter_association_driver {
 
   /// Find matching calorimeters:
   void _measure_matching_calorimeters_(
-      const snemo::datamodel::calibrated_data::calorimeter_hit_collection_type& calorimeter_hits_,
+      const snemo::datamodel::CalorimeterHitHdlCollection& calorimeter_hits_,
       snemo::datamodel::particle_track& particle_);
 
  private:

--- a/modules/ChargedParticleTracking/ChargedParticleTracking/charge_computation_driver.cc
+++ b/modules/ChargedParticleTracking/ChargedParticleTracking/charge_computation_driver.cc
@@ -44,7 +44,7 @@ void charge_computation_driver::process(const snemo::datamodel::tracker_trajecto
   const snedm::base_trajectory_pattern &a_track_pattern = trajectory_.get_pattern();
 
   if (a_track_pattern.get_pattern_id() == snedm::line_trajectory_pattern::pattern_id()) {
-    particle_.set_charge(snedm::particle_track::undefined);
+    particle_.set_charge(snedm::particle_track::UNDEFINED);
     return;
   }
 
@@ -69,9 +69,9 @@ void charge_computation_driver::process(const snemo::datamodel::tracker_trajecto
   }
 
   if (a_charge < 0) {
-    particle_.set_charge(snedm::particle_track::negative);
+    particle_.set_charge(snedm::particle_track::NEGATIVE);
   } else {
-    particle_.set_charge(snedm::particle_track::positive);
+    particle_.set_charge(snedm::particle_track::POSITIVE);
   }
 }
 

--- a/modules/ChargedParticleTracking/ChargedParticleTracking/charged_particle_tracking_module.cc
+++ b/modules/ChargedParticleTracking/ChargedParticleTracking/charged_particle_tracking_module.cc
@@ -121,20 +121,20 @@ charged_particle_tracking_module::~charged_particle_tracking_module() {
 
 // Processing :
 dpp::base_module::process_status charged_particle_tracking_module::process(
-    datatools::things& data_record_) {
+    datatools::things& event) {
   DT_THROW_IF(!is_initialized(), std::logic_error,
               "Module '" << get_name() << "' is not initialized !");
   namespace snedm = snemo::datamodel;
 
   // Get required input products
-  const auto& the_calibrated_data = data_record_.get<snedm::calibrated_data>(CDTag_);
+  const auto& the_calibrated_data = event.get<snedm::calibrated_data>(CDTag_);
   const auto& the_tracker_trajectory_data =
-      data_record_.get<snedm::tracker_trajectory_data>(TTDTag_);
+      event.get<snedm::tracker_trajectory_data>(TTDTag_);
 
   // Create or reset output bank
   auto the_particle_track_data =
-      ::snedm::getOrAddToEvent<snedm::particle_track_data>(PTDTag_, data_record_);
-  the_particle_track_data.reset();
+      ::snedm::getOrAddToEvent<snedm::particle_track_data>(PTDTag_, event);
+  the_particle_track_data.clear();
 
   // Main processing method :
   this->_process(the_calibrated_data, the_tracker_trajectory_data, the_particle_track_data);
@@ -152,7 +152,7 @@ void charged_particle_tracking_module::_process(
   if (!tracker_trajectory_data_.has_default_solution()) {
     // Fill non associated calorimeter hits
     for (const auto& chit : calibrated_data_.calibrated_calorimeter_hits()) {
-      particle_track_data_.grab_non_associated_calorimeters().push_back(chit);
+      particle_track_data_.isolatedCalorimeters().push_back(chit);
     }
     return;
   }
@@ -175,8 +175,8 @@ void charged_particle_tracking_module::_process(
     // Add a new particle_track
     auto hPT = datatools::make_handle<snedm::particle_track>();
     hPT->set_trajectory_handle(a_trajectory);
-    hPT->set_track_id(particle_track_data_.get_number_of_particles());
-    particle_track_data_.add_particle(hPT);
+    hPT->set_track_id(particle_track_data_.numberOfParticles());
+    particle_track_data_.insertParticle(hPT);
 
     // Compute particle charge
     if (CCAlgo_) {
@@ -203,7 +203,7 @@ void charged_particle_tracking_module::_post_process(
     snemo::datamodel::particle_track_data& particle_track_data_) {
   namespace snedm = snemo::datamodel;
   // Grab non associated calorimeters :
-  if (!particle_track_data_.has_non_associated_calorimeters()) {
+  if (!particle_track_data_.hasIsolatedCalorimeters()) {
     geomtools::base_hit::has_flag_predicate asso_pred(calorimeter_utils::associated_flag());
     geomtools::base_hit::negates_predicate not_asso_pred(asso_pred);
     // Wrapper predicates :
@@ -216,7 +216,7 @@ void charged_particle_tracking_module::_post_process(
     // The below might be better with copy_if and back_inserter?
     auto ihit = std::find_if(chits.begin(), chits.end(), pred_via_handle);
     while (ihit != chits.end()) {
-      particle_track_data_.grab_non_associated_calorimeters().push_back(*ihit);
+      particle_track_data_.isolatedCalorimeters().push_back(*ihit);
       ihit = std::find_if(++ihit, chits.end(), pred_via_handle);
     }
   }
@@ -227,7 +227,7 @@ void charged_particle_tracking_module::_post_process(
   const snedm::calibrated_data::tracker_hit_collection_type& thits =
       calibrated_data_.calibrated_tracker_hits();
   snedm::calibrated_data::calorimeter_hit_collection_type& chits =
-      particle_track_data_.grab_non_associated_calorimeters();
+      particle_track_data_.isolatedCalorimeters();
 
   for (datatools::handle<snedm::calibrated_calorimeter_hit>& a_calo_hit : chits) {
     const bool has_neighbors =
@@ -325,8 +325,7 @@ DOCD_CLASS_IMPLEMENT_LOAD_BEGIN(snemo::reconstruction::charged_particle_tracking
         .set_long_description(
             "This is the name of the bank to be used      \n"
             "as the source of input tracker trajectories. \n")
-        .set_default_value_string(
-            snedm::labels::tracker_trajectory_data())
+        .set_default_value_string(snedm::labels::tracker_trajectory_data())
         .add_example(
             "Use an alternative name for the  \n"
             "'tracker trajectory data' bank:: \n"

--- a/modules/ChargedParticleTracking/ChargedParticleTracking/charged_particle_tracking_module.cc
+++ b/modules/ChargedParticleTracking/ChargedParticleTracking/charged_particle_tracking_module.cc
@@ -209,7 +209,7 @@ void charged_particle_tracking_module::_post_process(
         pred_M2D(not_asso_pred);
     datatools::handle_predicate<snedm::calibrated_calorimeter_hit> pred_via_handle(pred_M2D);
 
-    const snedm::calibrated_data::calorimeter_hit_collection_type& chits =
+    const snedm::CalorimeterHitHdlCollection& chits =
         calibrated_data_.calibrated_calorimeter_hits();
     // The below might be better with copy_if and back_inserter?
     auto ihit = std::find_if(chits.begin(), chits.end(), pred_via_handle);
@@ -222,10 +222,8 @@ void charged_particle_tracking_module::_post_process(
   // 2015/12/02 XG: Also look if the non associated calorimeters are
   // isolated i.e. without Geiger cells in front or not: tag them
   // consequently
-  const snedm::calibrated_data::tracker_hit_collection_type& thits =
-      calibrated_data_.calibrated_tracker_hits();
-  snedm::calibrated_data::calorimeter_hit_collection_type& chits =
-      particle_track_data_.isolatedCalorimeters();
+  const snedm::TrackerHitHdlCollection& thits = calibrated_data_.calibrated_tracker_hits();
+  snedm::CalorimeterHitHdlCollection& chits = particle_track_data_.isolatedCalorimeters();
 
   for (datatools::handle<snedm::calibrated_calorimeter_hit>& a_calo_hit : chits) {
     const bool has_neighbors =

--- a/modules/ChargedParticleTracking/ChargedParticleTracking/charged_particle_tracking_module.cc
+++ b/modules/ChargedParticleTracking/ChargedParticleTracking/charged_particle_tracking_module.cc
@@ -128,8 +128,7 @@ dpp::base_module::process_status charged_particle_tracking_module::process(
 
   // Get required input products
   const auto& the_calibrated_data = event.get<snedm::calibrated_data>(CDTag_);
-  const auto& the_tracker_trajectory_data =
-      event.get<snedm::tracker_trajectory_data>(TTDTag_);
+  const auto& the_tracker_trajectory_data = event.get<snedm::tracker_trajectory_data>(TTDTag_);
 
   // Create or reset output bank
   auto the_particle_track_data =
@@ -159,8 +158,7 @@ void charged_particle_tracking_module::_process(
 
   const snedm::tracker_trajectory_solution& a_solution =
       tracker_trajectory_data_.get_default_solution();
-  const snedm::tracker_trajectory_solution::trajectory_col_type& trajectories =
-      a_solution.get_trajectories();
+  const snedm::TrackerTrajectoryHdlCollection& trajectories = a_solution.get_trajectories();
 
   for (const datatools::handle<snedm::tracker_trajectory> a_trajectory : trajectories) {
     // Look into properties to find the default

--- a/modules/ChargedParticleTracking/ChargedParticleTracking/charged_particle_tracking_module.cc
+++ b/modules/ChargedParticleTracking/ChargedParticleTracking/charged_particle_tracking_module.cc
@@ -38,10 +38,9 @@ DPP_MODULE_REGISTRATION_IMPLEMENT(charged_particle_tracking_module,
                                   "snemo::reconstruction::charged_particle_tracking_module")
 
 void charged_particle_tracking_module::_set_defaults() {
-  using sdmi = snemo::datamodel::data_info;
-  CDTag_ = sdmi::default_calibrated_data_label();
-  TTDTag_ = sdmi::default_tracker_trajectory_data_label();
-  PTDTag_ = sdmi::default_particle_track_data_label();
+  CDTag_ = snedm::labels::calibrated_data();
+  TTDTag_ = snedm::labels::tracker_trajectory_data();
+  PTDTag_ = snedm::labels::particle_track_data();
 
   geoManager_ = snemo::service_handle<snemo::geometry_svc>{};
 
@@ -56,7 +55,6 @@ void charged_particle_tracking_module::initialize(
     dpp::module_handle_dict_type& /* module_dict_ */) {
   DT_THROW_IF(is_initialized(), std::logic_error,
               "Module '" << get_name() << "' is already initialized ! ");
-  using sdmi = snemo::datamodel::data_info;
   namespace snreco = snemo::reconstruction;
 
   using VertexExtrapolator = snreco::vertex_extrapolation_driver;
@@ -68,9 +66,9 @@ void charged_particle_tracking_module::initialize(
 
   falaise::property_set ps{setup_};
 
-  CDTag_ = ps.get<std::string>("CD_label", sdmi::default_calibrated_data_label());
-  TTDTag_ = ps.get<std::string>("TTD_label", sdmi::default_tracker_trajectory_data_label());
-  PTDTag_ = ps.get<std::string>("PTD_label", sdmi::default_particle_track_data_label());
+  CDTag_ = ps.get<std::string>("CD_label", snedm::labels::calibrated_data());
+  TTDTag_ = ps.get<std::string>("TTD_label", snedm::labels::tracker_trajectory_data());
+  PTDTag_ = ps.get<std::string>("PTD_label", snedm::labels::particle_track_data());
 
   // Geometry manager :
   geoManager_ = snemo::service_handle<snemo::geometry_svc>{service_manager_};
@@ -135,7 +133,7 @@ dpp::base_module::process_status charged_particle_tracking_module::process(
 
   // Create or reset output bank
   auto the_particle_track_data =
-      snedm::getOrAddToEvent<snedm::particle_track_data>(PTDTag_, data_record_);
+      ::snedm::getOrAddToEvent<snedm::particle_track_data>(PTDTag_, data_record_);
   the_particle_track_data.reset();
 
   // Main processing method :
@@ -308,7 +306,7 @@ DOCD_CLASS_IMPLEMENT_LOAD_BEGIN(snemo::reconstruction::charged_particle_tracking
         .set_long_description(
             "This is the name of the bank to be used  \n"
             "as the source of input calorimeter hits. \n")
-        .set_default_value_string(snemo::datamodel::data_info::default_calibrated_data_label())
+        .set_default_value_string(snedm::labels::calibrated_data())
         .add_example(
             "Use an alternative name for the \n"
             "'calibrated data' bank::        \n"
@@ -328,7 +326,7 @@ DOCD_CLASS_IMPLEMENT_LOAD_BEGIN(snemo::reconstruction::charged_particle_tracking
             "This is the name of the bank to be used      \n"
             "as the source of input tracker trajectories. \n")
         .set_default_value_string(
-            snemo::datamodel::data_info::default_tracker_trajectory_data_label())
+            snedm::labels::tracker_trajectory_data())
         .add_example(
             "Use an alternative name for the  \n"
             "'tracker trajectory data' bank:: \n"
@@ -347,7 +345,7 @@ DOCD_CLASS_IMPLEMENT_LOAD_BEGIN(snemo::reconstruction::charged_particle_tracking
         .set_long_description(
             "This is the name of the bank to be used as \n"
             "the sink of output particle tracks.        \n")
-        .set_default_value_string(snemo::datamodel::data_info::default_particle_track_data_label())
+        .set_default_value_string(snedm::labels::particle_track_data())
         .add_example(
             "Use an alternative name for the \n"
             "'particle track data' bank::    \n"

--- a/modules/ChargedParticleTracking/ChargedParticleTracking/charged_particle_tracking_module.cc
+++ b/modules/ChargedParticleTracking/ChargedParticleTracking/charged_particle_tracking_module.cc
@@ -150,7 +150,7 @@ void charged_particle_tracking_module::_process(
 
   if (!tracker_trajectory_data_.has_default_solution()) {
     // Fill non associated calorimeter hits
-    for (const auto& chit : calibrated_data_.calibrated_calorimeter_hits()) {
+    for (const auto& chit : calibrated_data_.calorimeter_hits()) {
       particle_track_data_.isolatedCalorimeters().push_back(chit);
     }
     return;
@@ -186,7 +186,7 @@ void charged_particle_tracking_module::_process(
     }
     // Associate vertices to calorimeter hits
     if (CAAlgo_) {
-      CAAlgo_->process(calibrated_data_.calibrated_calorimeter_hits(), *hPT);
+      CAAlgo_->process(calibrated_data_.calorimeter_hits(), *hPT);
     }
   }
 
@@ -210,7 +210,7 @@ void charged_particle_tracking_module::_post_process(
     datatools::handle_predicate<snedm::calibrated_calorimeter_hit> pred_via_handle(pred_M2D);
 
     const snedm::CalorimeterHitHdlCollection& chits =
-        calibrated_data_.calibrated_calorimeter_hits();
+        calibrated_data_.calorimeter_hits();
     // The below might be better with copy_if and back_inserter?
     auto ihit = std::find_if(chits.begin(), chits.end(), pred_via_handle);
     while (ihit != chits.end()) {
@@ -222,7 +222,7 @@ void charged_particle_tracking_module::_post_process(
   // 2015/12/02 XG: Also look if the non associated calorimeters are
   // isolated i.e. without Geiger cells in front or not: tag them
   // consequently
-  const snedm::TrackerHitHdlCollection& thits = calibrated_data_.calibrated_tracker_hits();
+  const snedm::TrackerHitHdlCollection& thits = calibrated_data_.tracker_hits();
   snedm::CalorimeterHitHdlCollection& chits = particle_track_data_.isolatedCalorimeters();
 
   for (datatools::handle<snedm::calibrated_calorimeter_hit>& a_calo_hit : chits) {

--- a/modules/ChargedParticleTracking/ChargedParticleTracking/vertex_extrapolation_driver.cc
+++ b/modules/ChargedParticleTracking/ChargedParticleTracking/vertex_extrapolation_driver.cc
@@ -20,9 +20,9 @@
 #include <falaise/snemo/geometry/calo_locator.h>
 #include <falaise/snemo/geometry/gg_locator.h>
 #include <falaise/snemo/geometry/gveto_locator.h>
+#include <falaise/snemo/geometry/locator_helpers.h>
 #include <falaise/snemo/geometry/locator_plugin.h>
 #include <falaise/snemo/geometry/xcalo_locator.h>
-#include <falaise/snemo/geometry/locator_helpers.h>
 
 namespace snemo {
 
@@ -422,7 +422,7 @@ void vertex_extrapolation_driver::_check_vertices_(
   _use_vertices_[snedm::particle_track::vertex_on_gamma_veto_label()] = false;
 
   const snedm::tracker_cluster &a_cluster = trajectory_.get_cluster();
-  const snedm::calibrated_tracker_hit::collection_type &the_hits = a_cluster.get_hits();
+  const snedm::TrackerHitHdlCollection &the_hits = a_cluster.get_hits();
   for (const datatools::handle<snedm::calibrated_tracker_hit> a_hit : the_hits) {
     const geomtools::geom_id &a_gid = a_hit->get_geom_id();
 

--- a/modules/ChargedParticleTracking/ChargedParticleTracking/vertex_extrapolation_driver.cc
+++ b/modules/ChargedParticleTracking/ChargedParticleTracking/vertex_extrapolation_driver.cc
@@ -422,7 +422,7 @@ void vertex_extrapolation_driver::_check_vertices_(
   _use_vertices_[snedm::particle_track::vertex_on_gamma_veto_label()] = false;
 
   const snedm::tracker_cluster &a_cluster = trajectory_.get_cluster();
-  const snedm::TrackerHitHdlCollection &the_hits = a_cluster.get_hits();
+  const snedm::TrackerHitHdlCollection &the_hits = a_cluster.hits();
   for (const datatools::handle<snedm::calibrated_tracker_hit> a_hit : the_hits) {
     const geomtools::geom_id &a_gid = a_hit->get_geom_id();
 

--- a/modules/EventBrowser/EventBrowser/browser_tracks.cc
+++ b/modules/EventBrowser/EventBrowser/browser_tracks.cc
@@ -1164,9 +1164,9 @@ void browser_tracks::_update_particle_track_data() {
     item_particle_track_data->SetTipText(tip_text.str().c_str());
   }
   // Add unassociated calorimeter hits info
-  if (ptd.has_non_associated_calorimeters()) {
+  if (ptd.hasIsolatedCalorimeters()) {
     snemo::datamodel::calibrated_data::calorimeter_hit_collection_type &cc_collection =
-        ptd.grab_non_associated_calorimeters();
+        ptd.isolatedCalorimeters();
 
     for (auto &it_hit : cc_collection) {
       snemo::datamodel::calibrated_calorimeter_hit &a_hit = it_hit.grab();
@@ -1206,12 +1206,8 @@ void browser_tracks::_update_particle_track_data() {
     }
   }
 
-  if (!ptd.has_particles()) {
-    return;
-  }
 
-  snemo::datamodel::particle_track_data::particle_collection_type &particles = ptd.grab_particles();
-  for (auto &particle : particles) {
+  for (auto &particle : ptd.particles()) {
     // Get current particle track:
     snemo::datamodel::particle_track &a_particle = particle.grab();
 

--- a/modules/EventBrowser/EventBrowser/browser_tracks.cc
+++ b/modules/EventBrowser/EventBrowser/browser_tracks.cc
@@ -799,8 +799,7 @@ void browser_tracks::_update_tracker_clustering_data() {
     item_tracker_cluster->SetTipText(tip_text.str().c_str());
   }
 
-  snemo::datamodel::TrackerClusteringSolutionHdlCollection &cluster_solutions = tcd.get_solutions();
-  for (auto &cluster_solution : cluster_solutions) {
+  for (auto &cluster_solution : tcd.solutions()) {
     // Get current tracker solution:
     snemo::datamodel::tracker_clustering_solution &a_solution = cluster_solution.grab();
 
@@ -809,8 +808,8 @@ void browser_tracks::_update_tracker_clustering_data() {
     label_solution << "Solution #" << a_solution.get_solution_id() << " - "
                    << a_solution.get_unclustered_hits().size() << " unclustered hit"
                    << (a_solution.get_unclustered_hits().size() > 1 ? "s" : "");
-    if (tcd.has_default_solution()) {
-      if (&a_solution == &(tcd.get_default_solution())) {
+    if (tcd.has_default()) {
+      if (&a_solution == &(tcd.get_default())) {
         label_solution << " - default";
       }
     }
@@ -846,7 +845,7 @@ void browser_tracks::_update_tracker_clustering_data() {
       // Add subitem:
       std::ostringstream label_cluster;
       label_cluster << "Cluster #" << a_cluster.get_cluster_id() << " "
-                    << "(" << a_cluster.get_hits().size() << " hits) ";
+                    << "(" << a_cluster.size() << " hits) ";
       if (a_cluster.is_prompt()) {
         label_cluster << "- prompt";
       } else {
@@ -885,7 +884,7 @@ void browser_tracks::_update_tracker_clustering_data() {
                                 _get_colored_icon_("cluster", hex_str));
 
       // Get tracker hits stored in the current tracker cluster:
-      for (auto &a_gg_hit : a_cluster.get_hits()) {
+      for (auto &a_gg_hit : a_cluster.hits()) {
         // Add subsubitem:
         std::ostringstream label_hit;
         label_hit.precision(3);
@@ -988,6 +987,8 @@ void browser_tracks::_update_tracker_trajectory_data() {
     item_solution->SetUserData((void *)(intptr_t)++icheck_id);
 
 // DONT couple data model to view
+// THIS IS THE ONLY PLACE PROPERTIES OF TRACKER_TRAJECTORY_SOLUTION ARE USED,
+// BUT IT'S SO TIGHTLY COUPLED I CANT FIX IT WITHOUT MAJOR SURGERY
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     // Get solution auxiliaries:
@@ -1208,16 +1209,16 @@ void browser_tracks::_update_particle_track_data() {
     size_t item_color = 0;
     std::ostringstream label_particle;
     label_particle << "Particle #" << a_particle.get_track_id();
-    if (a_particle.get_charge() == snemo::datamodel::particle_track::neutral) {
+    if (a_particle.get_charge() == snemo::datamodel::particle_track::NEUTRAL) {
       label_particle << " - neutral charged particle";
       item_color = style_manager::get_instance().get_particle_color("gamma");
-    } else if (a_particle.get_charge() == snemo::datamodel::particle_track::negative) {
+    } else if (a_particle.get_charge() == snemo::datamodel::particle_track::NEGATIVE) {
       label_particle << " - negative charged particle";
       item_color = style_manager::get_instance().get_particle_color("electron");
-    } else if (a_particle.get_charge() == snemo::datamodel::particle_track::positive) {
+    } else if (a_particle.get_charge() == snemo::datamodel::particle_track::POSITIVE) {
       label_particle << " - positive charged particle";
       item_color = style_manager::get_instance().get_particle_color("positron");
-    } else if (a_particle.get_charge() == snemo::datamodel::particle_track::undefined) {
+    } else if (a_particle.get_charge() == snemo::datamodel::particle_track::UNDEFINED) {
       label_particle << " - undefined charged particle";
       item_color = style_manager::get_instance().get_particle_color("alpha");
     }

--- a/modules/EventBrowser/EventBrowser/browser_tracks.cc
+++ b/modules/EventBrowser/EventBrowser/browser_tracks.cc
@@ -801,8 +801,7 @@ void browser_tracks::_update_tracker_clustering_data() {
     item_tracker_cluster->SetTipText(tip_text.str().c_str());
   }
 
-  snemo::datamodel::tracker_clustering_data::solution_col_type &cluster_solutions =
-      tcd.get_solutions();
+  snemo::datamodel::TrackerClusteringSolutionHdlCollection &cluster_solutions = tcd.get_solutions();
   for (auto &cluster_solution : cluster_solutions) {
     // Get current tracker solution:
     snemo::datamodel::tracker_clustering_solution &a_solution = cluster_solution.grab();
@@ -841,8 +840,7 @@ void browser_tracks::_update_tracker_clustering_data() {
     _properties_dictionnary_[icheck_id] = &(a_auxiliaries);
 
     // Get clusters stored in the current tracker solution:
-    snemo::datamodel::tracker_clustering_solution::cluster_col_type &clusters =
-        a_solution.get_clusters();
+    snemo::datamodel::TrackerClusterHdlCollection &clusters = a_solution.get_clusters();
     for (auto &cluster : clusters) {
       // Get current tracker cluster:
       snemo::datamodel::tracker_cluster &a_cluster = cluster.grab();
@@ -961,7 +959,7 @@ void browser_tracks::_update_tracker_trajectory_data() {
     return;
   }
 
-  snemo::datamodel::tracker_trajectory_data::solution_col_type &trajectory_solutions =
+  snemo::datamodel::TrackerTrajectorySolutionHdlCollection &trajectory_solutions =
       ttd.get_solutions();
   for (auto &trajectory_solution : trajectory_solutions) {
     // Get current tracker solution:
@@ -1012,8 +1010,7 @@ void browser_tracks::_update_tracker_trajectory_data() {
     TGListTreeItem *item_line_solution = nullptr;
 
     // Get trajectories stored in the current tracker trajectory solution:
-    snemo::datamodel::tracker_trajectory_solution::trajectory_col_type &trajectories =
-        a_solution.grab_trajectories();
+    snemo::datamodel::TrackerTrajectoryHdlCollection &trajectories = a_solution.grab_trajectories();
     for (auto &trajectorie : trajectories) {
       // Get current tracker trajectory:
       snemo::datamodel::tracker_trajectory &a_trajectory = trajectorie.grab();
@@ -1205,7 +1202,6 @@ void browser_tracks::_update_particle_track_data() {
       }
     }
   }
-
 
   for (auto &particle : ptd.particles()) {
     // Get current particle track:

--- a/modules/EventBrowser/EventBrowser/browser_tracks.cc
+++ b/modules/EventBrowser/EventBrowser/browser_tracks.cc
@@ -662,8 +662,7 @@ void browser_tracks::_update_calibrated_data() {
     item_calorimeter->SetCheckBox(false);
     item_calorimeter->SetUserData((void *)(intptr_t)++icheck_id);
 
-    snemo::datamodel::calibrated_data::calorimeter_hit_collection_type &cc_collection =
-        cd.calibrated_calorimeter_hits();
+    snemo::datamodel::CalorimeterHitHdlCollection &cc_collection = cd.calibrated_calorimeter_hits();
 
     for (auto &it_hit : cc_collection) {
       snemo::datamodel::calibrated_calorimeter_hit &a_hit = it_hit.grab();
@@ -720,8 +719,7 @@ void browser_tracks::_update_calibrated_data() {
     item_tracker->SetCheckBox(false);
     item_tracker->SetUserData((void *)(intptr_t)++icheck_id);
 
-    snemo::datamodel::calibrated_data::tracker_hit_collection_type &ct_collection =
-        cd.calibrated_tracker_hits();
+    snemo::datamodel::TrackerHitHdlCollection &ct_collection = cd.calibrated_tracker_hits();
 
     for (auto &it_hit : ct_collection) {
       snemo::datamodel::calibrated_tracker_hit &a_hit = it_hit.grab();
@@ -1162,8 +1160,7 @@ void browser_tracks::_update_particle_track_data() {
   }
   // Add unassociated calorimeter hits info
   if (ptd.hasIsolatedCalorimeters()) {
-    snemo::datamodel::calibrated_data::calorimeter_hit_collection_type &cc_collection =
-        ptd.isolatedCalorimeters();
+    snemo::datamodel::CalorimeterHitHdlCollection &cc_collection = ptd.isolatedCalorimeters();
 
     for (auto &it_hit : cc_collection) {
       snemo::datamodel::calibrated_calorimeter_hit &a_hit = it_hit.grab();
@@ -1302,7 +1299,7 @@ void browser_tracks::_update_particle_track_data() {
 
     // Get associated calorimeter
     if (a_particle.has_associated_calorimeter_hits()) {
-      snemo::datamodel::calibrated_data::calorimeter_hit_collection_type &cc_collection =
+      snemo::datamodel::CalorimeterHitHdlCollection &cc_collection =
           a_particle.get_associated_calorimeter_hits();
 
       for (auto &it_hit : cc_collection) {

--- a/modules/EventBrowser/EventBrowser/browser_tracks.cc
+++ b/modules/EventBrowser/EventBrowser/browser_tracks.cc
@@ -662,7 +662,7 @@ void browser_tracks::_update_calibrated_data() {
     item_calorimeter->SetCheckBox(false);
     item_calorimeter->SetUserData((void *)(intptr_t)++icheck_id);
 
-    snemo::datamodel::CalorimeterHitHdlCollection &cc_collection = cd.calibrated_calorimeter_hits();
+    snemo::datamodel::CalorimeterHitHdlCollection &cc_collection = cd.calorimeter_hits();
 
     for (auto &it_hit : cc_collection) {
       snemo::datamodel::calibrated_calorimeter_hit &a_hit = it_hit.grab();
@@ -719,7 +719,7 @@ void browser_tracks::_update_calibrated_data() {
     item_tracker->SetCheckBox(false);
     item_tracker->SetUserData((void *)(intptr_t)++icheck_id);
 
-    snemo::datamodel::TrackerHitHdlCollection &ct_collection = cd.calibrated_tracker_hits();
+    snemo::datamodel::TrackerHitHdlCollection &ct_collection = cd.tracker_hits();
 
     for (auto &it_hit : ct_collection) {
       snemo::datamodel::calibrated_tracker_hit &a_hit = it_hit.grab();

--- a/modules/EventBrowser/EventBrowser/calorimeter_hit_renderer.cc
+++ b/modules/EventBrowser/EventBrowser/calorimeter_hit_renderer.cc
@@ -125,7 +125,7 @@ void calorimeter_hit_renderer::push_calibrated_hits() {
     return;
   }
 
-  const snemo::datamodel::calibrated_data::calorimeter_hit_collection_type& cc_collection =
+  const snemo::datamodel::CalorimeterHitHdlCollection& cc_collection =
       calib_data.calibrated_calorimeter_hits();
 
   if (cc_collection.empty()) {

--- a/modules/EventBrowser/EventBrowser/calorimeter_hit_renderer.cc
+++ b/modules/EventBrowser/EventBrowser/calorimeter_hit_renderer.cc
@@ -119,14 +119,8 @@ void calorimeter_hit_renderer::push_calibrated_hits() {
   const io::event_record& event = _server->get_event();
   const auto& calib_data = event.get<snemo::datamodel::calibrated_data>(io::CD_LABEL);
 
-  if (!calib_data.has_calibrated_calorimeter_hits()) {
-    DT_LOG_DEBUG(options_manager::get_instance().get_logging_priority(),
-                 "Event has no calibrated calorimeter hits");
-    return;
-  }
-
   const snemo::datamodel::CalorimeterHitHdlCollection& cc_collection =
-      calib_data.calibrated_calorimeter_hits();
+      calib_data.calorimeter_hits();
 
   if (cc_collection.empty()) {
     DT_LOG_DEBUG(options_manager::get_instance().get_logging_priority(),

--- a/modules/EventBrowser/EventBrowser/io/data_model.h
+++ b/modules/EventBrowser/EventBrowser/io/data_model.h
@@ -50,22 +50,22 @@ namespace io {
 typedef datatools::things event_record;
 
 // event header
-const std::string EH_LABEL = snemo::datamodel::data_info::default_event_header_label();
+const std::string EH_LABEL = snedm::labels::event_header();
 
 // simulated stuff
-const std::string SD_LABEL = snemo::datamodel::data_info::default_simulated_data_label();
+const std::string SD_LABEL = snedm::labels::simulated_data();
 
 // calibrated stuff
-const std::string CD_LABEL = snemo::datamodel::data_info::default_calibrated_data_label();
+const std::string CD_LABEL = snedm::labels::calibrated_data();
 
 // tracker clustering stuff
-const std::string TCD_LABEL = snemo::datamodel::data_info::default_tracker_clustering_data_label();
+const std::string TCD_LABEL = snedm::labels::tracker_clustering_data();
 
 // tracker trajectory stuff
-const std::string TTD_LABEL = snemo::datamodel::data_info::default_tracker_trajectory_data_label();
+const std::string TTD_LABEL = snedm::labels::tracker_trajectory_data();
 
 // particle track stuff
-const std::string PTD_LABEL = snemo::datamodel::data_info::default_particle_track_data_label();
+const std::string PTD_LABEL = snedm::labels::particle_track_data();
 
 }  // end of namespace io
 

--- a/modules/EventBrowser/EventBrowser/signal_handling.cc
+++ b/modules/EventBrowser/EventBrowser/signal_handling.cc
@@ -56,7 +56,7 @@ namespace view {
 const unsigned int g__binded_keys[] = {
     kKey_Escape,  kKey_PageDown, kKey_PageUp, kKey_Home, kKey_End, kKey_Space, kKey_Tab,
     kKey_Backtab, kKey_P,        kKey_A,      kKey_D,    kKey_o,   kKey_r};
-const unsigned int g__nbr_binded_keys = sizeof(g__binded_keys) / sizeof(unsigned int);
+//const unsigned int g__nbr_binded_keys = sizeof(g__binded_keys) / sizeof(unsigned int);
 
 // ctor:
 signal_handling::signal_handling(TGMainFrame* main_) : _browser_(nullptr) {

--- a/modules/EventBrowser/EventBrowser/tracker_hit_renderer.cc
+++ b/modules/EventBrowser/EventBrowser/tracker_hit_renderer.cc
@@ -206,9 +206,7 @@ void tracker_hit_renderer::push_clustered_hits() {
   const auto &tracker_clustered_data =
       event.get<snemo::datamodel::tracker_clustering_data>(io::TCD_LABEL);
 
-  const snemo::datamodel::TrackerClusteringSolutionHdlCollection &cluster_solutions =
-      tracker_clustered_data.get_solutions();
-  for (const auto &cluster_solution : cluster_solutions) {
+  for (const auto &cluster_solution : tracker_clustered_data.solutions()) {
     // Get current tracker solution:
     const snemo::datamodel::tracker_clustering_solution &a_solution = cluster_solution.get();
 
@@ -243,7 +241,7 @@ void tracker_hit_renderer::push_clustered_hits() {
       cluster_properties.update(browser_tracks::COLOR_FLAG, hex_str);
 
       // Get tracker hits stored in the current tracker cluster:
-      const snemo::datamodel::TrackerHitHdlCollection &hits = a_cluster.get_hits();
+      const snemo::datamodel::TrackerHitHdlCollection &hits = a_cluster.hits();
 
       // Make a gradient color starting from color_solution:
       for (const auto &hit : hits) {
@@ -364,7 +362,7 @@ void tracker_hit_renderer::push_fitted_tracks() {
         if (a_trajectory.has_cluster()) {
           const snemo::datamodel::tracker_cluster &a_cluster = a_trajectory.get_cluster();
           // Get tracker hits stored in the current tracker cluster:
-          const snemo::datamodel::TrackerHitHdlCollection &hits = a_cluster.get_hits();
+          const snemo::datamodel::TrackerHitHdlCollection &hits = a_cluster.hits();
 
           for (const auto &igg : hits) {
             snemo::datamodel::calibrated_tracker_hit a_gg_hit_copy = igg.get();

--- a/modules/EventBrowser/EventBrowser/tracker_hit_renderer.cc
+++ b/modules/EventBrowser/EventBrowser/tracker_hit_renderer.cc
@@ -180,14 +180,7 @@ void tracker_hit_renderer::push_calibrated_hits() {
   const io::event_record &event = _server->get_event();
   const auto &calib_data = event.get<snemo::datamodel::calibrated_data>(io::CD_LABEL);
 
-  if (!calib_data.has_calibrated_tracker_hits()) {
-    DT_LOG_INFORMATION(options_manager::get_instance().get_logging_priority(),
-                       "Event has no calibrated tracker hits");
-    return;
-  }
-
-  const snemo::datamodel::TrackerHitHdlCollection &ct_collection =
-      calib_data.calibrated_tracker_hits();
+  const snemo::datamodel::TrackerHitHdlCollection &ct_collection = calib_data.tracker_hits();
 
   if (ct_collection.empty()) {
     DT_LOG_INFORMATION(options_manager::get_instance().get_logging_priority(),

--- a/modules/EventBrowser/EventBrowser/tracker_hit_renderer.cc
+++ b/modules/EventBrowser/EventBrowser/tracker_hit_renderer.cc
@@ -186,7 +186,7 @@ void tracker_hit_renderer::push_calibrated_hits() {
     return;
   }
 
-  const snemo::datamodel::calibrated_data::tracker_hit_collection_type &ct_collection =
+  const snemo::datamodel::TrackerHitHdlCollection &ct_collection =
       calib_data.calibrated_tracker_hits();
 
   if (ct_collection.empty()) {

--- a/modules/EventBrowser/EventBrowser/tracker_hit_renderer.cc
+++ b/modules/EventBrowser/EventBrowser/tracker_hit_renderer.cc
@@ -206,7 +206,7 @@ void tracker_hit_renderer::push_clustered_hits() {
   const auto &tracker_clustered_data =
       event.get<snemo::datamodel::tracker_clustering_data>(io::TCD_LABEL);
 
-  const snemo::datamodel::tracker_clustering_data::solution_col_type &cluster_solutions =
+  const snemo::datamodel::TrackerClusteringSolutionHdlCollection &cluster_solutions =
       tracker_clustered_data.get_solutions();
   for (const auto &cluster_solution : cluster_solutions) {
     // Get current tracker solution:
@@ -219,8 +219,7 @@ void tracker_hit_renderer::push_clustered_hits() {
     }
 
     // Get clusters stored in the current tracker solution:
-    const snemo::datamodel::tracker_clustering_solution::cluster_col_type &clusters =
-        a_solution.get_clusters();
+    const snemo::datamodel::TrackerClusterHdlCollection &clusters = a_solution.get_clusters();
 
     for (auto icluster = clusters.begin(); icluster != clusters.end(); ++icluster) {
       // Get current tracker cluster:
@@ -244,7 +243,7 @@ void tracker_hit_renderer::push_clustered_hits() {
       cluster_properties.update(browser_tracks::COLOR_FLAG, hex_str);
 
       // Get tracker hits stored in the current tracker cluster:
-      const snemo::datamodel::calibrated_tracker_hit::collection_type &hits = a_cluster.get_hits();
+      const snemo::datamodel::TrackerHitHdlCollection &hits = a_cluster.get_hits();
 
       // Make a gradient color starting from color_solution:
       for (const auto &hit : hits) {
@@ -292,7 +291,7 @@ void tracker_hit_renderer::push_fitted_tracks() {
   const auto &tracker_trajectory_data =
       event.get<snemo::datamodel::tracker_trajectory_data>(io::TTD_LABEL);
 
-  const snemo::datamodel::tracker_trajectory_data::solution_col_type &trajectory_solutions =
+  const snemo::datamodel::TrackerTrajectorySolutionHdlCollection &trajectory_solutions =
       tracker_trajectory_data.get_solutions();
   for (const auto &isolution : trajectory_solutions) {
     // Get current tracker trajectory solution:
@@ -309,7 +308,7 @@ void tracker_hit_renderer::push_fitted_tracks() {
 #pragma GCC diagnostic pop
 
     // Get trajectories stored in the current tracker trajectory solution:
-    const snemo::datamodel::tracker_trajectory_solution::trajectory_col_type &trajectories =
+    const snemo::datamodel::TrackerTrajectoryHdlCollection &trajectories =
         a_solution.get_trajectories();
 
     for (const auto &itrajectory : trajectories) {
@@ -365,8 +364,7 @@ void tracker_hit_renderer::push_fitted_tracks() {
         if (a_trajectory.has_cluster()) {
           const snemo::datamodel::tracker_cluster &a_cluster = a_trajectory.get_cluster();
           // Get tracker hits stored in the current tracker cluster:
-          const snemo::datamodel::calibrated_tracker_hit::collection_type &hits =
-              a_cluster.get_hits();
+          const snemo::datamodel::TrackerHitHdlCollection &hits = a_cluster.get_hits();
 
           for (const auto &igg : hits) {
             snemo::datamodel::calibrated_tracker_hit a_gg_hit_copy = igg.get();

--- a/modules/EventBrowser/EventBrowser/visual_track_renderer.cc
+++ b/modules/EventBrowser/EventBrowser/visual_track_renderer.cc
@@ -207,16 +207,16 @@ void visual_track_renderer::push_reconstructed_tracks() {
   const io::event_record &event = _server->get_event();
   const auto &pt_data = event.get<snemo::datamodel::particle_track_data>(io::PTD_LABEL);
 
-  if (!pt_data.has_particles()) {
+  if (!pt_data.hasParticles()) {
     DT_LOG_DEBUG(options_manager::get_instance().get_logging_priority(),
                  "Event has no reconstructed particles");
     return;
   }
 
   // Show non-associated calorimeters
-  if (pt_data.has_non_associated_calorimeters()) {
+  if (pt_data.hasIsolatedCalorimeters()) {
     const snemo::datamodel::calibrated_calorimeter_hit::collection_type &calos =
-        pt_data.get_non_associated_calorimeters();
+        pt_data.isolatedCalorimeters();
     for (const auto &calo : calos) {
       const snemo::datamodel::calibrated_calorimeter_hit &a_calo = calo.get();
       const geomtools::geom_id &a_calo_gid = a_calo.get_geom_id();
@@ -244,9 +244,7 @@ void visual_track_renderer::push_reconstructed_tracks() {
                  "No calorimeter hits unassociated to particle track");
   }
 
-  const snemo::datamodel::particle_track_data::particle_collection_type &particles =
-      pt_data.get_particles();
-  for (const auto &particle : particles) {
+  for (const auto &particle : pt_data.particles()) {
     const snemo::datamodel::particle_track &a_particle = particle.get();
 
     if (a_particle.get_auxiliaries().has_key(browser_tracks::CHECKED_FLAG) &&

--- a/modules/EventBrowser/EventBrowser/visual_track_renderer.cc
+++ b/modules/EventBrowser/EventBrowser/visual_track_renderer.cc
@@ -253,13 +253,13 @@ void visual_track_renderer::push_reconstructed_tracks() {
 
     // Get color from charge
     size_t color = 0;
-    if (a_particle.get_charge() == snemo::datamodel::particle_track::neutral) {
+    if (a_particle.get_charge() == snemo::datamodel::particle_track::NEUTRAL) {
       color = style_manager::get_instance().get_particle_color("gamma");
-    } else if (a_particle.get_charge() == snemo::datamodel::particle_track::negative) {
+    } else if (a_particle.get_charge() == snemo::datamodel::particle_track::NEGATIVE) {
       color = style_manager::get_instance().get_particle_color("electron");
-    } else if (a_particle.get_charge() == snemo::datamodel::particle_track::positive) {
+    } else if (a_particle.get_charge() == snemo::datamodel::particle_track::POSITIVE) {
       color = style_manager::get_instance().get_particle_color("positron");
-    } else if (a_particle.get_charge() == snemo::datamodel::particle_track::undefined) {
+    } else if (a_particle.get_charge() == snemo::datamodel::particle_track::UNDEFINED) {
       color = style_manager::get_instance().get_particle_color("alpha");
     }
 
@@ -285,7 +285,7 @@ void visual_track_renderer::push_reconstructed_tracks() {
       }  // end of vertex list
 
       // Gamma tracks
-      if (a_particle.get_charge() == snemo::datamodel::particle_track::neutral) {
+      if (a_particle.get_charge() == snemo::datamodel::particle_track::NEUTRAL) {
         geomtools::polyline_type vtces;
         for (const auto &ivtx : vtx) {
           vtces.push_back(ivtx.get().get_position());

--- a/modules/EventBrowser/EventBrowser/visual_track_renderer.cc
+++ b/modules/EventBrowser/EventBrowser/visual_track_renderer.cc
@@ -215,8 +215,7 @@ void visual_track_renderer::push_reconstructed_tracks() {
 
   // Show non-associated calorimeters
   if (pt_data.hasIsolatedCalorimeters()) {
-    const snemo::datamodel::calibrated_calorimeter_hit::collection_type &calos =
-        pt_data.isolatedCalorimeters();
+    const snemo::datamodel::CalorimeterHitHdlCollection &calos = pt_data.isolatedCalorimeters();
     for (const auto &calo : calos) {
       const snemo::datamodel::calibrated_calorimeter_hit &a_calo = calo.get();
       const geomtools::geom_id &a_calo_gid = a_calo.get_geom_id();
@@ -309,7 +308,7 @@ void visual_track_renderer::push_reconstructed_tracks() {
 
     // Show associated calorimeters
     if (a_particle.has_associated_calorimeter_hits()) {
-      const snemo::datamodel::calibrated_calorimeter_hit::collection_type &calos =
+      const snemo::datamodel::CalorimeterHitHdlCollection &calos =
           a_particle.get_associated_calorimeter_hits();
       for (const auto &calo : calos) {
         const snemo::datamodel::calibrated_calorimeter_hit &a_calo = calo.get();

--- a/modules/GammaClustering/GammaClustering/gamma_clustering_driver.cc
+++ b/modules/GammaClustering/GammaClustering/gamma_clustering_driver.cc
@@ -115,7 +115,7 @@ int gamma_clustering_driver::_process_algo(
     auto hPT = datatools::make_handle<snemo::datamodel::particle_track>();
     ptd_.insertParticle(hPT);
     hPT->set_track_id(ptd_.numberOfParticles());
-    hPT->set_charge(snemo::datamodel::particle_track::neutral);
+    hPT->set_charge(snemo::datamodel::particle_track::NEUTRAL);
 
     for (const auto& j : a_cluster) {
       const snemo::datamodel::calibrated_calorimeter_hit& a_calo_hit = *(j.second);

--- a/modules/GammaClustering/GammaClustering/gamma_clustering_driver.cc
+++ b/modules/GammaClustering/GammaClustering/gamma_clustering_driver.cc
@@ -166,8 +166,8 @@ int gamma_clustering_driver::_process_algo(
 
 void gamma_clustering_driver::_get_geometrical_neighbours(
     const snemo::datamodel::calibrated_calorimeter_hit& hit_,
-    const snemo::datamodel::calibrated_data::calorimeter_hit_collection_type& hits_,
-    cluster_type& cluster_, gid_list_type& registered_calos_) const {
+    const snemo::datamodel::CalorimeterHitHdlCollection& hits_, cluster_type& cluster_,
+    gid_list_type& registered_calos_) const {
   const geomtools::geom_id& a_gid = hit_.get_geom_id();
 
   // If already clustered then skip it

--- a/modules/GammaClustering/GammaClustering/gamma_clustering_driver.cc
+++ b/modules/GammaClustering/GammaClustering/gamma_clustering_driver.cc
@@ -113,8 +113,8 @@ int gamma_clustering_driver::_process_algo(
   // Set new particles within 'particle track data' container
   for (const auto& a_cluster : the_reconstructed_gammas) {
     auto hPT = datatools::make_handle<snemo::datamodel::particle_track>();
-    ptd_.add_particle(hPT);
-    hPT->set_track_id(ptd_.get_number_of_particles());
+    ptd_.insertParticle(hPT);
+    hPT->set_track_id(ptd_.numberOfParticles());
     hPT->set_charge(snemo::datamodel::particle_track::neutral);
 
     for (const auto& j : a_cluster) {

--- a/modules/GammaClustering/GammaClustering/gamma_clustering_driver.h
+++ b/modules/GammaClustering/GammaClustering/gamma_clustering_driver.h
@@ -50,8 +50,7 @@ class gamma_clustering_driver : public ::snemo::processing::base_gamma_builder {
   typedef std::vector<geomtools::geom_id> gid_list_type;
 
   /// Typedef for time ordered calorimeter hits aka. gamma cluster
-  typedef std::map<double, const snemo::datamodel::calibrated_data::calorimeter_hit_handle_type>
-      cluster_type;
+  typedef std::map<double, const snemo::datamodel::CalorimeterHitHdl> cluster_type;
 
   /// Typedef for collection of clusters
   typedef std::vector<cluster_type> cluster_collection_type;
@@ -85,8 +84,8 @@ class gamma_clustering_driver : public ::snemo::processing::base_gamma_builder {
   /// Get calorimeter neighbours given teh current calorimeter hit
   virtual void _get_geometrical_neighbours(
       const snemo::datamodel::calibrated_calorimeter_hit& hit_,
-      const snemo::datamodel::calibrated_data::calorimeter_hit_collection_type& hits_,
-      cluster_type& cluster_, gid_list_type& registered_calos_) const;
+      const snemo::datamodel::CalorimeterHitHdlCollection& hits_, cluster_type& cluster_,
+      gid_list_type& registered_calos_) const;
 
   /// Split calorimeter cluster given a cluster time range value
   virtual void _get_time_neighbours(cluster_type& cluster_,

--- a/modules/GammaClustering/GammaClustering/gamma_clustering_module.cc
+++ b/modules/GammaClustering/GammaClustering/gamma_clustering_module.cc
@@ -65,15 +65,13 @@ class gamma_clustering_module {
 gamma_clustering_module::gamma_clustering_module(const falaise::property_set& ps,
                                                  datatools::service_manager& services)
     : geoSVC_{services},
-      PTD_tag_{ps.get<std::string>(
-          "PTD_label", snemo::datamodel::data_info::default_particle_track_data_label())} {
+      PTD_tag_{ps.get<std::string>("PTD_label", snedm::labels::particle_track_data())} {
   algo_.set_geometry_manager(*(geoSVC_.operator->()));
   algo_.initialize(ps);
 }
 
 falaise::processing::status gamma_clustering_module::process(datatools::things& event) {
-  auto& ptd =
-      snemo::datamodel::getOrAddToEvent<snemo::datamodel::particle_track_data>(PTD_tag_, event);
+  auto& ptd = snedm::getOrAddToEvent<snemo::datamodel::particle_track_data>(PTD_tag_, event);
   algo_.process(ptd.get_non_associated_calorimeters(), ptd);
   return falaise::processing::status::PROCESS_SUCCESS;
 }

--- a/modules/GammaClustering/GammaClustering/gamma_clustering_module.cc
+++ b/modules/GammaClustering/GammaClustering/gamma_clustering_module.cc
@@ -72,7 +72,7 @@ gamma_clustering_module::gamma_clustering_module(const falaise::property_set& ps
 
 falaise::processing::status gamma_clustering_module::process(datatools::things& event) {
   auto& ptd = snedm::getOrAddToEvent<snemo::datamodel::particle_track_data>(PTD_tag_, event);
-  algo_.process(ptd.get_non_associated_calorimeters(), ptd);
+  algo_.process(ptd.isolatedCalorimeters(), ptd);
   return falaise::processing::status::PROCESS_SUCCESS;
 }
 

--- a/modules/GammaClustering/GammaClustering/test/test_gamma_clustering_driver.cxx
+++ b/modules/GammaClustering/GammaClustering/test/test_gamma_clustering_driver.cxx
@@ -17,7 +17,7 @@
 
 #include <GammaClustering/gamma_clustering_driver.h>
 
-void generate_hits(snemo::datamodel::calibrated_data::calorimeter_hit_collection_type& hits_) {
+void generate_hits(snemo::datamodel::CalorimeterHitHdlCollection& hits_) {
   namespace sdm = snemo::datamodel;
 
   // Fake cluster
@@ -86,7 +86,7 @@ int main(int argc, char* argv[]) {
     std::clog << "Use GC driver with default configuration" << std::endl;
     {
       // Fake calorimeter hits :
-      sdm::calibrated_data::calorimeter_hit_collection_type hits;
+      sdm::CalorimeterHitHdlCollection hits;
       generate_hits(hits);
       // Particle track data bank :
       sdm::particle_track_data PTD;
@@ -102,7 +102,7 @@ int main(int argc, char* argv[]) {
     std::clog << "Use GC driver only in 'cluster' mode" << std::endl;
     {
       // Fake calorimeter hits :
-      sdm::calibrated_data::calorimeter_hit_collection_type hits;
+      sdm::CalorimeterHitHdlCollection hits;
       generate_hits(hits);
       // Particle track data bank :
       sdm::particle_track_data PTD;

--- a/modules/GammaTracking/GammaTracking/gamma_tracking_driver.cc
+++ b/modules/GammaTracking/GammaTracking/gamma_tracking_driver.cc
@@ -124,8 +124,7 @@ int gamma_tracking_driver::_process_algo(
     // List of associated calorimeters
     for (const int calo_id : a_list) {
       // Set calorimeter association
-      const snemo::datamodel::calibrated_calorimeter_hit::collection_type& cch =
-          ptd_.isolatedCalorimeters();
+      const snemo::datamodel::CalorimeterHitHdlCollection& cch = ptd_.isolatedCalorimeters();
       geomtools::base_hit::has_hit_id_predicate hit_pred(calo_id);
       datatools::mother_to_daughter_predicate<geomtools::base_hit,
                                               snemo::datamodel::calibrated_calorimeter_hit>

--- a/modules/GammaTracking/GammaTracking/gamma_tracking_driver.cc
+++ b/modules/GammaTracking/GammaTracking/gamma_tracking_driver.cc
@@ -118,7 +118,7 @@ int gamma_tracking_driver::_process_algo(
   for (const auto& a_list : gamma_tracks) {
     auto hPT = datatools::make_handle<snemo::datamodel::particle_track>();
     hPT->set_track_id(ptd_.numberOfParticles());
-    hPT->set_charge(snemo::datamodel::particle_track::neutral);
+    hPT->set_charge(snemo::datamodel::particle_track::NEUTRAL);
     ptd_.insertParticle(hPT);
 
     // List of associated calorimeters

--- a/modules/GammaTracking/GammaTracking/gamma_tracking_driver.cc
+++ b/modules/GammaTracking/GammaTracking/gamma_tracking_driver.cc
@@ -117,15 +117,15 @@ int gamma_tracking_driver::_process_algo(
 
   for (const auto& a_list : gamma_tracks) {
     auto hPT = datatools::make_handle<snemo::datamodel::particle_track>();
-    hPT->set_track_id(ptd_.get_number_of_particles());
+    hPT->set_track_id(ptd_.numberOfParticles());
     hPT->set_charge(snemo::datamodel::particle_track::neutral);
-    ptd_.add_particle(hPT);
+    ptd_.insertParticle(hPT);
 
     // List of associated calorimeters
     for (const int calo_id : a_list) {
       // Set calorimeter association
       const snemo::datamodel::calibrated_calorimeter_hit::collection_type& cch =
-          ptd_.get_non_associated_calorimeters();
+          ptd_.isolatedCalorimeters();
       geomtools::base_hit::has_hit_id_predicate hit_pred(calo_id);
       datatools::mother_to_daughter_predicate<geomtools::base_hit,
                                               snemo::datamodel::calibrated_calorimeter_hit>

--- a/modules/GammaTracking/GammaTracking/gamma_tracking_module.cc
+++ b/modules/GammaTracking/GammaTracking/gamma_tracking_module.cc
@@ -73,7 +73,7 @@ gamma_tracking_module::gamma_tracking_module(const falaise::property_set& ps,
 falaise::processing::status gamma_tracking_module::process(datatools::things& event) {
   auto& ptd = snedm::getOrAddToEvent<snemo::datamodel::particle_track_data>(PTD_tag_, event);
 
-  algo_.process(ptd.get_non_associated_calorimeters(), ptd);
+  algo_.process(ptd.isolatedCalorimeters(), ptd);
   return falaise::processing::status::PROCESS_SUCCESS;
 }
 

--- a/modules/GammaTracking/GammaTracking/gamma_tracking_module.cc
+++ b/modules/GammaTracking/GammaTracking/gamma_tracking_module.cc
@@ -65,15 +65,14 @@ class gamma_tracking_module {
 gamma_tracking_module::gamma_tracking_module(const falaise::property_set& ps,
                                              datatools::service_manager& services)
     : geoSVC_{services},
-      PTD_tag_{ps.get<std::string>(
-          "PTD_label", snemo::datamodel::data_info::default_particle_track_data_label())} {
+      PTD_tag_{ps.get<std::string>("PTD_label", snedm::labels::particle_track_data())} {
   algo_.set_geometry_manager(*(geoSVC_.operator->()));
   algo_.initialize(ps);
 }
 
 falaise::processing::status gamma_tracking_module::process(datatools::things& event) {
-  auto& ptd =
-      snemo::datamodel::getOrAddToEvent<snemo::datamodel::particle_track_data>(PTD_tag_, event);
+  auto& ptd = snedm::getOrAddToEvent<snemo::datamodel::particle_track_data>(PTD_tag_, event);
+
   algo_.process(ptd.get_non_associated_calorimeters(), ptd);
   return falaise::processing::status::PROCESS_SUCCESS;
 }

--- a/modules/MockTrackerClusterizer/MockTrackerClustering/mock_tracker_clustering_driver.cc
+++ b/modules/MockTrackerClusterizer/MockTrackerClustering/mock_tracker_clustering_driver.cc
@@ -34,14 +34,12 @@ mock_tracker_clustering_driver::mock_tracker_clustering_driver()
   _max_row_distance_ = 2;
   _max_layer_distance_ = 2;
   _max_sum_distance_ = 0;
-  return;
 }
 
 mock_tracker_clustering_driver::~mock_tracker_clustering_driver() {
   if (is_initialized()) {
     this->mock_tracker_clustering_driver::reset();
   }
-  return;
 }
 
 // Initialize the driver through configuration properties
@@ -71,7 +69,6 @@ void mock_tracker_clustering_driver::initialize(const datatools::properties& set
               "At least one maximum layer/row/sum distance must be non zero !");
 
   _set_initialized(true);
-  return;
 }
 
 // Reset the clusterizer
@@ -83,20 +80,7 @@ void mock_tracker_clustering_driver::reset() {
   _max_layer_distance_ = 2;
   _max_sum_distance_ = 0;
   this->snemo::processing::base_tracker_clusterizer::_reset();
-  return;
 }
-
-// int mock_tracker_clustering_driver::_prepare_process (const
-// base_tracker_clusterizer::hit_collection_type & gg_hits_,
-//                                                       const
-//                                                       base_tracker_clusterizer::calo_hit_collection_type
-//                                                       & calo_hits_,
-//                                                       snemo::datamodel::tracker_clustering_data &
-//                                                       clustering_)
-// {
-//   base_tracker_clusterizer::_prepare_process(gg_hits_, calo_hits_, clustering_);
-//   return 0;
-// }
 
 // Main clustering method
 int mock_tracker_clustering_driver::_process_algo(
@@ -106,10 +90,10 @@ int mock_tracker_clustering_driver::_process_algo(
   namespace sdm = snemo::datamodel;
 
   // Filling a unique tracker clustering solution:
-  sdm::tracker_clustering_solution::handle_type htcs(new sdm::tracker_clustering_solution);
+  sdm::TrackerClusteringSolutionHdl htcs(new sdm::tracker_clustering_solution);
   sdm::tracker_clustering_solution& tc_solution = htcs.grab();
   tc_solution.get_auxiliaries().update_string(sdm::tracker_clustering_data::clusterizer_id_key(),
-                                               MTC_ID);
+                                              MTC_ID);
 
   // GG hit loop :
   sdm::calibrated_tracker_hit previous_gg_hit = gg_hits_.begin()->get();
@@ -130,15 +114,14 @@ int mock_tracker_clustering_driver::_process_algo(
     if (!are_neighbours(a_gg_hit.get_geom_id(), previous_gg_hit.get_geom_id())) {
       DT_LOG_TRACE(get_logging_priority(), "New track found !");
       // Create a tracker cluster handle:
-      sdm::tracker_cluster::handle_type ht_cluster(new sdm::tracker_cluster);
+      sdm::TrackerClusterHdl ht_cluster(new sdm::tracker_cluster);
       ht_cluster.grab().set_cluster_id(tc_solution.get_clusters().size());
       tc_solution.get_clusters().push_back(ht_cluster);
     }
 
     // Continue to fill the current track
-    sdm::tracker_cluster::handle_type& cluster_handle = tc_solution.get_clusters().back();
-    DT_LOG_TRACE(get_logging_priority(),
-                 "Current cluster id " << cluster_handle->get_cluster_id());
+    sdm::TrackerClusterHdl& cluster_handle = tc_solution.get_clusters().back();
+    DT_LOG_TRACE(get_logging_priority(), "Current cluster id " << cluster_handle->get_cluster_id());
     cluster_handle->get_hits().push_back(*igg);
     // hits_ids.insert(a_gg_hit.get_hit_id());
     previous_gg_hit = a_gg_hit;

--- a/modules/MockTrackerClusterizer/MockTrackerClustering/mock_tracker_clustering_driver.cc
+++ b/modules/MockTrackerClusterizer/MockTrackerClustering/mock_tracker_clustering_driver.cc
@@ -92,8 +92,6 @@ int mock_tracker_clustering_driver::_process_algo(
   // Filling a unique tracker clustering solution:
   sdm::TrackerClusteringSolutionHdl htcs(new sdm::tracker_clustering_solution);
   sdm::tracker_clustering_solution& tc_solution = htcs.grab();
-  tc_solution.get_auxiliaries().update_string(sdm::tracker_clustering_data::clusterizer_id_key(),
-                                              MTC_ID);
 
   // GG hit loop :
   sdm::calibrated_tracker_hit previous_gg_hit = gg_hits_.begin()->get();
@@ -122,19 +120,19 @@ int mock_tracker_clustering_driver::_process_algo(
     // Continue to fill the current track
     sdm::TrackerClusterHdl& cluster_handle = tc_solution.get_clusters().back();
     DT_LOG_TRACE(get_logging_priority(), "Current cluster id " << cluster_handle->get_cluster_id());
-    cluster_handle->get_hits().push_back(*igg);
+    cluster_handle->hits().push_back(*igg);
     // hits_ids.insert(a_gg_hit.get_hit_id());
     previous_gg_hit = a_gg_hit;
   }
 
   // Set a unique Id to this solution:
-  tc_solution.set_solution_id(clustering_.get_number_of_solutions());
+  tc_solution.set_solution_id(clustering_.size());
 
   if (get_logging_priority() >= datatools::logger::PRIO_TRACE)
     tc_solution.tree_dump(std::clog, "Mock Tracker Clustering solution: ", "DEVEL: ");
 
   // Add the solution as the default one:
-  clustering_.add_solution(htcs, true);
+  clustering_.push_back(htcs, true);
 
   return 0;
 }

--- a/modules/MockTrackerClusterizer/MockTrackerClustering/mock_tracker_clustering_module.cc
+++ b/modules/MockTrackerClusterizer/MockTrackerClustering/mock_tracker_clustering_module.cc
@@ -204,11 +204,11 @@ dpp::base_module::process_status mock_tracker_clustering_module::process(
     ptr_cluster_data = &(data_record_.grab<snemo::datamodel::tracker_clustering_data>(_TCD_label_));
   }
   snemo::datamodel::tracker_clustering_data& the_clustering_data = *ptr_cluster_data;
-  if (the_clustering_data.has_solutions()) {
+  if (!the_clustering_data.empty()) {
     DT_THROW_IF(abort_at_former_output, std::logic_error,
                 "Already has processed tracker clustering data !");
     if (!preserve_former_output) {
-      the_clustering_data.reset();
+      the_clustering_data.clear();
     }
   }
 
@@ -285,8 +285,7 @@ DOCD_CLASS_IMPLEMENT_LOAD_BEGIN(snemo::reconstruction::mock_tracker_clustering_m
         .set_long_description(
             "This is the name of the bank to be used as   \n"
             "the sink of output clusters of tracker hits. \n")
-        .set_default_value_string(
-            snedm::labels::tracker_clustering_data())
+        .set_default_value_string(snedm::labels::tracker_clustering_data())
         .add_example(
             "Use an alternative name for the   \n"
             "'tracker clustering data' bank::  \n"

--- a/modules/MockTrackerClusterizer/MockTrackerClustering/mock_tracker_clustering_module.cc
+++ b/modules/MockTrackerClusterizer/MockTrackerClustering/mock_tracker_clustering_module.cc
@@ -117,7 +117,7 @@ void mock_tracker_clustering_module::initialize(const datatools::properties& set
   }
   // Default label:
   if (_CD_label_.empty()) {
-    _CD_label_ = snemo::datamodel::data_info::default_calibrated_data_label();
+    _CD_label_ = snedm::labels::calibrated_data();
   }
 
   if (_TCD_label_.empty()) {
@@ -127,7 +127,7 @@ void mock_tracker_clustering_module::initialize(const datatools::properties& set
   }
   // Default label:
   if (_TCD_label_.empty()) {
-    _TCD_label_ = snemo::datamodel::data_info::default_tracker_clustering_data_label();
+    _TCD_label_ = snedm::labels::tracker_clustering_data();
   }
 
   // Geometry manager :
@@ -266,7 +266,7 @@ DOCD_CLASS_IMPLEMENT_LOAD_BEGIN(snemo::reconstruction::mock_tracker_clustering_m
         .set_long_description(
             "This is the name of the bank to be used \n"
             "as the source of input tracker hits.    \n")
-        .set_default_value_string(snemo::datamodel::data_info::default_calibrated_data_label())
+        .set_default_value_string(snedm::labels::calibrated_data())
         .add_example(
             "Use an alternative name for the \n"
             "'calibrated data' bank::        \n"
@@ -286,7 +286,7 @@ DOCD_CLASS_IMPLEMENT_LOAD_BEGIN(snemo::reconstruction::mock_tracker_clustering_m
             "This is the name of the bank to be used as   \n"
             "the sink of output clusters of tracker hits. \n")
         .set_default_value_string(
-            snemo::datamodel::data_info::default_tracker_clustering_data_label())
+            snedm::labels::tracker_clustering_data())
         .add_example(
             "Use an alternative name for the   \n"
             "'tracker clustering data' bank::  \n"

--- a/modules/MockTrackerClusterizer/MockTrackerClustering/mock_tracker_clustering_module.cc
+++ b/modules/MockTrackerClusterizer/MockTrackerClustering/mock_tracker_clustering_module.cc
@@ -225,14 +225,8 @@ dpp::base_module::process_status mock_tracker_clustering_module::process(
 void mock_tracker_clustering_module::_process(
     const snemo::datamodel::calibrated_data& calib_data_,
     snemo::datamodel::tracker_clustering_data& clustering_data_) {
-  DT_LOG_TRACE(get_logging_priority(), "Entering...");
-
   // Process the clusterizer driver :
-  _driver_.get()->process(calib_data_.calibrated_tracker_hits(),
-                          calib_data_.calibrated_calorimeter_hits(), clustering_data_);
-
-  DT_LOG_TRACE(get_logging_priority(), "Exiting.");
-  return;
+  _driver_->process(calib_data_.tracker_hits(), calib_data_.calorimeter_hits(), clustering_data_);
 }
 
 }  // namespace reconstruction

--- a/modules/MockTrackerClusterizer/MockTrackerClustering/test/test_mock_tracker_clustering_module.cxx
+++ b/modules/MockTrackerClusterizer/MockTrackerClustering/test/test_mock_tracker_clustering_module.cxx
@@ -92,8 +92,7 @@ int main(int argc_, char** argv_) {
       datatools::things eventRecord;
       snemo::datamodel::calibrated_data& CD =
           eventRecord.add<snemo::datamodel::calibrated_data>("CD");
-      snemo::datamodel::calibrated_data::tracker_hit_collection_type& gghits =
-          CD.calibrated_tracker_hits();
+      snemo::datamodel::TrackerHitHdlCollection& gghits = CD.calibrated_tracker_hits();
       generate_gg_hits(*gg_locator, gghits);
       dpp::base_module::process_status status = MTCmod.process(eventRecord);
       if (status != 0) {

--- a/modules/MockTrackerClusterizer/MockTrackerClustering/test/test_mock_tracker_clustering_module.cxx
+++ b/modules/MockTrackerClusterizer/MockTrackerClustering/test/test_mock_tracker_clustering_module.cxx
@@ -92,7 +92,7 @@ int main(int argc_, char** argv_) {
       datatools::things eventRecord;
       snemo::datamodel::calibrated_data& CD =
           eventRecord.add<snemo::datamodel::calibrated_data>("CD");
-      snemo::datamodel::TrackerHitHdlCollection& gghits = CD.calibrated_tracker_hits();
+      snemo::datamodel::TrackerHitHdlCollection& gghits = CD.tracker_hits();
       generate_gg_hits(*gg_locator, gghits);
       dpp::base_module::process_status status = MTCmod.process(eventRecord);
       if (status != 0) {

--- a/modules/MockTrackerClusterizer/MockTrackerClustering/test/utilities.cc
+++ b/modules/MockTrackerClusterizer/MockTrackerClustering/test/utilities.cc
@@ -165,11 +165,10 @@ void display_event(const snemo::geometry::gg_locator& ggloc_,
     const sdm::tracker_clustering_solution& tcd_sol = tcd_.get_default_solution();
     tcd_sol.tree_dump(std::cerr, "Clustering solution: ", "DEVEL: ");
     for (int i = 0; i < (int)tcd_sol.get_clusters().size(); i++) {
-      const sdm::tracker_clustering_solution::cluster_handle_type& hcluster =
-          tcd_sol.get_clusters()[i];
+      const sdm::TrackerClusterHdl& hcluster = tcd_sol.get_clusters()[i];
       const sdm::tracker_cluster& cluster = hcluster.get();
       // cluster.tree_dump(std::cerr, "Cluster: ", "DEVEL: ");
-      const sdm::calibrated_tracker_hit::collection_type& clhits = cluster.get_hits();
+      const sdm::TrackerHitHdlCollection& clhits = cluster.get_hits();
       if (i == 0) CC.set_color_code(geomtools::color::COLOR_RED);
       if (i == 1) CC.set_color_code(geomtools::color::COLOR_GREEN);
       if (i == 2) CC.set_color_code(geomtools::color::COLOR_MAGENTA);
@@ -186,9 +185,8 @@ void display_event(const snemo::geometry::gg_locator& ggloc_,
         // double r  = clhit.get_r();
         // double er = clhit.get_sigma_r();
         geomtools::vector_3d hit_pos(x, y, z);
-        geomtools::gnuplot_draw::draw_box(tmp_file.out(), hit_pos, identity,
-                                          ggloc_.cellDiameter(), ggloc_.cellDiameter(),
-                                          2 * ez);
+        geomtools::gnuplot_draw::draw_box(tmp_file.out(), hit_pos, identity, ggloc_.cellDiameter(),
+                                          ggloc_.cellDiameter(), 2 * ez);
       }
     }
     CC.set_color_code(geomtools::color::COLOR_BLACK);
@@ -203,9 +201,8 @@ void display_event(const snemo::geometry::gg_locator& ggloc_,
       // double r  = uclhit.get_r();
       // double er = uclhit.get_sigma_r();
       geomtools::vector_3d hit_pos(x, y, z);
-      geomtools::gnuplot_draw::draw_box(tmp_file.out(), hit_pos, identity,
-                                        ggloc_.cellDiameter(), ggloc_.cellDiameter(),
-                                        2 * ez);
+      geomtools::gnuplot_draw::draw_box(tmp_file.out(), hit_pos, identity, ggloc_.cellDiameter(),
+                                        ggloc_.cellDiameter(), 2 * ez);
     }
   }
 

--- a/modules/MockTrackerClusterizer/MockTrackerClustering/test/utilities.cc
+++ b/modules/MockTrackerClusterizer/MockTrackerClustering/test/utilities.cc
@@ -156,14 +156,14 @@ void display_event(const snemo::geometry::gg_locator& ggloc_,
                                        hit_pos + geomtools::vector_3d(0, 0, -ez));
   }
 
-  if (tcd_.has_default_solution()) {
-    const sdm::tracker_clustering_solution& tcd_sol = tcd_.get_default_solution();
+  if (tcd_.has_default()) {
+    const sdm::tracker_clustering_solution& tcd_sol = tcd_.get_default();
     tcd_sol.tree_dump(std::cerr, "Clustering solution: ", "DEVEL: ");
     for (int i = 0; i < (int)tcd_sol.get_clusters().size(); i++) {
       const sdm::TrackerClusterHdl& hcluster = tcd_sol.get_clusters()[i];
       const sdm::tracker_cluster& cluster = hcluster.get();
       // cluster.tree_dump(std::cerr, "Cluster: ", "DEVEL: ");
-      const sdm::TrackerHitHdlCollection& clhits = cluster.get_hits();
+      const sdm::TrackerHitHdlCollection& clhits = cluster.hits();
       if (i == 0) CC.set_color_code(geomtools::color::COLOR_RED);
       if (i == 1) CC.set_color_code(geomtools::color::COLOR_GREEN);
       if (i == 2) CC.set_color_code(geomtools::color::COLOR_MAGENTA);

--- a/modules/MockTrackerClusterizer/MockTrackerClustering/test/utilities.cc
+++ b/modules/MockTrackerClusterizer/MockTrackerClustering/test/utilities.cc
@@ -13,11 +13,10 @@
 #include <geomtools/manager.h>
 
 void generate_gg_hits(const snemo::geometry::gg_locator& ggloc_,
-                      snemo::datamodel::calibrated_data::tracker_hit_collection_type& gghits_) {
+                      snemo::datamodel::TrackerHitHdlCollection& gghits_) {
   // A fake track:
   for (int i = 0; i < 9; i++) {
-    snemo::datamodel::calibrated_data::tracker_hit_handle_type hgghit(
-        new snemo::datamodel::calibrated_tracker_hit);
+    snemo::datamodel::TrackerHitHdl hgghit(new snemo::datamodel::calibrated_tracker_hit);
     snemo::datamodel::calibrated_tracker_hit& gghit = hgghit.grab();
     gghit.set_hit_id(i);
     gghit.grab_geom_id().set_type(1204);
@@ -38,8 +37,7 @@ void generate_gg_hits(const snemo::geometry::gg_locator& ggloc_,
 
   // A fake track:
   for (int i = 0; i < 4; i++) {
-    snemo::datamodel::calibrated_data::tracker_hit_handle_type hgghit(
-        new snemo::datamodel::calibrated_tracker_hit);
+    snemo::datamodel::TrackerHitHdl hgghit(new snemo::datamodel::calibrated_tracker_hit);
     snemo::datamodel::calibrated_tracker_hit& gghit = hgghit.grab();
     gghit.set_hit_id(i);
     gghit.grab_geom_id().set_type(1204);
@@ -60,8 +58,7 @@ void generate_gg_hits(const snemo::geometry::gg_locator& ggloc_,
 
   // A fake track:
   for (int i = 0; i < 3; i++) {
-    snemo::datamodel::calibrated_data::tracker_hit_handle_type hgghit(
-        new snemo::datamodel::calibrated_tracker_hit);
+    snemo::datamodel::TrackerHitHdl hgghit(new snemo::datamodel::calibrated_tracker_hit);
     snemo::datamodel::calibrated_tracker_hit& gghit = hgghit.grab();
     gghit.set_hit_id(i);
     gghit.grab_geom_id().set_type(1204);
@@ -82,8 +79,7 @@ void generate_gg_hits(const snemo::geometry::gg_locator& ggloc_,
 
   // A fake track:
   for (int i = 0; i < 6; i++) {
-    snemo::datamodel::calibrated_data::tracker_hit_handle_type hgghit(
-        new snemo::datamodel::calibrated_tracker_hit);
+    snemo::datamodel::TrackerHitHdl hgghit(new snemo::datamodel::calibrated_tracker_hit);
     snemo::datamodel::calibrated_tracker_hit& gghit = hgghit.grab();
     gghit.set_hit_id(i);
     gghit.grab_geom_id().set_type(1204);
@@ -104,8 +100,7 @@ void generate_gg_hits(const snemo::geometry::gg_locator& ggloc_,
 
   // Add random fake hits
   for (int i = 0; i < 3; i++) {
-    snemo::datamodel::calibrated_data::tracker_hit_handle_type hgghit(
-        new snemo::datamodel::calibrated_tracker_hit);
+    snemo::datamodel::TrackerHitHdl hgghit(new snemo::datamodel::calibrated_tracker_hit);
     snemo::datamodel::calibrated_tracker_hit& gghit = hgghit.grab();
     gghit.set_hit_id(i);
     gghit.grab_geom_id().set_type(1204);
@@ -127,7 +122,7 @@ void generate_gg_hits(const snemo::geometry::gg_locator& ggloc_,
 }
 
 void display_event(const snemo::geometry::gg_locator& ggloc_,
-                   const snemo::datamodel::calibrated_data::tracker_hit_collection_type& gghits_,
+                   const snemo::datamodel::TrackerHitHdlCollection& gghits_,
                    const snemo::datamodel::tracker_clustering_data& tcd_) {
   namespace sdm = snemo::datamodel;
   datatools::temp_file tmp_file;
@@ -145,7 +140,7 @@ void display_event(const snemo::geometry::gg_locator& ggloc_,
   geomtools::color::context& CC = geomtools::gnuplot_draw::color_context();
 
   for (int i = 0; i < (int)gghits_.size(); i++) {
-    const sdm::calibrated_data::tracker_hit_handle_type& hgghit = gghits_[i];
+    const sdm::TrackerHitHdl& hgghit = gghits_[i];
     const sdm::calibrated_tracker_hit& gghit = hgghit.get();
     double x = gghit.get_x();
     double y = gghit.get_y();
@@ -176,7 +171,7 @@ void display_event(const snemo::geometry::gg_locator& ggloc_,
       if (i == 4) CC.set_color_code(geomtools::color::COLOR_ORANGE);
       if (i > 4) CC.set_color_code(geomtools::color::COLOR_BLUE);
       for (int j = 0; j < (int)clhits.size(); j++) {
-        const sdm::calibrated_data::tracker_hit_handle_type& hclhit = clhits[j];
+        const sdm::TrackerHitHdl& hclhit = clhits[j];
         const sdm::calibrated_tracker_hit& clhit = hclhit.get();
         double x = clhit.get_x();
         double y = clhit.get_y();
@@ -191,8 +186,7 @@ void display_event(const snemo::geometry::gg_locator& ggloc_,
     }
     CC.set_color_code(geomtools::color::COLOR_BLACK);
     for (int j = 0; j < (int)tcd_sol.get_unclustered_hits().size(); j++) {
-      const sdm::calibrated_data::tracker_hit_handle_type& huclhit =
-          tcd_sol.get_unclustered_hits()[j];
+      const sdm::TrackerHitHdl& huclhit = tcd_sol.get_unclustered_hits()[j];
       const sdm::calibrated_tracker_hit& uclhit = huclhit.get();
       double x = uclhit.get_x();
       double y = uclhit.get_y();

--- a/modules/MockTrackerClusterizer/MockTrackerClustering/test/utilities.h
+++ b/modules/MockTrackerClusterizer/MockTrackerClustering/test/utilities.h
@@ -7,10 +7,10 @@
 #include <falaise/snemo/geometry/gg_locator.h>
 
 void generate_gg_hits(const snemo::geometry::gg_locator& ggloc_,
-                      snemo::datamodel::calibrated_data::tracker_hit_collection_type& gghits_);
+                      snemo::datamodel::TrackerHitHdlCollection& gghits_);
 
 void display_event(const snemo::geometry::gg_locator& ggloc_,
-                   const snemo::datamodel::calibrated_data::tracker_hit_collection_type& gghits_,
+                   const snemo::datamodel::TrackerHitHdlCollection& gghits_,
                    const snemo::datamodel::tracker_clustering_data& tcd_);
 
 #endif  // FALAISE_MOCKTRACKERCLUSTERIZER_PLUGIN_UTILITIES_H

--- a/modules/TrackFit/TrackFit/test/test_trackfit_driver.cxx
+++ b/modules/TrackFit/TrackFit/test/test_trackfit_driver.cxx
@@ -93,7 +93,7 @@ int main(int argc_, char** argv_) {
     // Event loop:
     for (int i = 0; i < 3; i++) {
       std::clog << "Processing event #" << i << "\n";
-      snemo::datamodel::calibrated_data::tracker_hit_collection_type CTH;
+      snemo::datamodel::TrackerHitHdlCollection CTH;
       snemo::datamodel::tracker_clustering_data TCD;
       generate_tcd(*gg_locator, CTH, TCD);
       snemo::datamodel::tracker_trajectory_data TTD;

--- a/modules/TrackFit/TrackFit/test/test_trackfit_tracker_fitting_module.cxx
+++ b/modules/TrackFit/TrackFit/test/test_trackfit_tracker_fitting_module.cxx
@@ -79,10 +79,8 @@ int main() {
     for (int i = 0; i < 3; i++) {
       std::clog << "Processing event #" << i << "\n";
       datatools::things eventRecord;
-      snemo::datamodel::calibrated_data& CD =
-          eventRecord.add<snemo::datamodel::calibrated_data>("CD");
-      snemo::datamodel::calibrated_data::tracker_hit_collection_type& gghits =
-          CD.calibrated_tracker_hits();
+      auto& CD = eventRecord.add<snemo::datamodel::calibrated_data>("CD");
+      snemo::datamodel::calibrated_data::tracker_hit_collection_type& gghits = CD.tracker_hits();
       generate_gg_hits(*gg_locator, gghits);
       dpp::base_module::process_status status = CATmod.process(eventRecord);
       if (status != 0) {

--- a/modules/TrackFit/TrackFit/test/utilities.cc
+++ b/modules/TrackFit/TrackFit/test/utilities.cc
@@ -60,15 +60,14 @@ void generate_tcd(const snemo::geometry::gg_locator &ggloc_,
   }
 
   // A fake clustering solution:
-  snemo::datamodel::tracker_clustering_solution::handle_type htcs(
+  snemo::datamodel::TrackerClusteringSolutionHdl htcs(
       new snemo::datamodel::tracker_clustering_solution);
   snemo::datamodel::tracker_clustering_solution &tcs = htcs.grab();
   tcs.set_solution_id(0);
   tcs.get_auxiliaries().store_flag("mock");
 
   // Add a cluster:
-  snemo::datamodel::tracker_clustering_solution::cluster_handle_type htc0(
-      new snemo::datamodel::tracker_cluster);
+  snemo::datamodel::TrackerClusterHdl htc0(new snemo::datamodel::tracker_cluster);
   snemo::datamodel::tracker_cluster &tc0 = htc0.grab();
   htc0.grab().grab_auxiliaries().store_flag("mock");
   htc0.grab().set_cluster_id(0);
@@ -104,8 +103,7 @@ void generate_tcd(const snemo::geometry::gg_locator &ggloc_,
   }
 
   // Add another cluster:
-  snemo::datamodel::tracker_clustering_solution::cluster_handle_type htc1(
-      new snemo::datamodel::tracker_cluster);
+  snemo::datamodel::TrackerClusterHdl htc1(new snemo::datamodel::tracker_cluster);
   snemo::datamodel::tracker_cluster &tc1 = htc1.grab();
   htc1.grab().grab_auxiliaries().store_flag("mock");
   htc1.grab().set_cluster_id(1);
@@ -166,8 +164,7 @@ void generate_tcd(const snemo::geometry::gg_locator &ggloc_,
   }
 
   // Yet another cluster:
-  snemo::datamodel::tracker_clustering_solution::cluster_handle_type htc2(
-      new snemo::datamodel::tracker_cluster);
+  snemo::datamodel::TrackerClusterHdl htc2(new snemo::datamodel::tracker_cluster);
   snemo::datamodel::tracker_cluster &tc2 = htc2.grab();
   htc2->grab_auxiliaries().store_flag("mock");
   htc2->set_cluster_id(2);
@@ -267,11 +264,10 @@ void display_event(const snemo::geometry::gg_locator &ggloc_,
     const sdm::tracker_clustering_solution &tcd_sol = tcd_.get_default_solution();
     tcd_sol.tree_dump(std::cerr, "Clustering solution: ", "DEVEL: ");
     for (int i = 0; i < (int)tcd_sol.get_clusters().size(); i++) {
-      const sdm::tracker_clustering_solution::cluster_handle_type &hcluster =
-          tcd_sol.get_clusters()[i];
+      const sdm::TrackerClusterHdl &hcluster = tcd_sol.get_clusters()[i];
       const sdm::tracker_cluster &cluster = hcluster.get();
       // cluster.tree_dump(std::cerr, "Cluster: ", "DEVEL: ");
-      const sdm::calibrated_tracker_hit::collection_type &clhits = cluster.get_hits();
+      const sdm::TrackerHitHdlCollection &clhits = cluster.get_hits();
       if (i == 0) CC.set_color_code(geomtools::color::COLOR_RED);
       if (i == 1) CC.set_color_code(geomtools::color::COLOR_GREEN);
       if (i == 2) CC.set_color_code(geomtools::color::COLOR_MAGENTA);
@@ -288,9 +284,8 @@ void display_event(const snemo::geometry::gg_locator &ggloc_,
         // double r  = clhit.get_r();
         // double er = clhit.get_sigma_r();
         geomtools::vector_3d hit_pos(x, y, z);
-        geomtools::gnuplot_draw::draw_box(tmp_file.out(), hit_pos, identity,
-                                          ggloc_.cellDiameter(), ggloc_.cellDiameter(),
-                                          2 * ez);
+        geomtools::gnuplot_draw::draw_box(tmp_file.out(), hit_pos, identity, ggloc_.cellDiameter(),
+                                          ggloc_.cellDiameter(), 2 * ez);
       }
     }
     CC.set_color_code(geomtools::color::COLOR_BLACK);
@@ -305,9 +300,8 @@ void display_event(const snemo::geometry::gg_locator &ggloc_,
       // double r  = uclhit.get_r();
       // double er = uclhit.get_sigma_r();
       geomtools::vector_3d hit_pos(x, y, z);
-      geomtools::gnuplot_draw::draw_box(tmp_file.out(), hit_pos, identity,
-                                        ggloc_.cellDiameter(), ggloc_.cellDiameter(),
-                                        2 * ez);
+      geomtools::gnuplot_draw::draw_box(tmp_file.out(), hit_pos, identity, ggloc_.cellDiameter(),
+                                        ggloc_.cellDiameter(), 2 * ez);
     }
   }
 
@@ -315,10 +309,9 @@ void display_event(const snemo::geometry::gg_locator &ggloc_,
   if (ttd_.has_default_solution()) {
     double chi2r_max = 10.0;
     const sdm::tracker_trajectory_solution &ttd_sol = ttd_.get_default_solution();
-    const sdm::tracker_trajectory_solution::trajectory_col_type &trajectories =
-        ttd_sol.get_trajectories();
+    const sdm::TrackerTrajectoryHdlCollection &trajectories = ttd_sol.get_trajectories();
     for (int i = 0; i < (int)trajectories.size(); i++) {
-      const sdm::tracker_trajectory_solution::trajectory_handle_type &htraj = trajectories[i];
+      const sdm::TrackerTrajectoryHdl &htraj = trajectories[i];
       const sdm::tracker_trajectory &traj = htraj.get();
       double chi2 = traj.get_auxiliaries().fetch_real("chi2");
       size_t ndof = traj.get_auxiliaries().fetch_integer("ndof");

--- a/modules/TrackFit/TrackFit/test/utilities.cc
+++ b/modules/TrackFit/TrackFit/test/utilities.cc
@@ -19,14 +19,13 @@
 #include <falaise/snemo/datamodels/tracker_trajectory.h>
 
 void generate_tcd(const snemo::geometry::gg_locator &ggloc_,
-                  snemo::datamodel::calibrated_data::tracker_hit_collection_type &gghits_,
+                  snemo::datamodel::TrackerHitHdlCollection &gghits_,
                   snemo::datamodel::tracker_clustering_data &tcd_) {
-  snemo::datamodel::calibrated_data::tracker_hit_collection_type &gghits = gghits_;
+  snemo::datamodel::TrackerHitHdlCollection &gghits = gghits_;
 
   // A collection of fake Geiger hits:
   for (int i = 0; i < 9; i++) {
-    snemo::datamodel::calibrated_data::tracker_hit_handle_type hgghit(
-        new snemo::datamodel::calibrated_tracker_hit);
+    snemo::datamodel::TrackerHitHdl hgghit(new snemo::datamodel::calibrated_tracker_hit);
     snemo::datamodel::calibrated_tracker_hit &gghit = hgghit.grab();
     gghit.set_hit_id(i);
     gghit.grab_auxiliaries().store_flag("mock");
@@ -72,14 +71,13 @@ void generate_tcd(const snemo::geometry::gg_locator &ggloc_,
   htc0.grab().grab_auxiliaries().store_flag("mock");
   htc0.grab().set_cluster_id(0);
   for (int i = 0; i < (int)gghits.size(); i++) {
-    snemo::datamodel::calibrated_data::tracker_hit_handle_type &gghit = gghits[i];
+    snemo::datamodel::TrackerHitHdl &gghit = gghits[i];
     tc0.get_hits().push_back(gghit);
   }
 
   // Another fake track:
   for (int i = 0; i < 6; i++) {
-    snemo::datamodel::calibrated_data::tracker_hit_handle_type hgghit(
-        new snemo::datamodel::calibrated_tracker_hit);
+    snemo::datamodel::TrackerHitHdl hgghit(new snemo::datamodel::calibrated_tracker_hit);
     snemo::datamodel::calibrated_tracker_hit &gghit = hgghit.grab();
     gghit.set_hit_id(i);
     gghit.grab_auxiliaries().store_flag("mock");
@@ -108,7 +106,7 @@ void generate_tcd(const snemo::geometry::gg_locator &ggloc_,
   htc1.grab().grab_auxiliaries().store_flag("mock");
   htc1.grab().set_cluster_id(1);
   for (int i = 0; i < (int)gghits.size(); i++) {
-    snemo::datamodel::calibrated_data::tracker_hit_handle_type &gghit = gghits[i];
+    snemo::datamodel::TrackerHitHdl &gghit = gghits[i];
     if (gghit->get_auxiliaries().has_key("cluster_id")) {
       if (gghit->get_auxiliaries().fetch_integer("cluster_id") == 1) {
         tc1.get_hits().push_back(gghit);
@@ -118,8 +116,7 @@ void generate_tcd(const snemo::geometry::gg_locator &ggloc_,
 
   // Yet another fake track:
   for (int i = 0; i < 7; i++) {
-    snemo::datamodel::calibrated_data::tracker_hit_handle_type hgghit(
-        new snemo::datamodel::calibrated_tracker_hit);
+    snemo::datamodel::TrackerHitHdl hgghit(new snemo::datamodel::calibrated_tracker_hit);
     snemo::datamodel::calibrated_tracker_hit &gghit = hgghit.grab();
     gghit.set_hit_id(i);
     gghit.grab_auxiliaries().store_flag("mock");
@@ -169,7 +166,7 @@ void generate_tcd(const snemo::geometry::gg_locator &ggloc_,
   htc2->grab_auxiliaries().store_flag("mock");
   htc2->set_cluster_id(2);
   for (int i = 0; i < (int)gghits.size(); i++) {
-    snemo::datamodel::calibrated_data::tracker_hit_handle_type &gghit = gghits[i];
+    snemo::datamodel::TrackerHitHdl &gghit = gghits[i];
     if (gghit->get_auxiliaries().has_key("cluster_id")) {
       if (gghit->get_auxiliaries().fetch_integer("cluster_id") == 2) {
         tc2.get_hits().push_back(gghit);
@@ -179,8 +176,7 @@ void generate_tcd(const snemo::geometry::gg_locator &ggloc_,
 
   // Add random fake hits
   for (int i = 0; i < 3; i++) {
-    snemo::datamodel::calibrated_data::tracker_hit_handle_type hgghit(
-        new snemo::datamodel::calibrated_tracker_hit);
+    snemo::datamodel::TrackerHitHdl hgghit(new snemo::datamodel::calibrated_tracker_hit);
     snemo::datamodel::calibrated_tracker_hit &gghit = hgghit.grab();
     gghit.set_hit_id(i);
     gghit.grab_auxiliaries().store_flag("mock");
@@ -220,7 +216,7 @@ void generate_tcd(const snemo::geometry::gg_locator &ggloc_,
 }
 
 void display_event(const snemo::geometry::gg_locator &ggloc_,
-                   const snemo::datamodel::calibrated_data::tracker_hit_collection_type &gghits_,
+                   const snemo::datamodel::TrackerHitHdlCollection &gghits_,
                    const snemo::datamodel::tracker_clustering_data &tcd_,
                    const snemo::datamodel::tracker_trajectory_data &ttd_) {
   namespace sdm = snemo::datamodel;
@@ -228,7 +224,7 @@ void display_event(const snemo::geometry::gg_locator &ggloc_,
   tmp_file.set_remove_at_destroy(true);
   tmp_file.create("/tmp", ".yaca_drawer_");
 
-  const sdm::calibrated_data::tracker_hit_collection_type &gghits = gghits_;
+  const sdm::TrackerHitHdlCollection &gghits = gghits_;
 
   // No rotation
   geomtools::rotation_3d identity;
@@ -243,7 +239,7 @@ void display_event(const snemo::geometry::gg_locator &ggloc_,
 
   // Draw hits:
   for (int i = 0; i < (int)gghits.size(); i++) {
-    const sdm::calibrated_data::tracker_hit_handle_type &hgghit = gghits[i];
+    const sdm::TrackerHitHdl &hgghit = gghits[i];
     const sdm::calibrated_tracker_hit &gghit = hgghit.get();
     double x = gghit.get_x();
     double y = gghit.get_y();
@@ -275,7 +271,7 @@ void display_event(const snemo::geometry::gg_locator &ggloc_,
       if (i == 4) CC.set_color_code(geomtools::color::COLOR_ORANGE);
       if (i > 4) CC.set_color_code(geomtools::color::COLOR_BLUE);
       for (int j = 0; j < (int)clhits.size(); j++) {
-        const sdm::calibrated_data::tracker_hit_handle_type &hclhit = clhits[j];
+        const sdm::TrackerHitHdl &hclhit = clhits[j];
         const sdm::calibrated_tracker_hit &clhit = hclhit.get();
         double x = clhit.get_x();
         double y = clhit.get_y();
@@ -290,8 +286,7 @@ void display_event(const snemo::geometry::gg_locator &ggloc_,
     }
     CC.set_color_code(geomtools::color::COLOR_BLACK);
     for (int j = 0; j < (int)tcd_sol.get_unclustered_hits().size(); j++) {
-      const sdm::calibrated_data::tracker_hit_handle_type &huclhit =
-          tcd_sol.get_unclustered_hits()[j];
+      const sdm::TrackerHitHdl &huclhit = tcd_sol.get_unclustered_hits()[j];
       const sdm::calibrated_tracker_hit &uclhit = huclhit.get();
       double x = uclhit.get_x();
       double y = uclhit.get_y();

--- a/modules/TrackFit/TrackFit/test/utilities.cc
+++ b/modules/TrackFit/TrackFit/test/utilities.cc
@@ -72,7 +72,7 @@ void generate_tcd(const snemo::geometry::gg_locator &ggloc_,
   htc0.grab().set_cluster_id(0);
   for (int i = 0; i < (int)gghits.size(); i++) {
     snemo::datamodel::TrackerHitHdl &gghit = gghits[i];
-    tc0.get_hits().push_back(gghit);
+    tc0.hits().push_back(gghit);
   }
 
   // Another fake track:
@@ -109,7 +109,7 @@ void generate_tcd(const snemo::geometry::gg_locator &ggloc_,
     snemo::datamodel::TrackerHitHdl &gghit = gghits[i];
     if (gghit->get_auxiliaries().has_key("cluster_id")) {
       if (gghit->get_auxiliaries().fetch_integer("cluster_id") == 1) {
-        tc1.get_hits().push_back(gghit);
+        tc1.hits().push_back(gghit);
       }
     }
   }
@@ -169,7 +169,7 @@ void generate_tcd(const snemo::geometry::gg_locator &ggloc_,
     snemo::datamodel::TrackerHitHdl &gghit = gghits[i];
     if (gghit->get_auxiliaries().has_key("cluster_id")) {
       if (gghit->get_auxiliaries().fetch_integer("cluster_id") == 2) {
-        tc2.get_hits().push_back(gghit);
+        tc2.hits().push_back(gghit);
       }
     }
   }
@@ -200,7 +200,7 @@ void generate_tcd(const snemo::geometry::gg_locator &ggloc_,
   tcs.get_clusters().push_back(htc0);
   tcs.get_clusters().push_back(htc1);
   tcs.get_clusters().push_back(htc2);
-  tcd_.add_solution(htcs);
+  tcd_.push_back(htcs);
   tcs.tree_dump(std::cerr, "Tracker clustering solution:", "", true);
   std::cerr << "|-- "
             << "Tracker cluster 0: " << std::endl;
@@ -256,14 +256,14 @@ void display_event(const snemo::geometry::gg_locator &ggloc_,
   }
 
   // Draw clusters:
-  if (tcd_.has_default_solution()) {
-    const sdm::tracker_clustering_solution &tcd_sol = tcd_.get_default_solution();
+  if (tcd_.has_default()) {
+    const sdm::tracker_clustering_solution &tcd_sol = tcd_.get_default();
     tcd_sol.tree_dump(std::cerr, "Clustering solution: ", "DEVEL: ");
     for (int i = 0; i < (int)tcd_sol.get_clusters().size(); i++) {
       const sdm::TrackerClusterHdl &hcluster = tcd_sol.get_clusters()[i];
       const sdm::tracker_cluster &cluster = hcluster.get();
       // cluster.tree_dump(std::cerr, "Cluster: ", "DEVEL: ");
-      const sdm::TrackerHitHdlCollection &clhits = cluster.get_hits();
+      const sdm::TrackerHitHdlCollection &clhits = cluster.hits();
       if (i == 0) CC.set_color_code(geomtools::color::COLOR_RED);
       if (i == 1) CC.set_color_code(geomtools::color::COLOR_GREEN);
       if (i == 2) CC.set_color_code(geomtools::color::COLOR_MAGENTA);

--- a/modules/TrackFit/TrackFit/test/utilities.h
+++ b/modules/TrackFit/TrackFit/test/utilities.h
@@ -8,11 +8,11 @@
 #include <falaise/snemo/geometry/gg_locator.h>
 
 void generate_tcd(const snemo::geometry::gg_locator& ggloc_,
-                  snemo::datamodel::calibrated_data::tracker_hit_collection_type& gghits_,
+                  snemo::datamodel::TrackerHitHdlCollection& gghits_,
                   snemo::datamodel::tracker_clustering_data& tcd_);
 
 void display_event(const snemo::geometry::gg_locator& ggloc_,
-                   const snemo::datamodel::calibrated_data::tracker_hit_collection_type& gghits_,
+                   const snemo::datamodel::TrackerHitHdlCollection& gghits_,
                    const snemo::datamodel::tracker_clustering_data& tcd_,
                    const snemo::datamodel::tracker_trajectory_data& ttd_);
 

--- a/modules/TrackFit/TrackFit/trackfit_driver.cc
+++ b/modules/TrackFit/TrackFit/trackfit_driver.cc
@@ -109,7 +109,6 @@ const TrackFit::gg_hits_col& trackfit_driver::get_hits_referential() const {
 
 TrackFit::gg_hits_col& trackfit_driver::grab_hits_referential() { return _gg_hits_referential_; }
 
-
 // Constructor
 trackfit_driver::trackfit_driver()
     : snemo::processing::base_tracker_fitter(trackfit_driver::trackfit_id()) {
@@ -234,8 +233,6 @@ void trackfit_driver::_install_drift_time_calibration_driver_() {
   }
 }
 
-
-
 // Main fitting method
 int trackfit_driver::_process_algo(const snemo::datamodel::tracker_clustering_data& clustering_,
                                    snemo::datamodel::tracker_trajectory_data& trajectory_) {
@@ -244,7 +241,7 @@ int trackfit_driver::_process_algo(const snemo::datamodel::tracker_clustering_da
   const double gg_cell_diameter = get_gg_locator().cellDiameter() / CLHEP::mm;
 
   // Get cluster solutions:
-  const snemo::datamodel::tracker_clustering_data::solution_col_type& cluster_solutions =
+  const snemo::datamodel::TrackerClusteringSolutionHdlCollection& cluster_solutions =
       clustering_.get_solutions();
 
   for (const datatools::handle<snemo::datamodel::tracker_clustering_solution>& a_cluster_solution :
@@ -256,12 +253,12 @@ int trackfit_driver::_process_algo(const snemo::datamodel::tracker_clustering_da
     a_trajectory_solution->set_clustering_solution(a_cluster_solution);
 
     // Get clusters stored in the current tracker solution:
-    const snemo::datamodel::tracker_clustering_solution::cluster_col_type& clusters =
+    const snemo::datamodel::TrackerClusterHdlCollection& clusters =
         a_cluster_solution->get_clusters();
 
     for (const datatools::handle<snemo::datamodel::tracker_cluster>& a_cluster : clusters) {
       // Get tracker hits stored in the current tracker cluster:
-      const snemo::datamodel::calibrated_tracker_hit::collection_type& hits = a_cluster->get_hits();
+      const snemo::datamodel::TrackerHitHdlCollection& hits = a_cluster->get_hits();
 
       // Home made Geiger hit model for 'trackfit':
       TrackFit::gg_hits_col gg_hits;
@@ -323,7 +320,7 @@ int trackfit_driver::_process_algo(const snemo::datamodel::tracker_clustering_da
 
         // Create new 'tracker_pattern' handle:
         // Needs to be polymorphic, check that make_handle supports this
-        snemo::datamodel::tracker_trajectory::handle_pattern h_pattern;
+        snemo::datamodel::TrajectoryPatternHdl h_pattern;
         auto htp = new snemo::datamodel::helix_trajectory_pattern;
         h_pattern.reset(htp);
 
@@ -369,7 +366,7 @@ int trackfit_driver::_process_algo(const snemo::datamodel::tracker_clustering_da
                                                     h_trajectory->grab_geom_id());
 
         // Create new 'tracker_pattern' handle:
-        snemo::datamodel::tracker_trajectory::handle_pattern h_pattern;
+        snemo::datamodel::TrajectoryPatternHdl h_pattern;
         auto ltp = new snemo::datamodel::line_trajectory_pattern;
         h_pattern.reset(ltp);
 
@@ -392,7 +389,7 @@ int trackfit_driver::_process_algo(const snemo::datamodel::tracker_clustering_da
       }
 
       if (!helix_fit_succeed && !line_fit_succeed) {
-        snemo::datamodel::tracker_trajectory_solution::cluster_col_type& cct =
+        snemo::datamodel::TrackerClusterHdlCollection& cct =
             a_trajectory_solution->grab_unfitted_clusters();
         cct.push_back(a_cluster);
       }

--- a/modules/TrackFit/TrackFit/trackfit_driver.cc
+++ b/modules/TrackFit/TrackFit/trackfit_driver.cc
@@ -242,7 +242,7 @@ int trackfit_driver::_process_algo(const snemo::datamodel::tracker_clustering_da
 
   // Get cluster solutions:
   const snemo::datamodel::TrackerClusteringSolutionHdlCollection& cluster_solutions =
-      clustering_.get_solutions();
+      clustering_.solutions();
 
   for (const datatools::handle<snemo::datamodel::tracker_clustering_solution>& a_cluster_solution :
        cluster_solutions) {
@@ -258,7 +258,7 @@ int trackfit_driver::_process_algo(const snemo::datamodel::tracker_clustering_da
 
     for (const datatools::handle<snemo::datamodel::tracker_cluster>& a_cluster : clusters) {
       // Get tracker hits stored in the current tracker cluster:
-      const snemo::datamodel::TrackerHitHdlCollection& hits = a_cluster->get_hits();
+      const snemo::datamodel::TrackerHitHdlCollection& hits = a_cluster->hits();
 
       // Home made Geiger hit model for 'trackfit':
       TrackFit::gg_hits_col gg_hits;
@@ -319,13 +319,13 @@ int trackfit_driver::_process_algo(const snemo::datamodel::tracker_clustering_da
                                                     h_trajectory->grab_geom_id());
 
         // Create new 'tracker_pattern' handle:
-        // Needs to be polymorphic, check that make_handle supports this
+        // Needs to be polymorphic, check that make_handle supports this as make_unique does
         snemo::datamodel::TrajectoryPatternHdl h_pattern;
         auto htp = new snemo::datamodel::helix_trajectory_pattern;
         h_pattern.reset(htp);
 
         // Set cluster and pattern handle to tracker_trajectory:
-        h_trajectory->set_trajectory_id(a_trajectory_solution->get_trajectories().size());
+        h_trajectory->set_id(a_trajectory_solution->get_trajectories().size());
         h_trajectory->set_cluster_handle(a_cluster);
         h_trajectory->set_pattern_handle(h_pattern);
         h_trajectory->grab_auxiliaries().store_real("chi2", pow(a_fit_solution.chi, 2));
@@ -371,7 +371,7 @@ int trackfit_driver::_process_algo(const snemo::datamodel::tracker_clustering_da
         h_pattern.reset(ltp);
 
         // Set cluster and pattern handle to tracker_trajectory:
-        h_trajectory->set_trajectory_id(a_trajectory_solution->get_trajectories().size());
+        h_trajectory->set_id(a_trajectory_solution->get_trajectories().size());
         h_trajectory->set_cluster_handle(a_cluster);
         h_trajectory->set_pattern_handle(h_pattern);
         h_trajectory->grab_auxiliaries().store_real("chi2", pow(a_fit_solution.chi, 2));

--- a/modules/TrackFit/TrackFit/trackfit_tracker_fitting_module.cc
+++ b/modules/TrackFit/TrackFit/trackfit_tracker_fitting_module.cc
@@ -80,10 +80,8 @@ void trackfit_tracker_fitting_module::initialize(const datatools::properties& co
   dpp::base_module::_common_initialize(config);
 
   falaise::property_set ps{config};
-  TCDTag_ = ps.get<std::string>(
-      "TCD_label", snemo::datamodel::data_info::default_tracker_clustering_data_label());
-  TTDTag_ = ps.get<std::string>(
-      "TTD_label", snemo::datamodel::data_info::default_tracker_trajectory_data_label());
+  TCDTag_ = ps.get<std::string>("TCD_label", snedm::labels::tracker_clustering_data());
+  TTDTag_ = ps.get<std::string>("TTD_label", snedm::labels::tracker_trajectory_data());
 
   snemo::service_handle<snemo::geometry_svc> geoSVC{services};
   set_geometry_manager(*(geoSVC.operator->()));
@@ -125,7 +123,7 @@ dpp::base_module::process_status trackfit_tracker_fitting_module::process(
   const auto& inputClusters = event.get<snedm::tracker_clustering_data>(TCDTag_);
 
   // Check tracker trajectory data
-  auto& outputTrajectories = snedm::getOrAddToEvent<snedm::tracker_trajectory_data>(TTDTag_, event);
+  auto& outputTrajectories = ::snedm::getOrAddToEvent<snedm::tracker_trajectory_data>(TTDTag_, event);
   if (outputTrajectories.has_solutions()) {
     DT_LOG_WARNING(get_logging_priority(),
                    "Event bank '" << TTDTag_ << "' already has processed tracker trajectory data");
@@ -180,7 +178,7 @@ DOCD_CLASS_IMPLEMENT_LOAD_BEGIN(snemo::reconstruction::trackfit_tracker_fitting_
             "This is the name of the bank to be used as    \n"
             "the source of input clusters of tracker hits. \n")
         .set_default_value_string(
-            snemo::datamodel::data_info::default_tracker_clustering_data_label())
+            snedm::labels::tracker_clustering_data())
         .add_example(
             "Use an alternative name for the 'tracker clustering data' bank:: \n"
             "                                  \n"
@@ -199,7 +197,7 @@ DOCD_CLASS_IMPLEMENT_LOAD_BEGIN(snemo::reconstruction::trackfit_tracker_fitting_
             "This is the name of the bank to be used as \n"
             "the sink of output tracker trajectories.   \n")
         .set_default_value_string(
-            snemo::datamodel::data_info::default_tracker_trajectory_data_label())
+            snedm::labels::tracker_trajectory_data())
         .add_example(
             "Use an alternative name for the 'tracker trajectory data' bank:: \n"
             "                                  \n"

--- a/modules/TrackFit/TrackFit/trackfit_tracker_fitting_module.cc
+++ b/modules/TrackFit/TrackFit/trackfit_tracker_fitting_module.cc
@@ -140,8 +140,7 @@ void trackfit_tracker_fitting_module::_process(
     const snemo::datamodel::tracker_clustering_data& clusters,
     snemo::datamodel::tracker_trajectory_data& trajectories) {
   // Process isolated tracks using external resource:
-  if (!clusters.has_solutions()) {
-    DT_LOG_TRACE(get_logging_priority(), "No clustered solution to be fitted");
+  if (clusters.empty()) {
     return;
   }
 

--- a/modules/VisuToy/VisuToy/toy_display_driver.cc
+++ b/modules/VisuToy/VisuToy/toy_display_driver.cc
@@ -601,7 +601,7 @@ void toy_display_driver::generate_SD_data_(std::ostream &out_, int &index_) {
   int index = index_;
   const std::string setup_label = gmgr->get_setup_label();
   // Simulated data :
-  const std::string &SD_label = snemo::datamodel::data_info::default_simulated_data_label();
+  const std::string &SD_label = snedm::labels::simulated_data();
   if (get_current_event_record_().has(SD_label)) {
     DT_LOG_DEBUG(logging_priority, "has SIMULATED_DATA_LABEL !");
     DT_THROW_IF(!get_current_event_record_().is_a<mctools::simulated_data>(SD_label),
@@ -1097,7 +1097,7 @@ void toy_display_driver::generate_CD_data_(std::ostream &out_, int &index_) {
   int index = index_;
   const std::string setup_label = gmgr->get_setup_label();
 
-  const std::string &CD_label = snemo::datamodel::data_info::default_calibrated_data_label();
+  const std::string &CD_label = snedm::labels::calibrated_data();
   if (get_current_event_record_().has(CD_label)) {
     DT_LOG_DEBUG(logging_priority, "has CALIBRATED_DATA_LABEL !");
     DT_THROW_IF(!get_current_event_record_().is_a<snemo::datamodel::calibrated_data>(CD_label),
@@ -1438,8 +1438,7 @@ void toy_display_driver::generate_TCD_data_(std::ostream &out_, int &index_) {
   int index = index_;
   const std::string setup_label = gmgr->get_setup_label();
   double cell_diameter = 44.0 * CLHEP::mm;
-  const std::string &TCD_label =
-      snemo::datamodel::data_info::default_tracker_clustering_data_label();
+  const std::string &TCD_label = snedm::labels::tracker_clustering_data();
   if (get_current_event_record_().has(TCD_label)) {
     DT_LOG_DEBUG(logging_priority, "has TRACKER_CLUSTERING_DATA_LABEL !");
     DT_THROW_IF(
@@ -1534,8 +1533,7 @@ void toy_display_driver::generate_TTD_data_(std::ostream &out_, int &index_) {
   int index = index_;
   const std::string setup_label = gmgr->get_setup_label();
 
-  const std::string &TTD_label =
-      snemo::datamodel::data_info::default_tracker_trajectory_data_label();
+  const std::string &TTD_label = snedm::labels::tracker_trajectory_data();
   if (get_current_event_record_().has(TTD_label)) {
     DT_LOG_DEBUG(logging_priority, "has TRACKER_TRAJECTORY_DATA_LABEL !");
     DT_THROW_IF(
@@ -2862,31 +2860,28 @@ void toy_display_driver::cmd_dump(datatools::things &a_data) {
   const sdm::tracker_trajectory_data *ttd_ptr = 0;
   const sdm::particle_track_data *ptd_ptr = 0;
 
-  if (a_data.has(sdm::data_info::default_event_header_label())) {
-    eh_ptr = &(a_data.get<sdm::event_header>(sdm::data_info::default_event_header_label()));
+  if (a_data.has(snedm::labels::event_header())) {
+    eh_ptr = &(a_data.get<sdm::event_header>(snedm::labels::event_header()));
   }
 
-  if (a_data.has(sdm::data_info::default_simulated_data_label())) {
-    sd_ptr = &(a_data.get<mctools::simulated_data>(sdm::data_info::default_simulated_data_label()));
+  if (a_data.has(snedm::labels::simulated_data())) {
+    sd_ptr = &(a_data.get<mctools::simulated_data>(snedm::labels::simulated_data()));
   }
 
-  if (a_data.has(sdm::data_info::default_calibrated_data_label())) {
-    cd_ptr = &(a_data.get<sdm::calibrated_data>(sdm::data_info::default_calibrated_data_label()));
+  if (a_data.has(snedm::labels::calibrated_data())) {
+    cd_ptr = &(a_data.get<sdm::calibrated_data>(snedm::labels::calibrated_data()));
   }
 
-  if (a_data.has(sdm::data_info::default_tracker_clustering_data_label())) {
-    tcd_ptr = &(a_data.get<sdm::tracker_clustering_data>(
-        sdm::data_info::default_tracker_clustering_data_label()));
+  if (a_data.has(snedm::labels::tracker_clustering_data())) {
+    tcd_ptr = &(a_data.get<sdm::tracker_clustering_data>(snedm::labels::tracker_clustering_data()));
   }
 
-  if (a_data.has(sdm::data_info::default_tracker_trajectory_data_label())) {
-    ttd_ptr = &(a_data.get<sdm::tracker_trajectory_data>(
-        sdm::data_info::default_tracker_trajectory_data_label()));
+  if (a_data.has(snedm::labels::tracker_trajectory_data())) {
+    ttd_ptr = &(a_data.get<sdm::tracker_trajectory_data>(snedm::labels::tracker_trajectory_data()));
   }
 
-  if (a_data.has(sdm::data_info::default_particle_track_data_label())) {
-    ptd_ptr = &(
-        a_data.get<sdm::particle_track_data>(sdm::data_info::default_particle_track_data_label()));
+  if (a_data.has(snedm::labels::particle_track_data())) {
+    ptd_ptr = &(a_data.get<sdm::particle_track_data>(snedm::labels::particle_track_data()));
   }
 
   if (eh_ptr != 0) {

--- a/modules/VisuToy/VisuToy/toy_display_driver.cc
+++ b/modules/VisuToy/VisuToy/toy_display_driver.cc
@@ -1455,8 +1455,7 @@ void toy_display_driver::generate_TCD_data_(std::ostream &out_, int &index_) {
       size_t cluster_count = 0;
       for (int i = 0; i < (int)the_tcs.get_clusters().size(); ++i) {
         const snemo::datamodel::tracker_cluster &the_cluster = the_tcs.get_clusters()[i].get();
-        const snemo::datamodel::calibrated_tracker_hit::collection_type &clhits =
-            the_cluster.get_hits();
+        const snemo::datamodel::TrackerHitHdlCollection &clhits = the_cluster.get_hits();
         // int test1 = geomtools::color::COLOR_TEST;
         // geomtools::color::code_type code = geomtools::color:: COLOR_MAGENTA;
         // geomtools::color::COLOR_MAGENTA;
@@ -1495,8 +1494,7 @@ void toy_display_driver::generate_TCD_data_(std::ostream &out_, int &index_) {
       }
 
       // Unclustered hits:
-      const snemo::datamodel::calibrated_tracker_hit::collection_type &the_uhits =
-          the_tcs.get_unclustered_hits();
+      const snemo::datamodel::TrackerHitHdlCollection &the_uhits = the_tcs.get_unclustered_hits();
       for (int i = 0; i < (int)the_uhits.size(); ++i) {
         const snemo::datamodel::calibrated_tracker_hit &uclhit = the_uhits[i].get();
         // Produce tracker unclustered hits rendering data

--- a/modules/VisuToy/VisuToy/toy_display_driver.cc
+++ b/modules/VisuToy/VisuToy/toy_display_driver.cc
@@ -1440,14 +1440,14 @@ void toy_display_driver::generate_TCD_data_(std::ostream &out_, int &index_) {
             << TCD_label << "' but which is not a 'tracker_clustering_data' instance !");
     snemo::datamodel::tracker_clustering_data &the_tcd =
         get_current_event_record_().grab<snemo::datamodel::tracker_clustering_data>(TCD_label);
-    if (the_tcd.has_default_solution()) {
+    if (the_tcd.has_default()) {
       // Color context:
       geomtools::color::context &CC = geomtools::gnuplot_draw::color_context();
-      const snemo::datamodel::tracker_clustering_solution &the_tcs = the_tcd.get_default_solution();
+      const snemo::datamodel::tracker_clustering_solution &the_tcs = the_tcd.get_default();
       size_t cluster_count = 0;
       for (int i = 0; i < (int)the_tcs.get_clusters().size(); ++i) {
         const snemo::datamodel::tracker_cluster &the_cluster = the_tcs.get_clusters()[i].get();
-        const snemo::datamodel::TrackerHitHdlCollection &clhits = the_cluster.get_hits();
+        const snemo::datamodel::TrackerHitHdlCollection &clhits = the_cluster.hits();
         // int test1 = geomtools::color::COLOR_TEST;
         // geomtools::color::code_type code = geomtools::color:: COLOR_MAGENTA;
         // geomtools::color::COLOR_MAGENTA;

--- a/modules/VisuToy/VisuToy/toy_display_driver.cc
+++ b/modules/VisuToy/VisuToy/toy_display_driver.cc
@@ -1109,17 +1109,15 @@ void toy_display_driver::generate_CD_data_(std::ostream &out_, int &index_) {
 
     // draw the calibrated tracker hits:
     {
-      snemo::datamodel::calibrated_data::tracker_hit_collection_type &CTHC =
-          the_cd.calibrated_tracker_hits();
+      snemo::datamodel::TrackerHitHdlCollection &CTHC = the_cd.calibrated_tracker_hits();
       if (CTHC.size()) {
         // Normal hits :
         {
           const std::string hit_category = "CD.tracker";
           size_t hit_count = 0;
-          for (snemo::datamodel::calibrated_data::tracker_hit_collection_type::const_iterator i =
-                   CTHC.begin();
+          for (snemo::datamodel::TrackerHitHdlCollection::const_iterator i = CTHC.begin();
                i != CTHC.end(); i++) {
-            const snemo::datamodel::calibrated_data::tracker_hit_handle_type &the_handle = *i;
+            const snemo::datamodel::TrackerHitHdl &the_handle = *i;
             if (!the_handle.has_data()) continue;
             const snemo::datamodel::calibrated_tracker_hit &CTH = the_handle.get();
 
@@ -1178,10 +1176,9 @@ void toy_display_driver::generate_CD_data_(std::ostream &out_, int &index_) {
         {
           const std::string hit_category = "CD.tracker_delayed";
           size_t hit_count = 0;
-          for (snemo::datamodel::calibrated_data::tracker_hit_collection_type::const_iterator i =
-                   CTHC.begin();
+          for (snemo::datamodel::TrackerHitHdlCollection::const_iterator i = CTHC.begin();
                i != CTHC.end(); i++) {
-            const snemo::datamodel::calibrated_data::tracker_hit_handle_type &the_handle = *i;
+            const snemo::datamodel::TrackerHitHdl &the_handle = *i;
             if (!the_handle.has_data()) continue;
             const snemo::datamodel::calibrated_tracker_hit &CTH = the_handle.get();
 
@@ -1238,10 +1235,9 @@ void toy_display_driver::generate_CD_data_(std::ostream &out_, int &index_) {
         {
           const std::string hit_category = "CD.tracker_noisy";
           size_t hit_count = 0;
-          for (snemo::datamodel::calibrated_data::tracker_hit_collection_type::const_iterator i =
-                   CTHC.begin();
+          for (snemo::datamodel::TrackerHitHdlCollection::const_iterator i = CTHC.begin();
                i != CTHC.end(); i++) {
-            const snemo::datamodel::calibrated_data::tracker_hit_handle_type &the_handle = *i;
+            const snemo::datamodel::TrackerHitHdl &the_handle = *i;
             if (!the_handle.has_data()) continue;
             const snemo::datamodel::calibrated_tracker_hit &CTH = the_handle.get();
 
@@ -1298,15 +1294,13 @@ void toy_display_driver::generate_CD_data_(std::ostream &out_, int &index_) {
 
     // Draw the calibrated calorimeter hits:
     if (setup_label == snemo_demo_label()) {
-      snemo::datamodel::calibrated_data::calorimeter_hit_collection_type &CCHC =
-          the_cd.calibrated_calorimeter_hits();
+      snemo::datamodel::CalorimeterHitHdlCollection &CCHC = the_cd.calibrated_calorimeter_hits();
       if (CCHC.size()) {
         const std::string hit_category = "CD.calorimeter";
         size_t hit_count = 0;
-        for (snemo::datamodel::calibrated_data::calorimeter_hit_collection_type::const_iterator i =
-                 CCHC.begin();
+        for (snemo::datamodel::CalorimeterHitHdlCollection::const_iterator i = CCHC.begin();
              i != CCHC.end(); i++) {
-          const snemo::datamodel::calibrated_data::calorimeter_hit_handle_type &the_handle = *i;
+          const snemo::datamodel::CalorimeterHitHdl &the_handle = *i;
           if (!the_handle.has_data()) continue;
           const snemo::datamodel::calibrated_calorimeter_hit &CCH = the_handle.get();
 
@@ -1379,15 +1373,13 @@ void toy_display_driver::generate_CD_data_(std::ostream &out_, int &index_) {
 
     // draw the calibrated muon trigger hits:
     if (setup_label == snemo_tc_label()) {
-      snemo::datamodel::calibrated_data::calorimeter_hit_collection_type &CCHC =
-          the_cd.calibrated_calorimeter_hits();
+      snemo::datamodel::CalorimeterHitHdlCollection &CCHC = the_cd.calibrated_calorimeter_hits();
       if (CCHC.size()) {
         const std::string hit_category = "CD.muon_trigger";
         size_t hit_count = 0;
-        for (snemo::datamodel::calibrated_data::calorimeter_hit_collection_type::const_iterator i =
-                 CCHC.begin();
+        for (snemo::datamodel::CalorimeterHitHdlCollection::const_iterator i = CCHC.begin();
              i != CCHC.end(); i++) {
-          const snemo::datamodel::calibrated_data::calorimeter_hit_handle_type &the_handle = *i;
+          const snemo::datamodel::CalorimeterHitHdl &the_handle = *i;
           if (!the_handle.has_data()) continue;
           const snemo::datamodel::calibrated_calorimeter_hit &CCH = the_handle.get();
 
@@ -1469,7 +1461,7 @@ void toy_display_driver::generate_TCD_data_(std::ostream &out_, int &index_) {
 
         // Produce tracker cluster rendering data for each hit in the current cluster:
         for (int j = 0; j < (int)clhits.size(); j++) {
-          const snemo::datamodel::calibrated_data::tracker_hit_handle_type &hclhit = clhits[j];
+          const snemo::datamodel::TrackerHitHdl &hclhit = clhits[j];
           const snemo::datamodel::calibrated_tracker_hit &clhit = hclhit.get();
           double x = clhit.get_x();
           double y = clhit.get_y();

--- a/modules/VisuToy/VisuToy/toy_display_driver.cc
+++ b/modules/VisuToy/VisuToy/toy_display_driver.cc
@@ -1109,7 +1109,7 @@ void toy_display_driver::generate_CD_data_(std::ostream &out_, int &index_) {
 
     // draw the calibrated tracker hits:
     {
-      snemo::datamodel::TrackerHitHdlCollection &CTHC = the_cd.calibrated_tracker_hits();
+      snemo::datamodel::TrackerHitHdlCollection &CTHC = the_cd.tracker_hits();
       if (CTHC.size()) {
         // Normal hits :
         {
@@ -1294,7 +1294,7 @@ void toy_display_driver::generate_CD_data_(std::ostream &out_, int &index_) {
 
     // Draw the calibrated calorimeter hits:
     if (setup_label == snemo_demo_label()) {
-      snemo::datamodel::CalorimeterHitHdlCollection &CCHC = the_cd.calibrated_calorimeter_hits();
+      snemo::datamodel::CalorimeterHitHdlCollection &CCHC = the_cd.calorimeter_hits();
       if (CCHC.size()) {
         const std::string hit_category = "CD.calorimeter";
         size_t hit_count = 0;
@@ -1373,7 +1373,7 @@ void toy_display_driver::generate_CD_data_(std::ostream &out_, int &index_) {
 
     // draw the calibrated muon trigger hits:
     if (setup_label == snemo_tc_label()) {
-      snemo::datamodel::CalorimeterHitHdlCollection &CCHC = the_cd.calibrated_calorimeter_hits();
+      snemo::datamodel::CalorimeterHitHdlCollection &CCHC = the_cd.calorimeter_hits();
       if (CCHC.size()) {
         const std::string hit_category = "CD.muon_trigger";
         size_t hit_count = 0;

--- a/modules/things2root/Things2Root.cpp
+++ b/modules/things2root/Things2Root.cpp
@@ -546,8 +546,8 @@ dpp::base_module::process_status Things2Root::process(datatools::things& workIte
     const snemo::datamodel::calibrated_data& CD =
         workItem.get<snemo::datamodel::calibrated_data>("CD");
     //      std::clog << "In process: found CD data bank " << std::endl;
-    tracker_.nohits_ = CD.calibrated_tracker_hits().size();
-    BOOST_FOREACH (const snemo::datamodel::TrackerHitHdl& gg_handle, CD.calibrated_tracker_hits()) {
+    tracker_.nohits_ = CD.tracker_hits().size();
+    BOOST_FOREACH (const snemo::datamodel::TrackerHitHdl& gg_handle, CD.tracker_hits()) {
       if (!gg_handle.has_data()) continue;
 
       const snemo::datamodel::calibrated_tracker_hit& sncore_gg_hit = gg_handle.get();
@@ -593,9 +593,9 @@ dpp::base_module::process_status Things2Root::process(datatools::things& workIte
     tracker_.truetrackid_ = &ws_->trackertruetrackid;
     tracker_.trueparenttrackid_ = &ws_->trackertrueparenttrackid;
 
-    calo_.nohits_ = CD.calibrated_calorimeter_hits().size();
+    calo_.nohits_ = CD.calorimeter_hits().size();
     BOOST_FOREACH (const snemo::datamodel::CalorimeterHitHdl& the_calo_hit_handle,
-                   CD.calibrated_calorimeter_hits()) {
+                   CD.calorimeter_hits()) {
       if (!the_calo_hit_handle.has_data()) continue;
 
       const snemo::datamodel::calibrated_calorimeter_hit& the_calo_hit = the_calo_hit_handle.get();

--- a/modules/things2root/Things2Root.cpp
+++ b/modules/things2root/Things2Root.cpp
@@ -547,8 +547,7 @@ dpp::base_module::process_status Things2Root::process(datatools::things& workIte
         workItem.get<snemo::datamodel::calibrated_data>("CD");
     //      std::clog << "In process: found CD data bank " << std::endl;
     tracker_.nohits_ = CD.calibrated_tracker_hits().size();
-    BOOST_FOREACH (const snemo::datamodel::calibrated_data::tracker_hit_handle_type& gg_handle,
-                   CD.calibrated_tracker_hits()) {
+    BOOST_FOREACH (const snemo::datamodel::TrackerHitHdl& gg_handle, CD.calibrated_tracker_hits()) {
       if (!gg_handle.has_data()) continue;
 
       const snemo::datamodel::calibrated_tracker_hit& sncore_gg_hit = gg_handle.get();
@@ -595,9 +594,8 @@ dpp::base_module::process_status Things2Root::process(datatools::things& workIte
     tracker_.trueparenttrackid_ = &ws_->trackertrueparenttrackid;
 
     calo_.nohits_ = CD.calibrated_calorimeter_hits().size();
-    BOOST_FOREACH (
-        const snemo::datamodel::calibrated_data::calorimeter_hit_handle_type& the_calo_hit_handle,
-        CD.calibrated_calorimeter_hits()) {
+    BOOST_FOREACH (const snemo::datamodel::CalorimeterHitHdl& the_calo_hit_handle,
+                   CD.calibrated_calorimeter_hits()) {
       if (!the_calo_hit_handle.has_data()) continue;
 
       const snemo::datamodel::calibrated_calorimeter_hit& the_calo_hit = the_calo_hit_handle.get();

--- a/source/falaise/snemo.cmake
+++ b/source/falaise/snemo.cmake
@@ -11,7 +11,6 @@ list(APPEND FalaiseLibrary_HEADERS
   snemo/datamodels/gg_track_utils.h
   snemo/datamodels/helix_trajectory_pattern.h
   snemo/datamodels/line_trajectory_pattern.h
-  snemo/datamodels/mock_raw_tracker_hit.h
   snemo/datamodels/particle_track.h
   snemo/datamodels/particle_track_data.h
   snemo/datamodels/polyline_trajectory_pattern.h
@@ -55,11 +54,8 @@ list(APPEND FalaiseLibrary_HEADERS
   snemo/simulation/gg_step_hit_processor.h
   snemo/simulation/calorimeter_step_hit_processor.h
 
-  snemo/processing/event_header_utils_module.h
   snemo/processing/calorimeter_regime.h
   snemo/processing/geiger_regime.h
-  snemo/processing/mock_calorimeter_s2c_module.h
-  snemo/processing/mock_tracker_s2c_module.h
   snemo/processing/base_tracker_clusterizer.h
   snemo/processing/base_tracker_fitter.h
   snemo/processing/module.h
@@ -94,7 +90,6 @@ list(APPEND FalaiseLibrary_SOURCES
   snemo/datamodels/tracker_trajectory_data.cc
   snemo/datamodels/particle_track.cc
   snemo/datamodels/particle_track_data.cc
-  snemo/datamodels/mock_raw_tracker_hit.cc
   snemo/datamodels/data_model.cc
   snemo/datamodels/boost_io/the_serializable.cc
   snemo/datamodels/gg_track_utils.cc
@@ -108,13 +103,18 @@ list(APPEND FalaiseLibrary_SOURCES
   snemo/geometry/mapped_magnetic_field.cc
 
   snemo/processing/event_header_utils_module.cc
+  snemo/processing/event_header_utils_module.h
   snemo/processing/calorimeter_regime.cc
   snemo/processing/geiger_regime.cc
   snemo/processing/mock_calorimeter_s2c_module.cc
+  snemo/processing/mock_calorimeter_s2c_module.h
   snemo/processing/mock_tracker_s2c_module.cc
+  snemo/processing/mock_tracker_s2c_module.h
   snemo/processing/base_tracker_clusterizer.cc
   snemo/processing/base_tracker_fitter.cc
   snemo/processing/base_gamma_builder.cc
+  snemo/processing/detail/mock_raw_tracker_hit.h
+  snemo/processing/detail/mock_raw_tracker_hit.cc
   snemo/processing/detail/GeigerTimePartitioner.cc
   snemo/processing/detail/testing/gg_hit.h
   snemo/processing/detail/testing/gg_hit.cc

--- a/source/falaise/snemo/cuts/simulated_data_cut.cc
+++ b/source/falaise/snemo/cuts/simulated_data_cut.cc
@@ -51,8 +51,7 @@ void simulated_data_cut::initialize(const datatools::properties& dps,
 
   falaise::property_set ps{dps};
 
-  SDTag_ =
-      ps.get<std::string>("SD_label", snemo::datamodel::data_info::default_simulated_data_label());
+  SDTag_ = ps.get<std::string>("SD_label", snedm::labels::simulated_data());
 
   if (ps.has_key("mode.flag")) {
     cutMode_ |= mode_t::FLAG;
@@ -92,7 +91,6 @@ void simulated_data_cut::initialize(const datatools::properties& dps,
 
   this->i_cut::_set_initialized(true);
 }
-
 
 void simulated_data_cut::setSDTag(const std::string& tag) { SDTag_ = tag; }
 
@@ -255,7 +253,7 @@ DOCD_CLASS_IMPLEMENT_LOAD_BEGIN(snemo::cut::simulated_data_cut, ocd_) {
     cpd.set_name_pattern("SD_label")
         .set_terse_description("The name of the Simulated Data bank")
         .set_traits(datatools::TYPE_STRING)
-        .set_default_value_string(snemo::datamodel::data_info::default_simulated_data_label())
+        .set_default_value_string(snedm::labels::simulated_data())
         .add_example(
             "Set the default value::                          \n"
             "                                                 \n"

--- a/source/falaise/snemo/datamodels/README.md
+++ b/source/falaise/snemo/datamodels/README.md
@@ -1,0 +1,149 @@
+# SuperNEMO (Event)DataModel Library
+
+Call this (Event)DataModel as likely to be separate from (Raw)DataModel
+library.
+
+# Namespace
+Currently `snemo::datamodel`, will become `snedm` or similar.
+
+# Classes
+Note: detailed inheritance not given yet, but can be assumed that all
+data model classes inherit from `datatools::i_serializable` so that they
+can be stored in `datatools::things` and persisted.
+
+## Fundamental models
+These model the lowest level data elements not composed from other datamodel
+types.
+
+- `calibrated_calorimeter_hit` (to become `CalorimeterHit` or similar)
+  - semi-POD type, with attributes
+    - Energy, Time, plus associated errors
+  - Attributes by inheritance from `geomtools::base_hit`
+    - Geometry ID
+    - "Hit" ID
+    - A set of properties (but we want to get rid of this!)
+- `calibrated_tracker_hit` (to become `TrackerHit` or similar)
+  - semi-POD type with attributes
+    - Radius, Z, Time, plus associates errors, Cell position, calibration/raw traits
+  - Attributes by inheritance from `geomtools::base_hit`
+    - Geometry ID
+    - "Hit" ID
+    - A set of properties (but we want to get rid of this!)
+- `base_trajectory_pattern`
+  - pABC for classes modelling a "trajectory"
+  - One attribute: `string` giving "id" of pattern
+  - Interface allows retrieval of
+    - pattern attribute
+    - (pure virtual) returns `const i_shape1d&` (presumably the model for the trajectory)
+- `helix_trajectory_pattern`
+  - Concrete class of `base_trajectory_pattern`
+  - Holds a `geomtools::helix_3d`
+- `line_trajectory_pattern`
+  - Concrete class of `base_trajectory_pattern`
+  - Holds a `geomtools::line_3d`
+- `polyline_trajectory_pattern`
+  - Concrete class of `base_trajectory_pattern`
+  - Holds a `geomtools::polyline_3d`
+- `timestamp`
+  - POD-type with attributes
+    - seconds part of time
+    - picoseconds part of time (picoseconds is the shortest time resolution of
+      any electronic component in the DAQ)
+
+## Composed Types
+These model collections of, or associations between, the fundamental types.
+
+- `event_record` (maybe change)
+  - Type alias to `datatools::things`
+- `event_header`
+  - POD type other than inheritance from `i_xxx` interfaces, with attributes
+    - `datatools::event_id`
+    - `generation_type` (simulated/real etc)
+    - `timestamp`
+    - `datatools::properties` (semi-relevant, but ideally separate since it's independent metadata)
+- `calibrated_data`
+  - POD type other than inheritance from `i_xxx` interfaces, with attributes
+    - `vector` of `datatools::handle`s to `calibrated_calorimeter_hit`
+    - `vector` of `datatools::handle`s to `calibrated_tracker_hit`
+- `tracker_cluster`
+  - POD type (effectively a `vector`) with attributes
+    - `vector` of `datatools::handle` to `calibrated_tracker_hit`
+  - Attributes by inheritance from `geomtools::base_hit`
+    - Geometry ID
+    - "Hit" ID
+    - A set of properties (but we want to get rid of this!)
+- `tracker_trajectory`
+  - `datatools::handle` to `tracker_cluster` (the "fitted" cluster)
+  - `datatools::handle` to `base_trajectory_pattern` (the pattern "fitted" to the cluster)
+  - Attributes by inheritance from `geomtools::base_hit`
+    - Geometry ID
+    - "Hit" ID
+    - A set of properties (but we want to get rid of this!)
+- `particle_track`
+  - POD(?) type with attributes
+    - enum representing electric charge
+    - `datatools::handle` to `tracker_trajectory`
+    - `vector` of `datatools::handle` to `geomtools::blur_spot` (models vertices)
+    - `vector` of `datatools::handle` to `calibrated_calorimeter_hit`
+  - Attributes by inheritance from `geomtools::base_hit`
+    - Geometry ID
+    - "Hit" ID
+    - A set of properties (but we want to get rid of this!)
+- `tracker_clustering_solution`
+  - semi-POD type with attributes
+    - `int32_t` as "solution id"
+    - `vector` of `datatools::handle` to `tracker_cluster` (calculated clusters)
+    - `vector` of `datatools::handle` to `calibrated_tracker_hit` (unclustered hits)
+    - `datatools::properties` (but would like to get rid!)
+    - `map` between `int32_t` and `datatools::handle` to `tracker_cluster`
+      - appears used to associate hit to the cluster it's in
+- `tracker_trajectory_solution`
+  - Semi-POD type with attributes
+    - `int32_t` as "solution id"
+    - `datatools::handle` to `tracker_clustering_solution` (the "fitted" clustering solution)
+    - `vector` of `datatools::handle` to `tracker_trajectory` ("fits" to the above cluster)
+    - `vector` of `datatools::handle` to `tracker_cluster` ("unfitted" clusters)
+- `tracker_clustering_data`
+  - semi-POD type with attributes
+    - `vector` of `datatools::handle` to `tracker_clustering_solution`
+    - `datatools::handle` to `tracker_clustering_solution`
+      - By definition, this is empty, or is == to a handle in the `vector`
+- `tracker_trajectory_data`
+  - semi-POD type with attributes
+    - `vector` of `datatools::handle` to `tracker_trajectory_solution`
+    - `datatools::handle` to `tracker_trajectory_solution`
+      - By definition, this is empty, or is == to a handle in the `vector`
+- `particle_track_data`
+  - POD type with attributes
+    - `vector` of `datatools::handle` to `particle_track`
+    - `vector` of `datatools::handle` to `calibrated_calorimeter_hit` (hits not associated to a particle_track)
+
+So can roughly see that
+
+- `_data` classes are pure "holders" or very light associations (typically holding vector of `_solution`)
+- `_solution` classes tend to hold
+  - An instance of what they "solve" for (though usually as a `handle`)
+  - A `handle` to the input data
+  - A `handle` to left over data
+
+Also note that use of `datatools::handle` makes ownership difficult to track.
+Whilst `handle`s are designed to share ownership, this requires care in knowing
+who and when can call things like `reset` to delete the held instance. `handle`
+will be o.k. in that it throws an exception if a null handle is accessed, but still
+need clarity to reduce this likelihood.
+
+## POD vs Logic Classes
+Which classes are true POD (i.e. `struct`s) vs those that implement
+useful operations on the data they hold?
+
+Can logic classes be split into POD and free functions?
+
+# Serialization
+Currently only Boost-based. Relevant files are:
+
+- `boost_io/`
+  - One `.ipp` file for each serialized type
+  - This only needs to define the `serialize` member/free function for the type
+- `the_serializable.cc`
+  - Boost macros for all(?) serialized types
+  - Purpose/need to be documented

--- a/source/falaise/snemo/datamodels/base_trajectory_pattern.cc
+++ b/source/falaise/snemo/datamodels/base_trajectory_pattern.cc
@@ -20,10 +20,6 @@ bool base_trajectory_pattern::has_pattern_id() const { return !_pattern_id_.empt
 
 const std::string& base_trajectory_pattern::get_pattern_id() const { return _pattern_id_; }
 
-void base_trajectory_pattern::_set_pattern_id(const std::string& pattern_id_) {
-  _pattern_id_ = pattern_id_;
-}
-
 }  // end of namespace datamodel
 
 }  // end of namespace snemo

--- a/source/falaise/snemo/datamodels/base_trajectory_pattern.h
+++ b/source/falaise/snemo/datamodels/base_trajectory_pattern.h
@@ -51,6 +51,9 @@ class base_trajectory_pattern : public datatools::i_serializable {
   DATATOOLS_SERIALIZATION_DECLARATION()
 };
 
+using TrajectoryPattern = base_trajectory_pattern;
+using TrajectoryPatternHdl = datatools::handle<TrajectoryPattern>;
+
 }  // end of namespace datamodel
 
 }  // end of namespace snemo

--- a/source/falaise/snemo/datamodels/base_trajectory_pattern.h
+++ b/source/falaise/snemo/datamodels/base_trajectory_pattern.h
@@ -41,10 +41,6 @@ class base_trajectory_pattern : public datatools::i_serializable {
   /// Return the reference to the 1D shape associated to the trajectory
   virtual const geomtools::i_shape_1d& get_shape() const = 0;
 
- protected:
-  /// Set the pattern ID
-  void _set_pattern_id(const std::string& pattern_id_);
-
  private:
   std::string _pattern_id_{""};  //!< The pattern identifier
 

--- a/source/falaise/snemo/datamodels/boost_io/calibrated_calorimeter_hit.ipp
+++ b/source/falaise/snemo/datamodels/boost_io/calibrated_calorimeter_hit.ipp
@@ -23,10 +23,10 @@ namespace datamodel {
 template <class Archive>
 void calibrated_calorimeter_hit::serialize(Archive& ar, const unsigned int /* version */) {
   ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(base_hit);
-  ar& boost::serialization::make_nvp("energy", _energy_);
-  ar& boost::serialization::make_nvp("sigma_energy", _sigma_energy_);
-  ar& boost::serialization::make_nvp("time", _time_);
-  ar& boost::serialization::make_nvp("sigma_time", _sigma_time_);
+  ar& boost::serialization::make_nvp("energy", energy_);
+  ar& boost::serialization::make_nvp("sigma_energy", sigma_energy_);
+  ar& boost::serialization::make_nvp("time", time_);
+  ar& boost::serialization::make_nvp("sigma_time", sigma_time_);
 }
 
 }  // end of namespace datamodel

--- a/source/falaise/snemo/datamodels/boost_io/calibrated_data.ipp
+++ b/source/falaise/snemo/datamodels/boost_io/calibrated_data.ipp
@@ -28,8 +28,8 @@ void calibrated_data::serialize(Archive& ar, const unsigned int version) {
   if (version > 0) {
     ar& DATATOOLS_SERIALIZATION_I_SERIALIZABLE_BASE_OBJECT_NVP;
   }
-  ar& boost::serialization::make_nvp("calibrated_calorimeter_hits", _calibrated_calorimeter_hits_);
-  ar& boost::serialization::make_nvp("calibrated_tracker_hits", _calibrated_tracker_hits_);
+  ar& boost::serialization::make_nvp("calibrated_calorimeter_hits", calorimeter_hits_);
+  ar& boost::serialization::make_nvp("calibrated_tracker_hits", tracker_hits_);
   ar& boost::serialization::make_nvp("properties", _properties_);
 }
 

--- a/source/falaise/snemo/datamodels/boost_io/calibrated_tracker_hit.ipp
+++ b/source/falaise/snemo/datamodels/boost_io/calibrated_tracker_hit.ipp
@@ -25,35 +25,35 @@ template <class Archive>
 void calibrated_tracker_hit::serialize(Archive& ar_, const unsigned int version_) {
   ar_& BOOST_SERIALIZATION_BASE_OBJECT_NVP(base_hit);
   if (version_ == 0 && Archive::is_loading::value) {
-    _traits_ = 0x0;
-    ar_& boost::serialization::make_nvp("r", _r_);
-    ar_& boost::serialization::make_nvp("sigma_r", _sigma_r_);
-    ar_& boost::serialization::make_nvp("z", _z_);
-    ar_& boost::serialization::make_nvp("sigma_z", _sigma_z_);
-    datatools::invalidate(_x_);
-    datatools::invalidate(_y_);
-    ar_& boost::serialization::make_nvp("x", _x_);
-    ar_& boost::serialization::make_nvp("y", _y_);
-    if (datatools::is_valid(_x_) && datatools::is_valid(_y_)) {
-      _set_trait_bit(true, xy);
+    traits_ = 0x0;
+    ar_& boost::serialization::make_nvp("r", r_);
+    ar_& boost::serialization::make_nvp("sigma_r", sigma_r_);
+    ar_& boost::serialization::make_nvp("z", z_);
+    ar_& boost::serialization::make_nvp("sigma_z", sigma_z_);
+    datatools::invalidate(x_);
+    datatools::invalidate(y_);
+    ar_& boost::serialization::make_nvp("x", x_);
+    ar_& boost::serialization::make_nvp("y", y_);
+    if (datatools::is_valid(x_) && datatools::is_valid(y_)) {
+      set_trait_bit(true, xy);
     }
-    datatools::invalidate(_delayed_time_);
-    datatools::invalidate(_delayed_time_error_);
+    datatools::invalidate(delayed_time_);
+    datatools::invalidate(delayed_time_error_);
   }
 
   // From version 1 :
-  ar_& boost::serialization::make_nvp("traits", _traits_);
-  ar_& boost::serialization::make_nvp("r", _r_);
-  ar_& boost::serialization::make_nvp("sigma_r", _sigma_r_);
-  ar_& boost::serialization::make_nvp("z", _z_);
-  ar_& boost::serialization::make_nvp("sigma_z", _sigma_z_);
+  ar_& boost::serialization::make_nvp("traits", traits_);
+  ar_& boost::serialization::make_nvp("r", r_);
+  ar_& boost::serialization::make_nvp("sigma_r", sigma_r_);
+  ar_& boost::serialization::make_nvp("z", z_);
+  ar_& boost::serialization::make_nvp("sigma_z", sigma_z_);
   if (has_xy()) {
-    ar_& boost::serialization::make_nvp("x", _x_);
-    ar_& boost::serialization::make_nvp("y", _y_);
+    ar_& boost::serialization::make_nvp("x", x_);
+    ar_& boost::serialization::make_nvp("y", y_);
   }
   if (is_delayed()) {
-    ar_& boost::serialization::make_nvp("delayed_time", _delayed_time_);
-    ar_& boost::serialization::make_nvp("delayed_time_error", _delayed_time_error_);
+    ar_& boost::serialization::make_nvp("delayed_time", delayed_time_);
+    ar_& boost::serialization::make_nvp("delayed_time_error", delayed_time_error_);
   }
 }
 

--- a/source/falaise/snemo/datamodels/boost_io/event_header.ipp
+++ b/source/falaise/snemo/datamodels/boost_io/event_header.ipp
@@ -28,10 +28,10 @@ void event_header::serialize(Archive& ar_, const unsigned int version_) {
   if (version_ > 0) {
     ar_& DATATOOLS_SERIALIZATION_I_SERIALIZABLE_BASE_OBJECT_NVP;
   }
-  ar_& boost::serialization::make_nvp("id", _id_);
-  ar_& boost::serialization::make_nvp("generation", _generation_);
-  ar_& boost::serialization::make_nvp("timestamp", _timestamp_);
-  ar_& boost::serialization::make_nvp("properties", _properties_);
+  ar_& boost::serialization::make_nvp("id", id_);
+  ar_& boost::serialization::make_nvp("generation", generation_);
+  ar_& boost::serialization::make_nvp("timestamp", timestamp_);
+  ar_& boost::serialization::make_nvp("properties", properties_);
 }
 
 }  // end of namespace datamodel

--- a/source/falaise/snemo/datamodels/boost_io/particle_track.ipp
+++ b/source/falaise/snemo/datamodels/boost_io/particle_track.ipp
@@ -24,10 +24,10 @@ namespace datamodel {
 template <class Archive>
 void particle_track::serialize(Archive& ar_, const unsigned int /*version_*/) {
   ar_& BOOST_SERIALIZATION_BASE_OBJECT_NVP(base_hit);
-  ar_& boost::serialization::make_nvp("charge_from_source", _charge_from_source_);
-  ar_& boost::serialization::make_nvp("trajectory", _trajectory_);
-  ar_& boost::serialization::make_nvp("vertices", _vertices_);
-  ar_& boost::serialization::make_nvp("associated_calorimeter_hits", _associated_calorimeter_hits_);
+  ar_& boost::serialization::make_nvp("charge_from_source", charge_from_source_);
+  ar_& boost::serialization::make_nvp("trajectory", trajectory_);
+  ar_& boost::serialization::make_nvp("vertices", vertices_);
+  ar_& boost::serialization::make_nvp("associated_calorimeter_hits", associated_calorimeters_);
 }
 
 }  // end of namespace datamodel

--- a/source/falaise/snemo/datamodels/boost_io/particle_track_data.ipp
+++ b/source/falaise/snemo/datamodels/boost_io/particle_track_data.ipp
@@ -25,8 +25,8 @@ namespace datamodel {
 template <class Archive>
 void particle_track_data::serialize(Archive& ar_, const unsigned int /*version_*/) {
   ar_& DATATOOLS_SERIALIZATION_I_SERIALIZABLE_BASE_OBJECT_NVP;
-  ar_& boost::serialization::make_nvp("particles", _particles_);
-  ar_& boost::serialization::make_nvp("non_associated_calorimeters", _non_associated_calorimeters_);
+  ar_& boost::serialization::make_nvp("particles", particles_);
+  ar_& boost::serialization::make_nvp("non_associated_calorimeters", isolated_calorimeters_);
   ar_& boost::serialization::make_nvp("auxiliaries", _auxiliaries_);
 }
 

--- a/source/falaise/snemo/datamodels/boost_io/timestamp.ipp
+++ b/source/falaise/snemo/datamodels/boost_io/timestamp.ipp
@@ -22,8 +22,8 @@ void timestamp::serialize(Archive& ar_, const unsigned int version_) {
   if (version_ > 0) {
     ar_& DATATOOLS_SERIALIZATION_I_SERIALIZABLE_BASE_OBJECT_NVP;
   }
-  ar_& boost::serialization::make_nvp("seconds", _seconds_);
-  ar_& boost::serialization::make_nvp("picoseconds", _picoseconds_);
+  ar_& boost::serialization::make_nvp("seconds", seconds_);
+  ar_& boost::serialization::make_nvp("picoseconds", picoseconds_);
 }
 
 }  // end of namespace datamodel

--- a/source/falaise/snemo/datamodels/boost_io/tracker_cluster.ipp
+++ b/source/falaise/snemo/datamodels/boost_io/tracker_cluster.ipp
@@ -27,7 +27,7 @@ namespace datamodel {
 template <class Archive>
 void tracker_cluster::serialize(Archive& ar_, const unsigned int /* version_ */) {
   ar_& BOOST_SERIALIZATION_BASE_OBJECT_NVP(base_hit);
-  ar_& boost::serialization::make_nvp("hits", _hits_);
+  ar_& boost::serialization::make_nvp("hits", hits_);
 }
 
 }  // end of namespace datamodel

--- a/source/falaise/snemo/datamodels/boost_io/tracker_clustering_data.ipp
+++ b/source/falaise/snemo/datamodels/boost_io/tracker_clustering_data.ipp
@@ -27,8 +27,8 @@ namespace datamodel {
 template <class Archive>
 void tracker_clustering_data::serialize(Archive& ar_, const unsigned int /* version_ */) {
   ar_& DATATOOLS_SERIALIZATION_I_SERIALIZABLE_BASE_OBJECT_NVP;
-  ar_& boost::serialization::make_nvp("solutions", _solutions_);
-  ar_& boost::serialization::make_nvp("default_solution", _default_solution_);
+  ar_& boost::serialization::make_nvp("solutions", solutions_);
+  ar_& boost::serialization::make_nvp("default_solution", default_);
   ar_& boost::serialization::make_nvp("auxiliaries", _auxiliaries_);
 }
 

--- a/source/falaise/snemo/datamodels/boost_io/tracker_clustering_solution.ipp
+++ b/source/falaise/snemo/datamodels/boost_io/tracker_clustering_solution.ipp
@@ -28,13 +28,13 @@ namespace datamodel {
 template <class Archive>
 void tracker_clustering_solution::serialize(Archive& ar_, const unsigned int /* version_ */) {
   ar_& DATATOOLS_SERIALIZATION_I_SERIALIZABLE_BASE_OBJECT_NVP;
-  ar_& boost::serialization::make_nvp("solution_id", _solution_id_);
-  ar_& boost::serialization::make_nvp("clusters", _clusters_);
+  ar_& boost::serialization::make_nvp("solution_id", id_);
+  ar_& boost::serialization::make_nvp("clusters", clusters_);
   // if (version_ > 0) {
   //   ar_ & boost::serialization::make_nvp("delayed_clusters", _delayed__clusters_);
   // }
-  ar_& boost::serialization::make_nvp("unclustered_hits", _unclustered_hits_);
-  ar_& boost::serialization::make_nvp("auxiliaries", _auxiliaries_);
+  ar_& boost::serialization::make_nvp("unclustered_hits", unclustered_hits_);
+  ar_& boost::serialization::make_nvp("auxiliaries", auxiliaries_);
 }
 
 }  // end of namespace datamodel

--- a/source/falaise/snemo/datamodels/boost_io/tracker_trajectory.ipp
+++ b/source/falaise/snemo/datamodels/boost_io/tracker_trajectory.ipp
@@ -27,9 +27,9 @@ namespace datamodel {
 template <class Archive>
 void tracker_trajectory::serialize(Archive& ar, const unsigned int /* version */) {
   ar& BOOST_SERIALIZATION_BASE_OBJECT_NVP(base_hit);
-  ar& boost::serialization::make_nvp("cluster", _cluster_);
-  ar& boost::serialization::make_nvp("orphans", _orphans_);
-  ar& boost::serialization::make_nvp("pattern", _pattern_);
+  ar& boost::serialization::make_nvp("cluster", cluster_);
+  ar& boost::serialization::make_nvp("orphans", orphans_);
+  ar& boost::serialization::make_nvp("pattern", pattern_);
 }
 
 }  // end of namespace datamodel

--- a/source/falaise/snemo/datamodels/boost_io/tracker_trajectory_data.ipp
+++ b/source/falaise/snemo/datamodels/boost_io/tracker_trajectory_data.ipp
@@ -27,8 +27,8 @@ namespace datamodel {
 template <class Archive>
 void tracker_trajectory_data::serialize(Archive& ar_, const unsigned int /* version_ */) {
   ar_& DATATOOLS_SERIALIZATION_I_SERIALIZABLE_BASE_OBJECT_NVP;
-  ar_& boost::serialization::make_nvp("solutions", _solutions_);
-  ar_& boost::serialization::make_nvp("default_solution", _default_solution_);
+  ar_& boost::serialization::make_nvp("solutions", solutions_);
+  ar_& boost::serialization::make_nvp("default_solution", default_);
   ar_& boost::serialization::make_nvp("auxiliaries", _auxiliaries_);
 }
 

--- a/source/falaise/snemo/datamodels/boost_io/tracker_trajectory_solution.ipp
+++ b/source/falaise/snemo/datamodels/boost_io/tracker_trajectory_solution.ipp
@@ -29,10 +29,10 @@ namespace datamodel {
 template <class Archive>
 void tracker_trajectory_solution::serialize(Archive& ar_, const unsigned int /* version_ */) {
   ar_& DATATOOLS_SERIALIZATION_I_SERIALIZABLE_BASE_OBJECT_NVP;
-  ar_& boost::serialization::make_nvp("solution_id", _solution_id_);
-  ar_& boost::serialization::make_nvp("clustering_solution", _clustering_solution_);
-  ar_& boost::serialization::make_nvp("trajectories", _trajectories_);
-  ar_& boost::serialization::make_nvp("unfitted_clusters", _unfitted_clusters_);
+  ar_& boost::serialization::make_nvp("solution_id", id_);
+  ar_& boost::serialization::make_nvp("clustering_solution", solutions_);
+  ar_& boost::serialization::make_nvp("trajectories", trajectories_);
+  ar_& boost::serialization::make_nvp("unfitted_clusters", unfitted_);
   ar_& boost::serialization::make_nvp("auxiliaries", _auxiliaries_);
 }
 

--- a/source/falaise/snemo/datamodels/calibrated_calorimeter_hit.cc
+++ b/source/falaise/snemo/datamodels/calibrated_calorimeter_hit.cc
@@ -20,57 +20,47 @@ namespace datamodel {
 DATATOOLS_SERIALIZATION_SERIAL_TAG_IMPLEMENTATION(calibrated_calorimeter_hit,
                                                   "snemo::datamodel::calibrated_calorimeter_hit")
 
-double calibrated_calorimeter_hit::get_time() const { return _time_; }
+double calibrated_calorimeter_hit::get_time() const { return time_; }
 
-void calibrated_calorimeter_hit::set_time(double time_) {
-  _time_ = time_;
-}
+void calibrated_calorimeter_hit::set_time(double time) { time_ = time; }
 
-double calibrated_calorimeter_hit::get_sigma_time() const { return _sigma_time_; }
+double calibrated_calorimeter_hit::get_sigma_time() const { return sigma_time_; }
 
-void calibrated_calorimeter_hit::set_sigma_time(double sigma_time_) {
-  _sigma_time_ = sigma_time_;
-}
+void calibrated_calorimeter_hit::set_sigma_time(double sigma_time) { sigma_time_ = sigma_time; }
 
-double calibrated_calorimeter_hit::get_energy() const { return _energy_; }
+double calibrated_calorimeter_hit::get_energy() const { return energy_; }
 
-void calibrated_calorimeter_hit::set_energy(double energy_) {
-  _energy_ = energy_;
-}
+void calibrated_calorimeter_hit::set_energy(double energy) { energy_ = energy; }
 
-double calibrated_calorimeter_hit::get_sigma_energy() const { return _sigma_energy_; }
+double calibrated_calorimeter_hit::get_sigma_energy() const { return sigma_energy_; }
 
-void calibrated_calorimeter_hit::set_sigma_energy(double sigma_energy_) {
-  _sigma_energy_ = sigma_energy_;
+void calibrated_calorimeter_hit::set_sigma_energy(double sigma_energy) {
+  sigma_energy_ = sigma_energy;
 }
 
 bool calibrated_calorimeter_hit::is_valid() const {
-  return this->base_hit::is_valid() && std::isnormal(_energy_);
+  return this->base_hit::is_valid() && std::isnormal(energy_);
 }
 
 void calibrated_calorimeter_hit::invalidate() {
   this->base_hit::invalidate();
-  datatools::invalidate(_energy_);
-  datatools::invalidate(_sigma_energy_);
-  datatools::invalidate(_time_);
-  datatools::invalidate(_sigma_time_);
+  datatools::invalidate(energy_);
+  datatools::invalidate(sigma_energy_);
+  datatools::invalidate(time_);
+  datatools::invalidate(sigma_time_);
 }
 
-void calibrated_calorimeter_hit::tree_dump(std::ostream& out_, const std::string& title_,
-                                           const std::string& indent_, bool inherit_) const {
-  base_hit::tree_dump(out_, title_, indent_, true);
+void calibrated_calorimeter_hit::tree_dump(std::ostream& out, const std::string& title,
+                                           const std::string& indent, bool is_last) const {
+  base_hit::tree_dump(out, title, indent, true);
 
-  out_ << indent_ << datatools::i_tree_dumpable::tag << "Time  : " << _time_ / CLHEP::ns << " ns"
-       << std::endl;
-
-  out_ << indent_ << datatools::i_tree_dumpable::tag << "Sigma(time) : " << _sigma_time_ / CLHEP::ns
-       << " ns" << std::endl;
-
-  out_ << indent_ << datatools::i_tree_dumpable::tag << "Energy  : " << _energy_ / CLHEP::keV
-       << " keV" << std::endl;
-
-  out_ << indent_ << datatools::i_tree_dumpable::inherit_tag(inherit_)
-       << "Sigma(energy) : " << _sigma_energy_ / CLHEP::keV << " keV" << std::endl;
+  out << indent << datatools::i_tree_dumpable::tag << "Time  : " << time_ / CLHEP::ns << " ns\n"
+      << indent << datatools::i_tree_dumpable::tag << "Sigma(time) : " << sigma_time_ / CLHEP::ns
+      << " ns\n"
+      << indent << datatools::i_tree_dumpable::tag << "Energy  : " << energy_ / CLHEP::keV
+      << " keV\n"
+      << indent << datatools::i_tree_dumpable::inherit_tag(is_last)
+      << "Sigma(energy) : " << sigma_energy_ / CLHEP::keV << " keV" << std::endl;
 }
 
 }  // end of namespace datamodel

--- a/source/falaise/snemo/datamodels/calibrated_calorimeter_hit.cc
+++ b/source/falaise/snemo/datamodels/calibrated_calorimeter_hit.cc
@@ -73,10 +73,6 @@ void calibrated_calorimeter_hit::tree_dump(std::ostream& out_, const std::string
        << "Sigma(energy) : " << _sigma_energy_ / CLHEP::keV << " keV" << std::endl;
 }
 
-void calibrated_calorimeter_hit::dump() const {
-  this->tree_dump(std::clog, "snemo::datamodel::calibrated_calorimeter_hit");
-}
-
 }  // end of namespace datamodel
 
 }  // end of namespace snemo

--- a/source/falaise/snemo/datamodels/calibrated_calorimeter_hit.h
+++ b/source/falaise/snemo/datamodels/calibrated_calorimeter_hit.h
@@ -44,12 +44,6 @@ namespace datamodel {
 /// \brief Model of a calibrated calorimeter hit
 class calibrated_calorimeter_hit : public geomtools::base_hit {
  public:
-  /// Handle of calibrated calorimeter hit
-  typedef datatools::handle<calibrated_calorimeter_hit> handle_type;
-
-  /// Collection of handles of calibrated calorimeter hit
-  typedef std::vector<handle_type> collection_type;
-
   /// Return the time associated to the hit
   double get_time() const;
 
@@ -84,17 +78,24 @@ class calibrated_calorimeter_hit : public geomtools::base_hit {
   virtual void tree_dump(std::ostream& out_ = std::clog, const std::string& title_ = "",
                          const std::string& indent_ = "", bool inherit_ = false) const;
 
-  /// Basic print
-  void dump() const;
-
  private:
-  double _energy_{datatools::invalid_real()};       //!< Energy associated to the hit
-  double _sigma_energy_{datatools::invalid_real()}; //!< Error on the energy associated to the hit
-  double _time_{datatools::invalid_real()};         //!< Time associated to the hit
-  double _sigma_time_{datatools::invalid_real()};   //!< Error on the time associated to the hit
+  double _energy_{datatools::invalid_real()};        //!< Energy associated to the hit
+  double _sigma_energy_{datatools::invalid_real()};  //!< Error on the energy associated to the hit
+  double _time_{datatools::invalid_real()};          //!< Time associated to the hit
+  double _sigma_time_{datatools::invalid_real()};    //!< Error on the time associated to the hit
 
   DATATOOLS_SERIALIZATION_DECLARATION()
 };
+
+/// Handle of calibrated calorimeter hit
+// typedef datatools::handle<calibrated_calorimeter_hit> handle_type;
+/// Collection of handles of calibrated calorimeter hit
+// typedef std::vector<handle_type> collection_type;
+using CalorimeterHit = calibrated_calorimeter_hit;
+using CalorimeterHitCollection = std::vector<CalorimeterHit>;
+
+using CalorimeterHitHdl = datatools::handle<CalorimeterHit>;
+using CalorimeterHitHdlCollection = std::vector<CalorimeterHitHdl>;
 
 }  // end of namespace datamodel
 

--- a/source/falaise/snemo/datamodels/calibrated_calorimeter_hit.h
+++ b/source/falaise/snemo/datamodels/calibrated_calorimeter_hit.h
@@ -75,14 +75,14 @@ class calibrated_calorimeter_hit : public geomtools::base_hit {
   void invalidate();
 
   /// Smart print
-  virtual void tree_dump(std::ostream& out_ = std::clog, const std::string& title_ = "",
-                         const std::string& indent_ = "", bool inherit_ = false) const;
+  virtual void tree_dump(std::ostream& out = std::clog, const std::string& title = "",
+                         const std::string& indent = "", bool is_last = false) const;
 
  private:
-  double _energy_{datatools::invalid_real()};        //!< Energy associated to the hit
-  double _sigma_energy_{datatools::invalid_real()};  //!< Error on the energy associated to the hit
-  double _time_{datatools::invalid_real()};          //!< Time associated to the hit
-  double _sigma_time_{datatools::invalid_real()};    //!< Error on the time associated to the hit
+  double energy_{datatools::invalid_real()};        //!< Energy associated to the hit
+  double sigma_energy_{datatools::invalid_real()};  //!< Error on the energy associated to the hit
+  double time_{datatools::invalid_real()};          //!< Time associated to the hit
+  double sigma_time_{datatools::invalid_real()};    //!< Error on the time associated to the hit
 
   DATATOOLS_SERIALIZATION_DECLARATION()
 };

--- a/source/falaise/snemo/datamodels/calibrated_data.cc
+++ b/source/falaise/snemo/datamodels/calibrated_data.cc
@@ -15,45 +15,21 @@ namespace datamodel {
 DATATOOLS_SERIALIZATION_SERIAL_TAG_IMPLEMENTATION(calibrated_data,
                                                   "snemo::datamodel::calibrated_data")
 
-bool calibrated_data::has_data() const {
-  return has_calibrated_calorimeter_hits() || has_calibrated_tracker_hits();
+const CalorimeterHitHdlCollection& calibrated_data::calorimeter_hits() const {
+  return calorimeter_hits_;
 }
 
-bool calibrated_data::has_calibrated_calorimeter_hits() const {
-  return !_calibrated_calorimeter_hits_.empty();
-}
+CalorimeterHitHdlCollection& calibrated_data::calorimeter_hits() { return calorimeter_hits_; }
 
-const CalorimeterHitHdlCollection& calibrated_data::calibrated_calorimeter_hits() const {
-  return _calibrated_calorimeter_hits_;
-}
+const TrackerHitHdlCollection& calibrated_data::tracker_hits() const { return tracker_hits_; }
 
-CalorimeterHitHdlCollection& calibrated_data::calibrated_calorimeter_hits() {
-  return _calibrated_calorimeter_hits_;
-}
+TrackerHitHdlCollection& calibrated_data::tracker_hits() { return tracker_hits_; }
 
-bool calibrated_data::has_calibrated_tracker_hits() const {
-  return !_calibrated_tracker_hits_.empty();
-}
-
-const TrackerHitHdlCollection& calibrated_data::calibrated_tracker_hits() const {
-  return _calibrated_tracker_hits_;
-}
-
-TrackerHitHdlCollection& calibrated_data::calibrated_tracker_hits() {
-  return _calibrated_tracker_hits_;
-}
-
-void calibrated_data::reset_calibrated_calorimeter_hits() { _calibrated_calorimeter_hits_.clear(); }
-
-void calibrated_data::reset_calibrated_tracker_hits() { _calibrated_tracker_hits_.clear(); }
-
-void calibrated_data::reset() {
-  reset_calibrated_calorimeter_hits();
-  reset_calibrated_tracker_hits();
+void calibrated_data::clear() {
+  calorimeter_hits_.clear();
+  tracker_hits_.clear();
   _properties_.clear();
 }
-
-void calibrated_data::clear() { reset(); }
 
 void calibrated_data::tree_dump(std::ostream& out_, const std::string& title_,
                                 const std::string& indent_, bool inherit_) const {
@@ -63,15 +39,15 @@ void calibrated_data::tree_dump(std::ostream& out_, const std::string& title_,
 
   // Calibrated calorimeter hits:
   out_ << indent_ << datatools::i_tree_dumpable::tag;
-  out_ << "Calibrated calorimeter hits: " << _calibrated_calorimeter_hits_.size() << std::endl;
-  for (size_t i = 0; i < _calibrated_calorimeter_hits_.size(); i++) {
-    const calibrated_calorimeter_hit& calo_calib_hit = _calibrated_calorimeter_hits_.at(i).get();
+  out_ << "Calibrated calorimeter hits: " << calorimeter_hits_.size() << std::endl;
+  for (size_t i = 0; i < calorimeter_hits_.size(); i++) {
     out_ << indent_ << datatools::i_tree_dumpable::skip_tag;
-    if (i + 1 == _calibrated_calorimeter_hits_.size()) {
+    if (i + 1 == calorimeter_hits_.size()) {
       out_ << datatools::i_tree_dumpable::last_tag;
     } else {
       out_ << datatools::i_tree_dumpable::tag;
     }
+    const calibrated_calorimeter_hit& calo_calib_hit = calorimeter_hits_.at(i).get();
     out_ << "Hit #" << i << " : Id=" << calo_calib_hit.get_hit_id()
          << " GID=" << calo_calib_hit.get_geom_id()
          << " E=" << calo_calib_hit.get_energy() / CLHEP::keV << " keV"
@@ -80,15 +56,15 @@ void calibrated_data::tree_dump(std::ostream& out_, const std::string& title_,
 
   // Calibrated tracker hits:
   out_ << indent_ << datatools::i_tree_dumpable::inherit_tag(inherit_);
-  out_ << "Calibrated tracker hits: " << _calibrated_tracker_hits_.size() << std::endl;
-  for (size_t i = 0; i < _calibrated_tracker_hits_.size(); i++) {
-    const calibrated_tracker_hit& tracker_calib_hit = _calibrated_tracker_hits_.at(i).get();
+  out_ << "Calibrated tracker hits: " << tracker_hits_.size() << std::endl;
+  for (size_t i = 0; i < tracker_hits_.size(); i++) {
     out_ << indent_ << datatools::i_tree_dumpable::inherit_skip_tag(inherit_);
-    if (i + 1 == _calibrated_tracker_hits_.size()) {
+    if (i + 1 == tracker_hits_.size()) {
       out_ << datatools::i_tree_dumpable::last_tag;
     } else {
       out_ << datatools::i_tree_dumpable::tag;
     }
+    const calibrated_tracker_hit& tracker_calib_hit = tracker_hits_.at(i).get();
     out_ << "Hit #" << i << " : Id=" << tracker_calib_hit.get_hit_id()
          << " GID=" << tracker_calib_hit.get_geom_id() << ' ';
     if (tracker_calib_hit.is_prompt()) {

--- a/source/falaise/snemo/datamodels/calibrated_data.cc
+++ b/source/falaise/snemo/datamodels/calibrated_data.cc
@@ -23,12 +23,11 @@ bool calibrated_data::has_calibrated_calorimeter_hits() const {
   return !_calibrated_calorimeter_hits_.empty();
 }
 
-const calibrated_data::calorimeter_hit_collection_type&
-calibrated_data::calibrated_calorimeter_hits() const {
+const CalorimeterHitHdlCollection& calibrated_data::calibrated_calorimeter_hits() const {
   return _calibrated_calorimeter_hits_;
 }
 
-calibrated_data::calorimeter_hit_collection_type& calibrated_data::calibrated_calorimeter_hits() {
+CalorimeterHitHdlCollection& calibrated_data::calibrated_calorimeter_hits() {
   return _calibrated_calorimeter_hits_;
 }
 
@@ -36,12 +35,11 @@ bool calibrated_data::has_calibrated_tracker_hits() const {
   return !_calibrated_tracker_hits_.empty();
 }
 
-const calibrated_data::tracker_hit_collection_type& calibrated_data::calibrated_tracker_hits()
-    const {
+const TrackerHitHdlCollection& calibrated_data::calibrated_tracker_hits() const {
   return _calibrated_tracker_hits_;
 }
 
-calibrated_data::tracker_hit_collection_type& calibrated_data::calibrated_tracker_hits() {
+TrackerHitHdlCollection& calibrated_data::calibrated_tracker_hits() {
   return _calibrated_tracker_hits_;
 }
 

--- a/source/falaise/snemo/datamodels/calibrated_data.cc
+++ b/source/falaise/snemo/datamodels/calibrated_data.cc
@@ -41,7 +41,7 @@ void calibrated_data::tree_dump(std::ostream& out, const std::string& title,
 
   auto printTrackerHit = [&](const TrackerHitHdl& x) {
     out << "(Id : " << x->get_hit_id() << ", GID : " << x->get_geom_id()
-        << ", Type : " << (x->is_prompt() ? "prompt" : "delayed") << std::endl;
+        << ", Type : " << (x->is_prompt() ? "prompt" : "delayed") << ")" << std::endl;
   };
 
   if (!title.empty()) {
@@ -51,26 +51,29 @@ void calibrated_data::tree_dump(std::ostream& out, const std::string& title,
   // Calibrated calorimeter hits:
   out << indent << datatools::i_tree_dumpable::tag << "CalorimeterHits[" << calorimeter_hits_.size()
       << "]:" << std::endl;
-
-  std::for_each(
-      calorimeter_hits_.begin(), --calorimeter_hits_.end(), [&](const CalorimeterHitHdl& x) {
-        out << indent << datatools::i_tree_dumpable::skip_tag << datatools::i_tree_dumpable::tag;
-        printCaloHit(x);
-      });
-  out << indent << datatools::i_tree_dumpable::skip_tag << datatools::i_tree_dumpable::last_tag;
-  printCaloHit(calorimeter_hits_.back());
+  if (!calorimeter_hits_.empty()) {
+    std::for_each(
+        calorimeter_hits_.begin(), --calorimeter_hits_.end(), [&](const CalorimeterHitHdl& x) {
+          out << indent << datatools::i_tree_dumpable::skip_tag << datatools::i_tree_dumpable::tag;
+          printCaloHit(x);
+        });
+    out << indent << datatools::i_tree_dumpable::skip_tag << datatools::i_tree_dumpable::last_tag;
+    printCaloHit(calorimeter_hits_.back());
+  }
 
   // Calibrated tracker hits:
   out << indent << datatools::i_tree_dumpable::inherit_tag(is_last) << "TrackerHits["
       << tracker_hits_.size() << "]:" << std::endl;
-  std::for_each(tracker_hits_.begin(), --tracker_hits_.end(), [&](const TrackerHitHdl& x) {
+  if (!tracker_hits_.empty()) {
+    std::for_each(tracker_hits_.begin(), --tracker_hits_.end(), [&](const TrackerHitHdl& x) {
+      out << indent << datatools::i_tree_dumpable::inherit_skip_tag(is_last)
+          << datatools::i_tree_dumpable::tag;
+      printTrackerHit(x);
+    });
     out << indent << datatools::i_tree_dumpable::inherit_skip_tag(is_last)
-        << datatools::i_tree_dumpable::tag;
-    printTrackerHit(x);
-  });
-  out << indent << datatools::i_tree_dumpable::inherit_skip_tag(is_last)
-      << datatools::i_tree_dumpable::last_tag;
-  printTrackerHit(tracker_hits_.back());
+        << datatools::i_tree_dumpable::last_tag;
+    printTrackerHit(tracker_hits_.back());
+  }
 }
 
 }  // end of namespace datamodel

--- a/source/falaise/snemo/datamodels/calibrated_data.cc
+++ b/source/falaise/snemo/datamodels/calibrated_data.cc
@@ -31,50 +31,46 @@ void calibrated_data::clear() {
   _properties_.clear();
 }
 
-void calibrated_data::tree_dump(std::ostream& out_, const std::string& title_,
-                                const std::string& indent_, bool inherit_) const {
-  if (!title_.empty()) {
-    out_ << indent_ << title_ << std::endl;
+void calibrated_data::tree_dump(std::ostream& out, const std::string& title,
+                                const std::string& indent, bool is_last) const {
+  auto printCaloHit = [&](const CalorimeterHitHdl& x) {
+    out << "(Id : " << x->get_hit_id() << ", GID : " << x->get_geom_id()
+        << ", Energy : " << x->get_energy() / CLHEP::keV << " keV"
+        << ", Time : " << x->get_time() / CLHEP::ns << " ns)" << std::endl;
+  };
+
+  auto printTrackerHit = [&](const TrackerHitHdl& x) {
+    out << "(Id : " << x->get_hit_id() << ", GID : " << x->get_geom_id()
+        << ", Type : " << (x->is_prompt() ? "prompt" : "delayed") << std::endl;
+  };
+
+  if (!title.empty()) {
+    out << indent << title << std::endl;
   }
 
   // Calibrated calorimeter hits:
-  out_ << indent_ << datatools::i_tree_dumpable::tag;
-  out_ << "Calibrated calorimeter hits: " << calorimeter_hits_.size() << std::endl;
-  for (size_t i = 0; i < calorimeter_hits_.size(); i++) {
-    out_ << indent_ << datatools::i_tree_dumpable::skip_tag;
-    if (i + 1 == calorimeter_hits_.size()) {
-      out_ << datatools::i_tree_dumpable::last_tag;
-    } else {
-      out_ << datatools::i_tree_dumpable::tag;
-    }
-    const calibrated_calorimeter_hit& calo_calib_hit = calorimeter_hits_.at(i).get();
-    out_ << "Hit #" << i << " : Id=" << calo_calib_hit.get_hit_id()
-         << " GID=" << calo_calib_hit.get_geom_id()
-         << " E=" << calo_calib_hit.get_energy() / CLHEP::keV << " keV"
-         << " t=" << calo_calib_hit.get_time() / CLHEP::ns << " ns" << std::endl;
-  }
+  out << indent << datatools::i_tree_dumpable::tag << "CalorimeterHits[" << calorimeter_hits_.size()
+      << "]:" << std::endl;
+
+  std::for_each(
+      calorimeter_hits_.begin(), --calorimeter_hits_.end(), [&](const CalorimeterHitHdl& x) {
+        out << indent << datatools::i_tree_dumpable::skip_tag << datatools::i_tree_dumpable::tag;
+        printCaloHit(x);
+      });
+  out << indent << datatools::i_tree_dumpable::skip_tag << datatools::i_tree_dumpable::last_tag;
+  printCaloHit(calorimeter_hits_.back());
 
   // Calibrated tracker hits:
-  out_ << indent_ << datatools::i_tree_dumpable::inherit_tag(inherit_);
-  out_ << "Calibrated tracker hits: " << tracker_hits_.size() << std::endl;
-  for (size_t i = 0; i < tracker_hits_.size(); i++) {
-    out_ << indent_ << datatools::i_tree_dumpable::inherit_skip_tag(inherit_);
-    if (i + 1 == tracker_hits_.size()) {
-      out_ << datatools::i_tree_dumpable::last_tag;
-    } else {
-      out_ << datatools::i_tree_dumpable::tag;
-    }
-    const calibrated_tracker_hit& tracker_calib_hit = tracker_hits_.at(i).get();
-    out_ << "Hit #" << i << " : Id=" << tracker_calib_hit.get_hit_id()
-         << " GID=" << tracker_calib_hit.get_geom_id() << ' ';
-    if (tracker_calib_hit.is_prompt()) {
-      out_ << "[prompt]";
-    }
-    if (tracker_calib_hit.is_delayed()) {
-      out_ << "[delayed]";
-    }
-    out_ << std::endl;
-  }
+  out << indent << datatools::i_tree_dumpable::inherit_tag(is_last) << "TrackerHits["
+      << tracker_hits_.size() << "]:" << std::endl;
+  std::for_each(tracker_hits_.begin(), --tracker_hits_.end(), [&](const TrackerHitHdl& x) {
+    out << indent << datatools::i_tree_dumpable::inherit_skip_tag(is_last)
+        << datatools::i_tree_dumpable::tag;
+    printTrackerHit(x);
+  });
+  out << indent << datatools::i_tree_dumpable::inherit_skip_tag(is_last)
+      << datatools::i_tree_dumpable::last_tag;
+  printTrackerHit(tracker_hits_.back());
 }
 
 }  // end of namespace datamodel

--- a/source/falaise/snemo/datamodels/calibrated_data.cc
+++ b/source/falaise/snemo/datamodels/calibrated_data.cc
@@ -43,10 +43,6 @@ TrackerHitHdlCollection& calibrated_data::calibrated_tracker_hits() {
   return _calibrated_tracker_hits_;
 }
 
-const datatools::properties& calibrated_data::get_properties() const { return _properties_; }
-
-datatools::properties& calibrated_data::grab_properties() { return _properties_; }
-
 void calibrated_data::reset_calibrated_calorimeter_hits() { _calibrated_calorimeter_hits_.clear(); }
 
 void calibrated_data::reset_calibrated_tracker_hits() { _calibrated_tracker_hits_.clear(); }
@@ -63,21 +59,6 @@ void calibrated_data::tree_dump(std::ostream& out_, const std::string& title_,
                                 const std::string& indent_, bool inherit_) const {
   if (!title_.empty()) {
     out_ << indent_ << title_ << std::endl;
-  }
-
-  // Properties:
-  {
-    out_ << indent_ << datatools::i_tree_dumpable::tag << "Properties : ";
-    if (_properties_.empty()) {
-      out_ << "<empty>";
-    }
-    out_ << std::endl;
-    {
-      std::ostringstream indent_oss;
-      indent_oss << indent_;
-      indent_oss << datatools::i_tree_dumpable::skip_tag;
-      _properties_.tree_dump(out_, "", indent_oss.str());
-    }
   }
 
   // Calibrated calorimeter hits:

--- a/source/falaise/snemo/datamodels/calibrated_data.h
+++ b/source/falaise/snemo/datamodels/calibrated_data.h
@@ -45,35 +45,17 @@ class calibrated_data : public datatools::i_serializable,
                         public datatools::i_tree_dumpable,
                         public datatools::i_clear {
  public:
-  /// Check if there are some hits
-  bool has_data() const;
-
-  /// Check if there are some calibrated calorimeter hits
-  bool has_calibrated_calorimeter_hits() const;
-
-  /// Reset the collection of calorimeter hits
-  void reset_calibrated_calorimeter_hits();
-
   /// Return the const collection of calorimeter hits
-  const CalorimeterHitHdlCollection& calibrated_calorimeter_hits() const;
+  const CalorimeterHitHdlCollection& calorimeter_hits() const;
 
   /// Return the mutable collection of calorimeter hits
-  CalorimeterHitHdlCollection& calibrated_calorimeter_hits();
-
-  /// Check if there are some calibrated tracker hits
-  bool has_calibrated_tracker_hits() const;
-
-  /// Reset the collection of tracker hits
-  void reset_calibrated_tracker_hits();
+  CalorimeterHitHdlCollection& calorimeter_hits();
 
   /// Return the const collection of tracker hits
-  const TrackerHitHdlCollection& calibrated_tracker_hits() const;
+  const TrackerHitHdlCollection& tracker_hits() const;
 
   /// Return the mutable collection of tracker hits
-  TrackerHitHdlCollection& calibrated_tracker_hits();
-
-  /// Reset
-  void reset();
+  TrackerHitHdlCollection& tracker_hits();
 
   /// Clear attributes
   virtual void clear();
@@ -83,9 +65,8 @@ class calibrated_data : public datatools::i_serializable,
                          const std::string& indent_ = "", bool inherit_ = false) const;
 
  private:
-  CalorimeterHitHdlCollection
-      _calibrated_calorimeter_hits_;                  //!< Collection of calibrated calorimeter hits
-  TrackerHitHdlCollection _calibrated_tracker_hits_;  //!< Collection of calibrated tracker hits
+  CalorimeterHitHdlCollection calorimeter_hits_;  //!< Collection of calibrated calorimeter hits
+  TrackerHitHdlCollection tracker_hits_;          //!< Collection of calibrated tracker hits
 
   datatools::properties
       _properties_;  //!< Auxiliary properties (only retained for serialization compat)

--- a/source/falaise/snemo/datamodels/calibrated_data.h
+++ b/source/falaise/snemo/datamodels/calibrated_data.h
@@ -72,12 +72,6 @@ class calibrated_data : public datatools::i_serializable,
   /// Return the mutable collection of tracker hits
   TrackerHitHdlCollection& calibrated_tracker_hits();
 
-  /// Return the const container of properties
-  const datatools::properties& get_properties() const;
-
-  /// Return the mutable container of properties
-  datatools::properties& grab_properties();
-
   /// Reset
   void reset();
 
@@ -92,7 +86,9 @@ class calibrated_data : public datatools::i_serializable,
   CalorimeterHitHdlCollection
       _calibrated_calorimeter_hits_;                  //!< Collection of calibrated calorimeter hits
   TrackerHitHdlCollection _calibrated_tracker_hits_;  //!< Collection of calibrated tracker hits
-  datatools::properties _properties_;                 //!< Auxiliary properties
+
+  datatools::properties
+      _properties_;  //!< Auxiliary properties (only retained for serialization compat)
 
   DATATOOLS_SERIALIZATION_DECLARATION()
 };

--- a/source/falaise/snemo/datamodels/calibrated_data.h
+++ b/source/falaise/snemo/datamodels/calibrated_data.h
@@ -45,18 +45,6 @@ class calibrated_data : public datatools::i_serializable,
                         public datatools::i_tree_dumpable,
                         public datatools::i_clear {
  public:
-  /// Handle to a calibrated tracker hit
-  typedef datatools::handle<calibrated_tracker_hit> tracker_hit_handle_type;
-
-  /// Handle to a calibrated calorimeter hit
-  typedef datatools::handle<calibrated_calorimeter_hit> calorimeter_hit_handle_type;
-
-  /// Collection of handles on calibrated tracker hits
-  typedef std::vector<tracker_hit_handle_type> tracker_hit_collection_type;
-
-  /// Collection of handles on calibrated calorimeter hits
-  typedef std::vector<calorimeter_hit_handle_type> calorimeter_hit_collection_type;
-
   /// Check if there are some hits
   bool has_data() const;
 
@@ -67,10 +55,10 @@ class calibrated_data : public datatools::i_serializable,
   void reset_calibrated_calorimeter_hits();
 
   /// Return the const collection of calorimeter hits
-  const calorimeter_hit_collection_type& calibrated_calorimeter_hits() const;
+  const CalorimeterHitHdlCollection& calibrated_calorimeter_hits() const;
 
   /// Return the mutable collection of calorimeter hits
-  calorimeter_hit_collection_type& calibrated_calorimeter_hits();
+  CalorimeterHitHdlCollection& calibrated_calorimeter_hits();
 
   /// Check if there are some calibrated tracker hits
   bool has_calibrated_tracker_hits() const;
@@ -79,10 +67,10 @@ class calibrated_data : public datatools::i_serializable,
   void reset_calibrated_tracker_hits();
 
   /// Return the const collection of tracker hits
-  const tracker_hit_collection_type& calibrated_tracker_hits() const;
+  const TrackerHitHdlCollection& calibrated_tracker_hits() const;
 
   /// Return the mutable collection of tracker hits
-  tracker_hit_collection_type& calibrated_tracker_hits();
+  TrackerHitHdlCollection& calibrated_tracker_hits();
 
   /// Return the const container of properties
   const datatools::properties& get_properties() const;
@@ -101,10 +89,10 @@ class calibrated_data : public datatools::i_serializable,
                          const std::string& indent_ = "", bool inherit_ = false) const;
 
  private:
-  calorimeter_hit_collection_type
-      _calibrated_calorimeter_hits_;  //!< Collection of calibrated calorimeter hits
-  tracker_hit_collection_type _calibrated_tracker_hits_;  //!< Collection of calibrated tracker hits
-  datatools::properties _properties_;                     //!< Auxiliary properties
+  CalorimeterHitHdlCollection
+      _calibrated_calorimeter_hits_;                  //!< Collection of calibrated calorimeter hits
+  TrackerHitHdlCollection _calibrated_tracker_hits_;  //!< Collection of calibrated tracker hits
+  datatools::properties _properties_;                 //!< Auxiliary properties
 
   DATATOOLS_SERIALIZATION_DECLARATION()
 };

--- a/source/falaise/snemo/datamodels/calibrated_data.h
+++ b/source/falaise/snemo/datamodels/calibrated_data.h
@@ -61,8 +61,8 @@ class calibrated_data : public datatools::i_serializable,
   virtual void clear();
 
   /// Smart print
-  virtual void tree_dump(std::ostream& out_ = std::clog, const std::string& title_ = "",
-                         const std::string& indent_ = "", bool inherit_ = false) const;
+  virtual void tree_dump(std::ostream& out = std::clog, const std::string& title = "",
+                         const std::string& indent = "", bool is_last = false) const;
 
  private:
   CalorimeterHitHdlCollection calorimeter_hits_;  //!< Collection of calibrated calorimeter hits

--- a/source/falaise/snemo/datamodels/calibrated_tracker_hit.cc
+++ b/source/falaise/snemo/datamodels/calibrated_tracker_hit.cc
@@ -33,178 +33,167 @@ namespace datamodel {
 DATATOOLS_SERIALIZATION_SERIAL_TAG_IMPLEMENTATION(calibrated_tracker_hit,
                                                   "snemo::datamodel::calibrated_tracker_hit")
 
-bool calibrated_tracker_hit::get_trait_bit(uint32_t mask_) const { return _get_trait_bit(mask_); }
+bool calibrated_tracker_hit::get_trait_bit(uint32_t trait) const { return (traits_ & trait) != 0u; }
 
-bool calibrated_tracker_hit::_get_trait_bit(uint32_t mask_) const {
-  return (_traits_ & mask_) != 0u;
-}
-
-void calibrated_tracker_hit::_set_trait_bit(bool value_, uint32_t mask_) {
-  if (value_) {
-    _traits_ |= mask_;
+void calibrated_tracker_hit::set_trait_bit(bool value, uint32_t trait) {
+  if (value) {
+    traits_ |= trait;
   } else {
-    _traits_ &= ~mask_;
+    traits_ &= ~trait;
   }
 }
 
-bool calibrated_tracker_hit::is_delayed() const { return _get_trait_bit(delayed); }
+bool calibrated_tracker_hit::is_delayed() const { return get_trait_bit(delayed); }
 
 bool calibrated_tracker_hit::is_prompt() const { return !is_delayed(); }
 
-bool calibrated_tracker_hit::is_peripheral() const { return _get_trait_bit(peripheral); }
+bool calibrated_tracker_hit::is_peripheral() const { return get_trait_bit(peripheral); }
 
-bool calibrated_tracker_hit::is_noisy() const { return _get_trait_bit(noisy); }
+bool calibrated_tracker_hit::is_noisy() const { return get_trait_bit(noisy); }
 
-bool calibrated_tracker_hit::is_sterile() const { return _get_trait_bit(sterile); }
+bool calibrated_tracker_hit::is_sterile() const { return get_trait_bit(sterile); }
 
-bool calibrated_tracker_hit::is_fake() const { return _get_trait_bit(fake); }
+bool calibrated_tracker_hit::is_fake() const { return get_trait_bit(fake); }
 
-void calibrated_tracker_hit::set_fake(bool fake_) { _set_trait_bit(fake_, fake); }
+void calibrated_tracker_hit::set_fake(bool is_fake) { set_trait_bit(is_fake, fake); }
 
-void calibrated_tracker_hit::set_sterile(bool sterile_) { _set_trait_bit(sterile_, sterile); }
+void calibrated_tracker_hit::set_sterile(bool is_sterile) { set_trait_bit(is_sterile, sterile); }
 
-void calibrated_tracker_hit::set_delayed(bool delayed_) {
-  _set_trait_bit(delayed_, delayed);
-  if (!delayed_) {
-    datatools::invalidate(_delayed_time_);
-    datatools::invalidate(_delayed_time_error_);
+void calibrated_tracker_hit::set_delayed(bool is_delayed) {
+  set_trait_bit(is_delayed, delayed);
+  if (!is_delayed) {
+    datatools::invalidate(delayed_time_);
+    datatools::invalidate(delayed_time_error_);
   }
 }
 
-void calibrated_tracker_hit::set_delayed_time(double delayed_time_, double delayed_time_error_) {
-  if (datatools::is_valid(delayed_time_)) {
+void calibrated_tracker_hit::set_delayed_time(double time, double error) {
+  if (datatools::is_valid(time)) {
     set_delayed(true);
-    _delayed_time_ = delayed_time_;
-    _delayed_time_error_ = delayed_time_error_;
+    delayed_time_ = time;
+    delayed_time_error_ = error;
   } else {
     set_delayed(false);
-    datatools::invalidate(_delayed_time_);
-    datatools::invalidate(_delayed_time_error_);
+    datatools::invalidate(delayed_time_);
+    datatools::invalidate(delayed_time_error_);
   }
 }
 
-bool calibrated_tracker_hit::has_delayed_time() const {
-  return datatools::is_valid(_delayed_time_);
-}
+bool calibrated_tracker_hit::has_delayed_time() const { return datatools::is_valid(delayed_time_); }
 
 /// Return the delayed reference time of the hit
-double calibrated_tracker_hit::get_delayed_time() const { return _delayed_time_; }
+double calibrated_tracker_hit::get_delayed_time() const { return delayed_time_; }
 
 bool calibrated_tracker_hit::has_delayed_time_error() const {
-  return datatools::is_valid(_delayed_time_error_);
+  return datatools::is_valid(delayed_time_error_);
 }
 
 /// Return the delayed reference time of the hit
-double calibrated_tracker_hit::get_delayed_time_error() const { return _delayed_time_error_; }
+double calibrated_tracker_hit::get_delayed_time_error() const { return delayed_time_error_; }
 
-void calibrated_tracker_hit::set_bottom_cathode_missing(bool missing_) {
-  _set_trait_bit(missing_, missing_bottom_cathode);
+void calibrated_tracker_hit::set_bottom_cathode_missing(bool is_missing) {
+  set_trait_bit(is_missing, missing_bottom_cathode);
 }
 
-void calibrated_tracker_hit::set_top_cathode_missing(bool missing_) {
-  _set_trait_bit(missing_, missing_top_cathode);
+void calibrated_tracker_hit::set_top_cathode_missing(bool is_missing) {
+  set_trait_bit(is_missing, missing_top_cathode);
 }
 
-void calibrated_tracker_hit::set_noisy(bool noisy_) { _set_trait_bit(noisy_, noisy); }
+void calibrated_tracker_hit::set_noisy(bool is_noisy) { set_trait_bit(is_noisy, noisy); }
 
-void calibrated_tracker_hit::set_peripheral(bool peripheral_) {
-  _set_trait_bit(peripheral_, peripheral);
+void calibrated_tracker_hit::set_peripheral(bool is_peripheral) {
+  set_trait_bit(is_peripheral, peripheral);
 }
 
 bool calibrated_tracker_hit::has_anode_time() const {
-  bool ok = false;
   if (get_auxiliaries().has_key(anode_time_key())) {
     if (get_auxiliaries().is_real(anode_time_key())) {
-      ok = true;
+      return true;
     }
   }
-  return ok;
+  return false;
 }
 
-void calibrated_tracker_hit::set_anode_time(double anode_time_) {
-  grab_auxiliaries().update(anode_time_key(), anode_time_);
+void calibrated_tracker_hit::set_anode_time(double anode_time) {
+  grab_auxiliaries().update(anode_time_key(), anode_time);
 }
 
 double calibrated_tracker_hit::get_anode_time() const {
-  double anode_time;
-  datatools::invalidate(anode_time);
   if (get_auxiliaries().has_key(anode_time_key())) {
     if (get_auxiliaries().is_real(anode_time_key())) {
-      anode_time = get_auxiliaries().fetch_real(anode_time_key());
+      return get_auxiliaries().fetch_real(anode_time_key());
     }
   }
-  return anode_time;
+  return datatools::invalid_real();
 }
 
-bool calibrated_tracker_hit::has_xy() const { return _get_trait_bit(xy); }
+bool calibrated_tracker_hit::has_xy() const { return get_trait_bit(xy); }
 
-void calibrated_tracker_hit::set_xy(double x_, double y_) {
-  _set_trait_bit(true, xy);
-  _x_ = x_;
-  _y_ = y_;
+void calibrated_tracker_hit::set_xy(double x, double y) {
+  set_trait_bit(true, xy);
+  x_ = x;
+  y_ = y;
 }
 
-double calibrated_tracker_hit::get_x() const { return _x_; }
+double calibrated_tracker_hit::get_x() const { return x_; }
 
-double calibrated_tracker_hit::get_y() const { return _y_; }
+double calibrated_tracker_hit::get_y() const { return y_; }
 
-double calibrated_tracker_hit::get_z() const { return _z_; }
+double calibrated_tracker_hit::get_z() const { return z_; }
 
-void calibrated_tracker_hit::set_z(double z_) { _z_ = z_; }
+void calibrated_tracker_hit::set_z(double z) { z_ = z; }
 
-double calibrated_tracker_hit::get_sigma_z() const { return _sigma_z_; }
+double calibrated_tracker_hit::get_sigma_z() const { return sigma_z_; }
 
-void calibrated_tracker_hit::set_sigma_z(double sigma_z_) { _sigma_z_ = sigma_z_; }
+void calibrated_tracker_hit::set_sigma_z(double error) { sigma_z_ = error; }
 
-double calibrated_tracker_hit::get_r() const { return _r_; }
+double calibrated_tracker_hit::get_r() const { return r_; }
 
-void calibrated_tracker_hit::set_r(double r_) { _r_ = r_; }
+void calibrated_tracker_hit::set_r(double radius) { r_ = radius; }
 
-double calibrated_tracker_hit::get_sigma_r() const { return _sigma_r_; }
+double calibrated_tracker_hit::get_sigma_r() const { return sigma_r_; }
 
-void calibrated_tracker_hit::set_sigma_r(double sigma_r_) { _sigma_r_ = sigma_r_; }
+void calibrated_tracker_hit::set_sigma_r(double error) { sigma_r_ = error; }
 
 void calibrated_tracker_hit::invalidate_xy() {
-  datatools::invalidate(_x_);
-  datatools::invalidate(_y_);
-  _set_trait_bit(true, xy);
+  datatools::invalidate(x_);
+  datatools::invalidate(y_);
+  set_trait_bit(true, xy);
 }
 
 void calibrated_tracker_hit::invalidate_positions() {
-  datatools::invalidate(_r_);
-  datatools::invalidate(_sigma_r_);
-  datatools::invalidate(_z_);
-  datatools::invalidate(_sigma_z_);
+  datatools::invalidate(r_);
+  datatools::invalidate(sigma_r_);
+  datatools::invalidate(z_);
+  datatools::invalidate(sigma_z_);
 }
 
 bool calibrated_tracker_hit::is_valid() const {
-  return this->base_hit::is_valid() && std::isnormal(_z_) && std::isnormal(_r_);
+  return this->base_hit::is_valid() && std::isnormal(z_) && std::isnormal(r_);
 }
 
 void calibrated_tracker_hit::invalidate() {
   this->base_hit::invalidate();
   invalidate_positions();
   invalidate_xy();
-  datatools::invalidate(_delayed_time_);
-  datatools::invalidate(_delayed_time_error_);
-  _traits_ = 0x0;
+  datatools::invalidate(delayed_time_);
+  datatools::invalidate(delayed_time_error_);
+  traits_ = 0x0;
 }
 
 void calibrated_tracker_hit::clear() { calibrated_tracker_hit::invalidate(); }
 
 bool calibrated_tracker_hit::is_bottom_cathode_missing() const {
-  return _get_trait_bit(missing_bottom_cathode);
+  return get_trait_bit(missing_bottom_cathode);
 }
 
 bool calibrated_tracker_hit::is_top_cathode_missing() const {
-  return _get_trait_bit(missing_top_cathode);
+  return get_trait_bit(missing_top_cathode);
 }
 
 bool calibrated_tracker_hit::are_both_cathodes_missing() const {
   return is_bottom_cathode_missing() && is_top_cathode_missing();
 }
-
-
 
 int32_t calibrated_tracker_hit::get_id() const { return get_hit_id(); }
 
@@ -216,78 +205,51 @@ int32_t calibrated_tracker_hit::get_layer() const { return get_geom_id().get(2);
 
 int32_t calibrated_tracker_hit::get_row() const { return get_geom_id().get(3); }
 
-bool compare_tracker_hit_by_delayed_time::operator()(const calibrated_tracker_hit& hit_i_,
-                                                     const calibrated_tracker_hit& hit_j_) const {
+bool compare_tracker_hit_by_delayed_time::operator()(const calibrated_tracker_hit& lhs,
+                                                     const calibrated_tracker_hit& rhs) const {
   double dti = 0.0;
-  if (hit_i_.is_delayed()) {
-    dti = hit_i_.get_delayed_time();
+  if (lhs.is_delayed()) {
+    dti = lhs.get_delayed_time();
   }
   double dtj = 0.0;
-  if (hit_j_.is_delayed()) {
-    dtj = hit_j_.get_delayed_time();
+  if (rhs.is_delayed()) {
+    dtj = rhs.get_delayed_time();
   }
   return (dti < dtj);
 }
 
-void calibrated_tracker_hit::tree_dump(std::ostream& out_, const std::string& title_,
-                                       const std::string& indent_, bool inherit_) const {
-  base_hit::tree_dump(out_, title_, indent_, true);
+void calibrated_tracker_hit::tree_dump(std::ostream& out, const std::string& title,
+                                       const std::string& indent, bool is_last) const {
+  base_hit::tree_dump(out, title, indent, true);
 
-  out_ << indent_ << datatools::i_tree_dumpable::tag << "Traits        : " << _traits_ << std::endl;
+  std::ostringstream prefix_os;
+  prefix_os << indent << datatools::i_tree_dumpable::tag;
+  std::string prefix = prefix_os.str();
 
-  out_ << indent_ << datatools::i_tree_dumpable::tag << "Delayed        : " << is_delayed()
-       << std::endl;
-
-  out_ << indent_ << datatools::i_tree_dumpable::tag << "Noisy        : " << is_noisy()
-       << std::endl;
-
-  out_ << indent_ << datatools::i_tree_dumpable::tag << "Peripheral        : " << is_peripheral()
-       << std::endl;
-
-  out_ << indent_ << datatools::i_tree_dumpable::tag
-       << "Bottom cathode missing : " << is_bottom_cathode_missing() << std::endl;
-
-  out_ << indent_ << datatools::i_tree_dumpable::tag
-       << "Top cathode missing : " << is_top_cathode_missing() << std::endl;
-
-  out_ << indent_ << datatools::i_tree_dumpable::tag << "Sterile        : " << is_sterile()
-       << std::endl;
-
-  out_ << indent_ << datatools::i_tree_dumpable::tag << "Fake        : " << is_fake() << std::endl;
-
+  out << prefix << "Traits : " << traits_ << std::endl;
+  out << prefix << "Delayed : " << is_delayed() << std::endl;
+  out << prefix << "Noisy : " << is_noisy() << std::endl;
+  out << prefix << "Peripheral : " << is_peripheral() << std::endl;
+  out << prefix << "Bottom cathode missing : " << is_bottom_cathode_missing() << std::endl;
+  out << prefix << "Top cathode missing : " << is_top_cathode_missing() << std::endl;
+  out << prefix << "Sterile : " << is_sterile() << std::endl;
+  out << prefix << "Fake : " << is_fake() << std::endl;
   if (has_xy()) {
-    out_ << indent_ << datatools::i_tree_dumpable::tag << "x        : " << _x_ / CLHEP::mm << " mm"
-         << std::endl;
-
-    out_ << indent_ << datatools::i_tree_dumpable::tag << "y        : " << _y_ / CLHEP::mm << " mm"
-         << std::endl;
+    out << prefix << "x : " << x_ / CLHEP::mm << " mm" << std::endl;
+    out << prefix << "y : " << y_ / CLHEP::mm << " mm" << std::endl;
   }
-
   if (is_delayed()) {
-    out_ << indent_ << datatools::i_tree_dumpable::tag
-         << "delayed_time       : " << _delayed_time_ / CLHEP::microsecond << " us" << std::endl;
-
-    out_ << indent_ << datatools::i_tree_dumpable::tag
-         << "delayed_time_error : " << _delayed_time_error_ / CLHEP::microsecond << " us"
-         << std::endl;
+    out << prefix << "delayed_time : " << delayed_time_ / CLHEP::microsecond << " us" << std::endl;
+    out << prefix << "delayed_time_error : " << delayed_time_error_ / CLHEP::microsecond << " us"
+        << std::endl;
   }
-
-  out_ << indent_ << datatools::i_tree_dumpable::tag << "r        : " << _r_ / CLHEP::mm << " mm"
-       << std::endl;
-
-  out_ << indent_ << datatools::i_tree_dumpable::tag << "sigma(r) : " << _sigma_r_ / CLHEP::mm
-       << " mm" << std::endl;
-
-  out_ << indent_ << datatools::i_tree_dumpable::tag << "z        : " << _z_ / CLHEP::cm << " cm"
-       << std::endl;
-
-  out_ << indent_ << datatools::i_tree_dumpable::inherit_tag(inherit_)
-       << "sigma(z) : " << _sigma_z_ / CLHEP::cm << " cm" << std::endl;
+  out << prefix << "r : " << r_ / CLHEP::mm << " mm" << std::endl;
+  out << prefix << "sigma(r) : " << sigma_r_ / CLHEP::mm << " mm" << std::endl;
+  out << prefix << "z : " << z_ / CLHEP::cm << " cm" << std::endl;
+  out << indent << datatools::i_tree_dumpable::inherit_tag(is_last)
+      << "sigma(z) : " << sigma_z_ / CLHEP::cm << " cm" << std::endl;
 }
 
-void calibrated_tracker_hit::dump() const {
-  tree_dump(std::clog, "snemo::core::model::calibrated_tracker_hit");
-}
 }  // end of namespace datamodel
 
 }  // end of namespace snemo

--- a/source/falaise/snemo/datamodels/calibrated_tracker_hit.h
+++ b/source/falaise/snemo/datamodels/calibrated_tracker_hit.h
@@ -190,11 +190,11 @@ class calibrated_tracker_hit : public geomtools::base_hit {
 
   /// Smart print method
   virtual void tree_dump(std::ostream& out = std::clog, const std::string& title = "",
-                         const std::string& indent = "", bool inherit = false) const;
+                         const std::string& indent = "", bool is_last = false) const;
 
 
  protected:
-  void set_trait_bit(bool value, uint32_t mask);
+  void set_trait_bit(bool value, uint32_t trait);
 
  private:
   uint32_t traits_{0x0};                       //!< Bitset for special traits

--- a/source/falaise/snemo/datamodels/calibrated_tracker_hit.h
+++ b/source/falaise/snemo/datamodels/calibrated_tracker_hit.h
@@ -114,7 +114,7 @@ class calibrated_tracker_hit : public geomtools::base_hit {
   double get_anode_time() const;
 
   /// Interface to deal with trait bits
-  bool get_trait_bit(uint32_t mask_) const;
+  bool get_trait_bit(uint32_t trait) const;
 
   /// Check if the hit is marked as noisy
   bool is_noisy() const;
@@ -141,7 +141,7 @@ class calibrated_tracker_hit : public geomtools::base_hit {
   double get_delayed_time_error() const;
 
   /// Set the hit as delayed and store its referece delayed time and associated error
-  void set_delayed_time(double ref_delayed_time_, double ref_delayed_time_error_ = 0.0);
+  void set_delayed_time(double time, double error = 0.0);
 
   /// Check if the hit is not marked as delayed
   bool is_prompt() const;
@@ -189,44 +189,39 @@ class calibrated_tracker_hit : public geomtools::base_hit {
   virtual void clear();
 
   /// Smart print method
-  virtual void tree_dump(std::ostream& out_ = std::clog, const std::string& title_ = "",
-                         const std::string& indent_ = "", bool inherit_ = false) const;
+  virtual void tree_dump(std::ostream& out = std::clog, const std::string& title = "",
+                         const std::string& indent = "", bool inherit = false) const;
 
-  /// Shortcut for the smart print method
-  void dump() const;
 
  protected:
-  void _set_trait_bit(bool value_, uint32_t mask_);
-
-  bool _get_trait_bit(uint32_t mask_) const;
+  void set_trait_bit(bool value, uint32_t mask);
 
  private:
-  uint32_t _traits_{0x0};  //!< Bitset for special traits
-  double _r_{
-      datatools::invalid_real()};  //!< Transverse drift distance within the cell coordinates system
-  double _sigma_r_{datatools::invalid_real()};  //!< Transverse drift distance error
-  double _z_{
+  uint32_t traits_{0x0};                       //!< Bitset for special traits
+  double r_{datatools::invalid_real()};        //!< Transverse drift distance
+  double sigma_r_{datatools::invalid_real()};  //!< Transverse drift distance error
+  double z_{
       datatools::invalid_real()};  //!< Longitudinal position within the cell coordinates system
-  double _sigma_z_{datatools::invalid_real()};  //!< Longitudinal position error
-  double _x_{datatools::invalid_real()};        //!< X position of the anode wire within the module
-                                                //!< coordinates system
-  double _y_{datatools::invalid_real()};        //!< Y position of the anode wire within the module
-                                                //!< coordinates system
-  double _delayed_time_{datatools::invalid_real()};        //!< Delayed reference time
-  double _delayed_time_error_{datatools::invalid_real()};  //!< Delayed reference time error
+  double sigma_z_{datatools::invalid_real()};  //!< Longitudinal position error
+  double x_{datatools::invalid_real()};        //!< X position of the anode wire within the module
+                                               //!< coordinates system
+  double y_{datatools::invalid_real()};        //!< Y position of the anode wire within the module
+                                               //!< coordinates system
+  double delayed_time_{datatools::invalid_real()};        //!< Delayed reference time
+  double delayed_time_error_{datatools::invalid_real()};  //!< Delayed reference time error
 
   DATATOOLS_SERIALIZATION_DECLARATION()
 };
 
 /// Functor that compares hits by delayed time
 struct compare_tracker_hit_by_delayed_time {
-  bool operator()(const calibrated_tracker_hit& hit_i_, const calibrated_tracker_hit& hit_j_) const;
+  bool operator()(const calibrated_tracker_hit& lhs, const calibrated_tracker_hit& rhs) const;
 };
 
 /// Alias for a handle on a calibrated tracker hit
-//typedef datatools::handle<calibrated_tracker_hit> handle_type;
+// typedef datatools::handle<calibrated_tracker_hit> handle_type;
 /// Alias for a collection of handles on calibrated tracker hits
-//typedef std::vector<handle_type> collection_type;
+// typedef std::vector<handle_type> collection_type;
 
 using TrackerHit = calibrated_tracker_hit;
 using TrackerHitCollection = std::vector<TrackerHit>;

--- a/source/falaise/snemo/datamodels/calibrated_tracker_hit.h
+++ b/source/falaise/snemo/datamodels/calibrated_tracker_hit.h
@@ -47,12 +47,6 @@ class calibrated_tracker_hit : public geomtools::base_hit {
     fake = datatools::bit_mask::bit07
   };
 
-  /// Alias for a handle on a calibrated tracker hit
-  typedef datatools::handle<calibrated_tracker_hit> handle_type;
-
-  /// Alias for a collection of handles on calibrated tracker hits
-  typedef std::vector<handle_type> collection_type;
-
   /// Return the hit ID
   int32_t get_id() const;
 
@@ -207,15 +201,19 @@ class calibrated_tracker_hit : public geomtools::base_hit {
   bool _get_trait_bit(uint32_t mask_) const;
 
  private:
-  uint32_t _traits_{0x0};                                 //!< Bitset for special traits
-  double _r_{datatools::invalid_real()};                  //!< Transverse drift distance within the cell coordinates system
-  double _sigma_r_{datatools::invalid_real()};            //!< Transverse drift distance error
-  double _z_{datatools::invalid_real()};                  //!< Longitudinal position within the cell coordinates system
-  double _sigma_z_{datatools::invalid_real()};            //!< Longitudinal position error
-  double _x_{datatools::invalid_real()};                  //!< X position of the anode wire within the module coordinates system
-  double _y_{datatools::invalid_real()};                  //!< Y position of the anode wire within the module coordinates system
-  double _delayed_time_{datatools::invalid_real()};       //!< Delayed reference time
-  double _delayed_time_error_{datatools::invalid_real()}; //!< Delayed reference time error
+  uint32_t _traits_{0x0};  //!< Bitset for special traits
+  double _r_{
+      datatools::invalid_real()};  //!< Transverse drift distance within the cell coordinates system
+  double _sigma_r_{datatools::invalid_real()};  //!< Transverse drift distance error
+  double _z_{
+      datatools::invalid_real()};  //!< Longitudinal position within the cell coordinates system
+  double _sigma_z_{datatools::invalid_real()};  //!< Longitudinal position error
+  double _x_{datatools::invalid_real()};        //!< X position of the anode wire within the module
+                                                //!< coordinates system
+  double _y_{datatools::invalid_real()};        //!< Y position of the anode wire within the module
+                                                //!< coordinates system
+  double _delayed_time_{datatools::invalid_real()};        //!< Delayed reference time
+  double _delayed_time_error_{datatools::invalid_real()};  //!< Delayed reference time error
 
   DATATOOLS_SERIALIZATION_DECLARATION()
 };
@@ -224,6 +222,17 @@ class calibrated_tracker_hit : public geomtools::base_hit {
 struct compare_tracker_hit_by_delayed_time {
   bool operator()(const calibrated_tracker_hit& hit_i_, const calibrated_tracker_hit& hit_j_) const;
 };
+
+/// Alias for a handle on a calibrated tracker hit
+//typedef datatools::handle<calibrated_tracker_hit> handle_type;
+/// Alias for a collection of handles on calibrated tracker hits
+//typedef std::vector<handle_type> collection_type;
+
+using TrackerHit = calibrated_tracker_hit;
+using TrackerHitCollection = std::vector<TrackerHit>;
+
+using TrackerHitHdl = datatools::handle<TrackerHit>;
+using TrackerHitHdlCollection = std::vector<TrackerHitHdl>;
 
 }  // end of namespace datamodel
 

--- a/source/falaise/snemo/datamodels/calibrated_tracker_hit.h
+++ b/source/falaise/snemo/datamodels/calibrated_tracker_hit.h
@@ -96,7 +96,7 @@ class calibrated_tracker_hit : public geomtools::base_hit {
   bool has_xy() const;
 
   /// Set the X/Y position of the center of the cell in the module coordinates system
-  void set_xy(double x_, double y_);
+  void set_xy(double x, double y);
 
   /// Invalidate X/Y position of the center of the cell
   void invalidate_xy();

--- a/source/falaise/snemo/datamodels/data_model.cc
+++ b/source/falaise/snemo/datamodels/data_model.cc
@@ -21,26 +21,6 @@ const std::string& labels::simulated_data() {
   return lbl;
 }
 
-const std::string& labels::simulated_signal_data() {
-  static std::string lbl("SSD");
-  return lbl;
-}
-
-const std::string& labels::simulated_digitized_data() {
-  static std::string lbl("SDD");
-  return lbl;
-}
-
-const std::string& labels::raw_data() {
-  static std::string lbl("RD");
-  return lbl;
-}
-
-const std::string& labels::unified_digitized_data() {
-  static std::string lbl("UDD");
-  return lbl;
-}
-
 const std::string& labels::calibrated_data() {
   static std::string lbl("CD");
   return lbl;

--- a/source/falaise/snemo/datamodels/data_model.cc
+++ b/source/falaise/snemo/datamodels/data_model.cc
@@ -4,65 +4,61 @@
 // Ourselves:
 #include <falaise/snemo/datamodels/data_model.h>
 
-namespace snemo {
+namespace snedm {
 
-namespace datamodel {
-
-const std::string& data_info::default_event_record_label() {
+const std::string& labels::event_record() {
   static std::string lbl("ER");
   return lbl;
 }
 
-const std::string& data_info::default_event_header_label() {
+const std::string& labels::event_header() {
   static std::string lbl("EH");
   return lbl;
 }
 
-const std::string& data_info::default_simulated_data_label() {
+const std::string& labels::simulated_data() {
   static std::string lbl("SD");
   return lbl;
 }
 
-const std::string& data_info::default_simulated_signal_data_label() {
+const std::string& labels::simulated_signal_data() {
   static std::string lbl("SSD");
   return lbl;
 }
 
-const std::string& data_info::default_simulated_digitized_data_label() {
+const std::string& labels::simulated_digitized_data() {
   static std::string lbl("SDD");
   return lbl;
 }
 
-const std::string& data_info::default_raw_data_label() {
+const std::string& labels::raw_data() {
   static std::string lbl("RD");
   return lbl;
 }
 
-const std::string& data_info::default_unified_digitized_data_label() {
+const std::string& labels::unified_digitized_data() {
   static std::string lbl("UDD");
   return lbl;
 }
 
-const std::string& data_info::default_calibrated_data_label() {
+const std::string& labels::calibrated_data() {
   static std::string lbl("CD");
   return lbl;
 }
 
-const std::string& data_info::default_tracker_clustering_data_label() {
+const std::string& labels::tracker_clustering_data() {
   static std::string lbl("TCD");
   return lbl;
 }
 
-const std::string& data_info::default_tracker_trajectory_data_label() {
+const std::string& labels::tracker_trajectory_data() {
   static std::string lbl("TTD");
   return lbl;
 }
 
-const std::string& data_info::default_particle_track_data_label() {
+const std::string& labels::particle_track_data() {
   static std::string lbl("PTD");
   return lbl;
 }
 
-}  // end of namespace datamodel
-
-}  // end of namespace snemo
+}  // namespace snedm

--- a/source/falaise/snemo/datamodels/data_model.h
+++ b/source/falaise/snemo/datamodels/data_model.h
@@ -22,49 +22,45 @@
 // - Bayeux/datatools:
 #include <falaise/snemo/datamodels/event.h>
 
-namespace snemo {
+namespace snedm {
 
-namespace datamodel {
-
-class data_info {
+class labels {
  public:
   /// Return the default string label/name for the 'event record'
-  static const std::string& default_event_record_label();
+  static const std::string& event_record();
 
   // Data bank standard labels/names :
 
   /// default string label/name for the 'event header'
-  static const std::string& default_event_header_label();
+  static const std::string& event_header();
 
   /// default string label/name for the 'simulated data'
-  static const std::string& default_simulated_data_label();
+  static const std::string& simulated_data();
 
   /// default string label/name for the 'simulated signal data'
-  static const std::string& default_simulated_signal_data_label();
+  static const std::string& simulated_signal_data();
 
   /// default string label/name for the 'simulated digitized data'
-  static const std::string& default_simulated_digitized_data_label();
+  static const std::string& simulated_digitized_data();
 
   /// default string label/name for the 'raw data'
-  static const std::string& default_raw_data_label();
+  static const std::string& raw_data();
 
   /// default string label/name for the 'unified data'
-  static const std::string& default_unified_digitized_data_label();
+  static const std::string& unified_digitized_data();
 
   /// default string label/name for the 'calibrated data'
-  static const std::string& default_calibrated_data_label();
+  static const std::string& calibrated_data();
 
   /// default string label/name for the 'tracker clustering data'
-  static const std::string& default_tracker_clustering_data_label();
+  static const std::string& tracker_clustering_data();
 
   /// Return the default string label/name for the 'tracker trajectory data'
-  static const std::string& default_tracker_trajectory_data_label();
+  static const std::string& tracker_trajectory_data();
 
   /// Return the default string label/name for the 'particle track data'
-  static const std::string& default_particle_track_data_label();
+  static const std::string& particle_track_data();
 };
-
-}  // end of namespace datamodel
 
 }  // end of namespace snemo
 

--- a/source/falaise/snemo/datamodels/data_model.h
+++ b/source/falaise/snemo/datamodels/data_model.h
@@ -37,18 +37,6 @@ class labels {
   /// default string label/name for the 'simulated data'
   static const std::string& simulated_data();
 
-  /// default string label/name for the 'simulated signal data'
-  static const std::string& simulated_signal_data();
-
-  /// default string label/name for the 'simulated digitized data'
-  static const std::string& simulated_digitized_data();
-
-  /// default string label/name for the 'raw data'
-  static const std::string& raw_data();
-
-  /// default string label/name for the 'unified data'
-  static const std::string& unified_digitized_data();
-
   /// default string label/name for the 'calibrated data'
   static const std::string& calibrated_data();
 

--- a/source/falaise/snemo/datamodels/event.h
+++ b/source/falaise/snemo/datamodels/event.h
@@ -8,19 +8,18 @@
 
 #include <bayeux/datatools/things.h>
 
-namespace snemo {
-namespace datamodel {
+namespace snedm {
 //! Event record type definition
 using event_record = datatools::things;
 
 //! Get or add instance of T at supplied key in event record
-  /*!
-   * \tparam T type of value to be retrieved or added
-   * \param[in] key key for value to find
-   * \param[in] event event record to search in
-   * \returns reference to value held at key
-   * \throws datatools::bad_things_cast if value at key is not of type T
-   */
+/*!
+ * \tparam T type of value to be retrieved or added
+ * \param[in] key key for value to find
+ * \param[in] event event record to search in
+ * \returns reference to value held at key
+ * \throws datatools::bad_things_cast if value at key is not of type T
+ */
 template <typename T>
 T& getOrAddToEvent(std::string const& key, event_record& event) {
   if (event.has(key)) {
@@ -29,7 +28,6 @@ T& getOrAddToEvent(std::string const& key, event_record& event) {
   return event.add<T>(key);
 }
 
-}  // namespace datamodels
-}  // namespace snemo
+}  // namespace snedm
 
 #endif

--- a/source/falaise/snemo/datamodels/event_header.cc
+++ b/source/falaise/snemo/datamodels/event_header.cc
@@ -10,88 +10,70 @@ namespace datamodel {
 // Serial tag for datatools::i_serializable interface :
 DATATOOLS_SERIALIZATION_SERIAL_TAG_IMPLEMENTATION(event_header, "snemo::datamodel::event_header")
 
-const datatools::event_id& event_header::get_id() const { return _id_; }
+const datatools::event_id& event_header::get_id() const { return id_; }
 
-datatools::event_id& event_header::get_id() { return _id_; }
+datatools::event_id& event_header::get_id() { return id_; }
 
-void event_header::set_id(const datatools::event_id& id_) {
-  _id_ = id_;
-}
+void event_header::set_id(const datatools::event_id& id) { id_ = id; }
 
-const datatools::properties& event_header::get_properties() const { return _properties_; }
+const datatools::properties& event_header::get_properties() const { return properties_; }
 
-datatools::properties& event_header::get_properties() { return _properties_; }
+datatools::properties& event_header::get_properties() { return properties_; }
 
-void event_header::set_properties(const datatools::properties& properties_) {
-  _properties_ = properties_;
-}
+void event_header::set_properties(const datatools::properties& pset) { properties_ = pset; }
 
-const snemo::datamodel::timestamp& event_header::get_timestamp() const { return _timestamp_; }
+const snemo::datamodel::timestamp& event_header::get_timestamp() const { return timestamp_; }
 
-snemo::datamodel::timestamp& event_header::get_timestamp() { return _timestamp_; }
+snemo::datamodel::timestamp& event_header::get_timestamp() { return timestamp_; }
 
-void event_header::set_timestamp(const snemo::datamodel::timestamp& timestamp_) {
-  _timestamp_ = timestamp_;
-}
+void event_header::set_timestamp(const snemo::datamodel::timestamp& ts) { timestamp_ = ts; }
 
-event_header::generation_type event_header::get_generation() const { return _generation_; }
+event_header::generation_type event_header::get_generation() const { return generation_; }
 
-void event_header::set_generation(generation_type generation_) {
-  _generation_ = generation_;
-}
+void event_header::set_generation(generation_type gen) { generation_ = gen; }
 
-bool event_header::is_real() const { return _generation_ == GENERATION_REAL; }
+bool event_header::is_real() const { return generation_ == GENERATION_REAL; }
 
-bool event_header::is_simulated() const { return _generation_ == GENERATION_SIMULATED; }
+bool event_header::is_simulated() const { return generation_ == GENERATION_SIMULATED; }
 
 void event_header::clear() {
-  _properties_.clear();
-  _timestamp_ = snemo::datamodel::timestamp{};
-  _generation_ = GENERATION_INVALID;
-  _id_.clear();
+  properties_.clear();
+  timestamp_ = snemo::datamodel::timestamp{};
+  generation_ = GENERATION_INVALID;
+  id_.clear();
 }
 
-void event_header::tree_dump(std::ostream& out_, const std::string& title_,
-                             const std::string& indent_, bool inherit_) const {
-  if (!title_.empty()) {
-    out_ << indent_ << title_ << std::endl;
+void event_header::tree_dump(std::ostream& out, const std::string& title, const std::string& indent,
+                             bool is_last) const {
+  if (!title.empty()) {
+    out << indent << title << std::endl;
   }
 
-  out_ << indent_ << datatools::i_tree_dumpable::tag << "Id : " << std::endl;
+  out << indent << datatools::i_tree_dumpable::tag << "Id : " << std::endl;
   {
     std::ostringstream indent_oss;
-    indent_oss << indent_;
-    indent_oss << datatools::i_tree_dumpable::skip_tag;
-    _id_.tree_dump(out_, "", indent_oss.str());
+    indent_oss << indent << datatools::i_tree_dumpable::skip_tag;
+    id_.tree_dump(out, "", indent_oss.str());
   }
 
-  out_ << indent_ << datatools::i_tree_dumpable::tag << "Timestamp : " << _timestamp_ << std::endl;
+  out << indent << datatools::i_tree_dumpable::tag << "Timestamp : " << timestamp_ << std::endl;
 
-  out_ << indent_ << datatools::i_tree_dumpable::tag << "Properties : ";
-  if (_properties_.empty()) {
-    out_ << "<empty>";
-  }
-  out_ << std::endl;
+  out << indent << datatools::i_tree_dumpable::tag << "Properties : " << std::endl;
   {
     std::ostringstream indent_oss;
-    indent_oss << indent_;
-    indent_oss << datatools::i_tree_dumpable::skip_tag;
-    _properties_.tree_dump(out_, "", indent_oss.str());
+    indent_oss << indent << datatools::i_tree_dumpable::skip_tag;
+    properties_.tree_dump(out, "", indent_oss.str());
   }
 
-  out_ << indent_ << datatools::i_tree_dumpable::inherit_tag(inherit_)
-       << "Generation : " << _generation_;
+  out << indent << datatools::i_tree_dumpable::inherit_tag(is_last)
+      << "Generation : " << generation_;
   if (is_simulated()) {
-    out_ << ' ' << "[simulated]";
+    out << ' ' << "[simulated]";
   }
   if (is_real()) {
-    out_ << ' ' << "[real]";
+    out << ' ' << "[real]";
   }
-  out_ << std::endl;
-}
-
-void event_header::dump() const {
-  tree_dump(std::clog, event_header::SERIAL_TAG);
+  out << std::endl;
 }
 
 }  // end of namespace datamodel

--- a/source/falaise/snemo/datamodels/event_header.cc
+++ b/source/falaise/snemo/datamodels/event_header.cc
@@ -46,7 +46,7 @@ bool event_header::is_simulated() const { return _generation_ == GENERATION_SIMU
 
 void event_header::clear() {
   _properties_.clear();
-  _timestamp_.invalidate();
+  _timestamp_ = snemo::datamodel::timestamp{};
   _generation_ = GENERATION_INVALID;
   _id_.clear();
 }

--- a/source/falaise/snemo/datamodels/event_header.cc
+++ b/source/falaise/snemo/datamodels/event_header.cc
@@ -65,13 +65,12 @@ void event_header::tree_dump(std::ostream& out, const std::string& title, const 
     properties_.tree_dump(out, "", indent_oss.str());
   }
 
-  out << indent << datatools::i_tree_dumpable::inherit_tag(is_last)
-      << "Generation : " << generation_;
+  out << indent << datatools::i_tree_dumpable::inherit_tag(is_last) << "Generation : ";
   if (is_simulated()) {
-    out << ' ' << "[simulated]";
+    out << "simulated";
   }
   if (is_real()) {
-    out << ' ' << "[real]";
+    out << "real";
   }
   out << std::endl;
 }

--- a/source/falaise/snemo/datamodels/event_header.h
+++ b/source/falaise/snemo/datamodels/event_header.h
@@ -88,17 +88,14 @@ class event_header : public datatools::i_serializable,
   virtual void clear();
 
   /// Smart print
-  virtual void tree_dump(std::ostream &out_ = std::clog, const std::string &title_ = "",
-                         const std::string &indent_ = "", bool inherit_ = false) const;
-
-  /// Basic print
-  void dump() const;
+  virtual void tree_dump(std::ostream &out = std::clog, const std::string &title = "",
+                         const std::string &indent = "", bool is_last = false) const;
 
  private:
-  datatools::event_id _id_{};                 //!< Run/Event ID
-  generation_type _generation_{GENERATION_INVALID};             //!< Generation flag
-  snemo::datamodel::timestamp _timestamp_{};  //!< Reference time of the event
-  datatools::properties _properties_{};       //!< Dictionary of properties
+  datatools::event_id id_{};                        //!< Run/Event ID
+  generation_type generation_{GENERATION_INVALID};  //!< Generation flag
+  snemo::datamodel::timestamp timestamp_{};         //!< Reference time of the event
+  datatools::properties properties_{};              //!< Dictionary of properties
 
   DATATOOLS_SERIALIZATION_DECLARATION()
 };

--- a/source/falaise/snemo/datamodels/particle_track.cc
+++ b/source/falaise/snemo/datamodels/particle_track.cc
@@ -7,24 +7,24 @@ namespace snemo {
 
 namespace datamodel {
 
-bool particle_track::particle_has(const particle_track& pt_, charge_type charge_) {
+bool particle_has(const Particle& pt_, Particle::charge_type charge_) {
   return pt_.get_charge() == charge_;
 }
 
-bool particle_track::particle_has_negative_charge(const particle_track& pt_) {
-  return particle_has(pt_, NEGATIVE);
+bool particle_has_negative_charge(const Particle& pt_) {
+  return particle_has(pt_, Particle::NEGATIVE);
 }
 
-bool particle_track::particle_has_positive_charge(const particle_track& pt_) {
-  return particle_has(pt_, POSITIVE);
+bool particle_has_positive_charge(const Particle& pt_) {
+  return particle_has(pt_, Particle::POSITIVE);
 }
 
-bool particle_track::particle_has_undefined_charge(const particle_track& pt_) {
-  return particle_has(pt_, UNDEFINED);
+bool particle_has_undefined_charge(const Particle& pt_) {
+  return particle_has(pt_, Particle::UNDEFINED);
 }
 
-bool particle_track::particle_has_neutral_charge(const particle_track& pt_) {
-  return particle_has(pt_, NEUTRAL);
+bool particle_has_neutral_charge(const Particle& pt_) {
+  return particle_has(pt_, Particle::NEUTRAL);
 }
 
 const std::string& particle_track::vertex_type_key() {
@@ -219,7 +219,7 @@ void particle_track::clear() {
   reset_associated_calorimeter_hits();
   detach_trajectory();
   base_hit::clear();
-  _charge_from_source_ = invalid;
+  _charge_from_source_ = UNDEFINED;
 }
 
 void particle_track::tree_dump(std::ostream& out_, const std::string& title_,
@@ -231,20 +231,20 @@ void particle_track::tree_dump(std::ostream& out_, const std::string& title_,
 
   out_ << indent_ << datatools::i_tree_dumpable::tag << "Trajectory : ";
   if (has_trajectory()) {
-    out_ << _trajectory_.get().get_trajectory_id();
+    out_ << _trajectory_->get_id();
   } else {
     out_ << "<No>";
   }
   out_ << std::endl;
 
   out_ << indent_ << datatools::i_tree_dumpable::tag << "Particle charge : ";
-  if (get_charge() == invalid) {
+  if (get_charge() == UNDEFINED) {
     out_ << "invalid";
-  } else if (get_charge() == negative) {
+  } else if (get_charge() == NEGATIVE) {
     out_ << "negative";
-  } else if (get_charge() == positive) {
+  } else if (get_charge() == POSITIVE) {
     out_ << "positive";
-  } else if (get_charge() == neutral) {
+  } else if (get_charge() == NEUTRAL) {
     out_ << "neutral";
   }
   out_ << std::endl;

--- a/source/falaise/snemo/datamodels/particle_track.cc
+++ b/source/falaise/snemo/datamodels/particle_track.cc
@@ -203,11 +203,11 @@ bool particle_track::has_associated_calorimeter_hits() const {
 
 void particle_track::reset_associated_calorimeter_hits() { _associated_calorimeter_hits_.clear(); }
 
-calibrated_calorimeter_hit::collection_type& particle_track::get_associated_calorimeter_hits() {
+CalorimeterHitHdlCollection& particle_track::get_associated_calorimeter_hits() {
   return _associated_calorimeter_hits_;
 }
 
-const calibrated_calorimeter_hit::collection_type& particle_track::get_associated_calorimeter_hits()
+const CalorimeterHitHdlCollection& particle_track::get_associated_calorimeter_hits()
     const {
   return _associated_calorimeter_hits_;
 }

--- a/source/falaise/snemo/datamodels/particle_track.cc
+++ b/source/falaise/snemo/datamodels/particle_track.cc
@@ -140,14 +140,14 @@ bool particle_track::has_trajectory() const { return _trajectory_.has_data(); }
 
 void particle_track::detach_trajectory() { _trajectory_.reset(); }
 
-tracker_trajectory::handle_type& particle_track::get_trajectory_handle() { return _trajectory_; }
+TrackerTrajectoryHdl& particle_track::get_trajectory_handle() { return _trajectory_; }
 
-const tracker_trajectory::handle_type& particle_track::get_trajectory_handle() const {
+const TrackerTrajectoryHdl& particle_track::get_trajectory_handle() const {
   return _trajectory_;
 }
 
 void particle_track::set_trajectory_handle(
-    const tracker_trajectory::handle_type& trajectory_handle_) {
+    const TrackerTrajectoryHdl& trajectory_handle_) {
   _trajectory_ = trajectory_handle_;
 }
 

--- a/source/falaise/snemo/datamodels/particle_track.cc
+++ b/source/falaise/snemo/datamodels/particle_track.cc
@@ -7,33 +7,27 @@ namespace snemo {
 
 namespace datamodel {
 
-bool particle_has(const Particle& pt_, Particle::charge_type charge_) {
-  return pt_.get_charge() == charge_;
+bool particle_has(const Particle& p, Particle::charge_type charge) {
+  return p.get_charge() == charge;
 }
 
-bool particle_has_negative_charge(const Particle& pt_) {
-  return particle_has(pt_, Particle::NEGATIVE);
+bool particle_has_negative_charge(const Particle& p) { return particle_has(p, Particle::NEGATIVE); }
+
+bool particle_has_positive_charge(const Particle& p) { return particle_has(p, Particle::POSITIVE); }
+
+bool particle_has_undefined_charge(const Particle& p) {
+  return particle_has(p, Particle::UNDEFINED);
 }
 
-bool particle_has_positive_charge(const Particle& pt_) {
-  return particle_has(pt_, Particle::POSITIVE);
-}
-
-bool particle_has_undefined_charge(const Particle& pt_) {
-  return particle_has(pt_, Particle::UNDEFINED);
-}
-
-bool particle_has_neutral_charge(const Particle& pt_) {
-  return particle_has(pt_, Particle::NEUTRAL);
-}
+bool particle_has_neutral_charge(const Particle& p) { return particle_has(p, Particle::NEUTRAL); }
 
 const std::string& particle_track::vertex_type_key() {
   static const std::string _flag("vertex.type");
   return _flag;
 }
 
-const std::string& particle_track::vertex_type_to_label(vertex_type vt_) {
-  switch (vt_) {
+const std::string& particle_track::vertex_type_to_label(vertex_type v) {
+  switch (v) {
     case VERTEX_ON_SOURCE_FOIL:
       return vertex_on_source_foil_label();
     case VERTEX_ON_MAIN_CALORIMETER:
@@ -49,20 +43,20 @@ const std::string& particle_track::vertex_type_to_label(vertex_type vt_) {
   }
 }
 
-particle_track::vertex_type particle_track::label_to_vertex_type(const std::string& label_) {
-  if (label_ == vertex_on_source_foil_label()) {
+particle_track::vertex_type particle_track::label_to_vertex_type(const std::string& label) {
+  if (label == vertex_on_source_foil_label()) {
     return VERTEX_ON_SOURCE_FOIL;
   }
-  if (label_ == vertex_on_main_calorimeter_label()) {
+  if (label == vertex_on_main_calorimeter_label()) {
     return VERTEX_ON_MAIN_CALORIMETER;
   }
-  if (label_ == vertex_on_x_calorimeter_label()) {
+  if (label == vertex_on_x_calorimeter_label()) {
     return VERTEX_ON_X_CALORIMETER;
   }
-  if (label_ == vertex_on_gamma_veto_label()) {
+  if (label == vertex_on_gamma_veto_label()) {
     return VERTEX_ON_GAMMA_VETO;
   }
-  if (label_ == vertex_on_wire_label()) {
+  if (label == vertex_on_wire_label()) {
     return VERTEX_ON_WIRE;
   }
   return VERTEX_NONE;
@@ -98,202 +92,152 @@ const std::string& particle_track::vertex_on_gamma_veto_label() {
   return _flag;
 }
 
-bool particle_track::vertex_is(const geomtools::blur_spot& vtx_, vertex_type vtype_) {
-  if (vtx_.get_auxiliaries().has_key(vertex_type_key())) {
-    std::string vtype_label = vtx_.get_auxiliaries().fetch_string(vertex_type_key());
-    return vtype_label == vertex_type_to_label(vtype_);
+bool particle_track::vertex_is(const geomtools::blur_spot& vtx, vertex_type vtype) {
+  if (vtx.get_auxiliaries().has_key(vertex_type_key())) {
+    std::string vtype_label = vtx.get_auxiliaries().fetch_string(vertex_type_key());
+    return vtype_label == vertex_type_to_label(vtype);
   }
-  return vtype_ == VERTEX_NONE;
+  return vtype == VERTEX_NONE;
 }
 
-bool particle_track::vertex_is_on_source_foil(const geomtools::blur_spot& vtx_) {
-  return vertex_is(vtx_, VERTEX_ON_SOURCE_FOIL);
+bool particle_track::vertex_is_on_source_foil(const geomtools::blur_spot& vtx) {
+  return vertex_is(vtx, VERTEX_ON_SOURCE_FOIL);
 }
 
-bool particle_track::vertex_is_on_main_calorimeter(const geomtools::blur_spot& vtx_) {
-  return vertex_is(vtx_, VERTEX_ON_MAIN_CALORIMETER);
+bool particle_track::vertex_is_on_main_calorimeter(const geomtools::blur_spot& vtx) {
+  return vertex_is(vtx, VERTEX_ON_MAIN_CALORIMETER);
 }
 
-bool particle_track::vertex_is_on_x_calorimeter(const geomtools::blur_spot& vtx_) {
-  return vertex_is(vtx_, VERTEX_ON_X_CALORIMETER);
+bool particle_track::vertex_is_on_x_calorimeter(const geomtools::blur_spot& vtx) {
+  return vertex_is(vtx, VERTEX_ON_X_CALORIMETER);
 }
 
-bool particle_track::vertex_is_on_gamma_veto(const geomtools::blur_spot& vtx_) {
-  return vertex_is(vtx_, VERTEX_ON_GAMMA_VETO);
+bool particle_track::vertex_is_on_gamma_veto(const geomtools::blur_spot& vtx) {
+  return vertex_is(vtx, VERTEX_ON_GAMMA_VETO);
 }
 
-bool particle_track::vertex_is_on_wire(const geomtools::blur_spot& vtx_) {
-  return vertex_is(vtx_, VERTEX_ON_WIRE);
+bool particle_track::vertex_is_on_wire(const geomtools::blur_spot& vtx) {
+  return vertex_is(vtx, VERTEX_ON_WIRE);
 }
 
 bool particle_track::has_track_id() const { return has_hit_id(); }
 
 int particle_track::get_track_id() const { return get_hit_id(); }
 
-void particle_track::set_track_id(int32_t track_id_) { set_hit_id(track_id_); }
+void particle_track::set_track_id(int32_t id) { set_hit_id(id); }
 
-void particle_track::set_charge(charge_type charge_) { _charge_from_source_ = charge_; }
+void particle_track::set_charge(charge_type charge) { charge_from_source_ = charge; }
 
-particle_track::charge_type particle_track::get_charge() const { return _charge_from_source_; }
+particle_track::charge_type particle_track::get_charge() const { return charge_from_source_; }
 
-bool particle_track::has_trajectory() const { return _trajectory_.has_data(); }
+bool particle_track::has_trajectory() const { return trajectory_.has_data(); }
 
-void particle_track::detach_trajectory() { _trajectory_.reset(); }
+void particle_track::detach_trajectory() { trajectory_.reset(); }
 
-TrackerTrajectoryHdl& particle_track::get_trajectory_handle() { return _trajectory_; }
+TrackerTrajectoryHdl& particle_track::get_trajectory_handle() { return trajectory_; }
 
-const TrackerTrajectoryHdl& particle_track::get_trajectory_handle() const {
-  return _trajectory_;
+const TrackerTrajectoryHdl& particle_track::get_trajectory_handle() const { return trajectory_; }
+
+void particle_track::set_trajectory_handle(const TrackerTrajectoryHdl& trajectory) {
+  trajectory_ = trajectory;
 }
 
-void particle_track::set_trajectory_handle(
-    const TrackerTrajectoryHdl& trajectory_handle_) {
-  _trajectory_ = trajectory_handle_;
-}
+tracker_trajectory& particle_track::get_trajectory() { return *trajectory_; }
 
-tracker_trajectory& particle_track::get_trajectory() { return *_trajectory_; }
+const tracker_trajectory& particle_track::get_trajectory() const { return *trajectory_; }
 
-const tracker_trajectory& particle_track::get_trajectory() const { return *_trajectory_; }
+bool particle_track::has_vertices() const { return !vertices_.empty(); }
 
-bool particle_track::has_vertices() const { return !_vertices_.empty(); }
+void particle_track::clear_vertices() { vertices_.clear(); }
 
-void particle_track::reset_vertices() { _vertices_.clear(); }
-
-particle_track::vertex_collection_type& particle_track::get_vertices() { return _vertices_; }
+particle_track::vertex_collection_type& particle_track::get_vertices() { return vertices_; }
 
 const particle_track::vertex_collection_type& particle_track::get_vertices() const {
-  return _vertices_;
-}
-
-size_t particle_track::fetch_vertices(vertex_collection_type& vertices_, const uint32_t flags_,
-                                      const bool clear_) const {
-  if (clear_) {
-    vertices_.clear();
-  }
-  size_t ivtx = 0;
-  for (const auto& a_vertex : get_vertices()) {
-    const datatools::properties& aux = a_vertex->get_auxiliaries();
-    std::string vtx_type;
-    if (aux.has_key(vertex_type_key())) {
-      vtx_type = aux.fetch_string(vertex_type_key());
-    }
-    const bool has_vertex_on_foil =
-        ((flags_ & VERTEX_ON_SOURCE_FOIL) != 0u) && vertex_is_on_source_foil(*a_vertex);
-    const bool has_vertex_on_calo =
-        ((flags_ & VERTEX_ON_MAIN_CALORIMETER) != 0u) && vertex_is_on_main_calorimeter(*a_vertex);
-    const bool has_vertex_on_xcalo =
-        ((flags_ & VERTEX_ON_X_CALORIMETER) != 0u) && vertex_is_on_x_calorimeter(*a_vertex);
-    const bool has_vertex_on_gveto =
-        ((flags_ & VERTEX_ON_GAMMA_VETO) != 0u) && vertex_is_on_gamma_veto(*a_vertex);
-    const bool has_vertex_on_wire =
-        ((flags_ & VERTEX_ON_WIRE) != 0u) && vertex_is_on_wire(*a_vertex);
-
-    if (has_vertex_on_foil || has_vertex_on_calo || has_vertex_on_xcalo || has_vertex_on_gveto ||
-        has_vertex_on_wire) {
-      vertices_.push_back(a_vertex);
-      ivtx++;
-    }
-  }
-  return ivtx;
+  return vertices_;
 }
 
 bool particle_track::has_associated_calorimeter_hits() const {
-  return !_associated_calorimeter_hits_.empty();
+  return !associated_calorimeters_.empty();
 }
 
-void particle_track::reset_associated_calorimeter_hits() { _associated_calorimeter_hits_.clear(); }
+void particle_track::clear_associated_calorimeter_hits() { associated_calorimeters_.clear(); }
 
 CalorimeterHitHdlCollection& particle_track::get_associated_calorimeter_hits() {
-  return _associated_calorimeter_hits_;
+  return associated_calorimeters_;
 }
 
-const CalorimeterHitHdlCollection& particle_track::get_associated_calorimeter_hits()
-    const {
-  return _associated_calorimeter_hits_;
+const CalorimeterHitHdlCollection& particle_track::get_associated_calorimeter_hits() const {
+  return associated_calorimeters_;
 }
-
-void particle_track::reset() { this->clear(); }
 
 void particle_track::clear() {
-  reset_vertices();
-  reset_associated_calorimeter_hits();
+  clear_vertices();
+  clear_associated_calorimeter_hits();
   detach_trajectory();
   base_hit::clear();
-  _charge_from_source_ = UNDEFINED;
+  charge_from_source_ = UNDEFINED;
 }
 
-void particle_track::tree_dump(std::ostream& out_, const std::string& title_,
-                               const std::string& indent_, bool inherit_) const {
-  base_hit::tree_dump(out_, title_, indent_, true);
+void particle_track::tree_dump(std::ostream& out, const std::string& title,
+                               const std::string& indent, bool is_last) const {
+  base_hit::tree_dump(out, title, indent, true);
 
-  out_ << indent_ << datatools::i_tree_dumpable::tag << "Track ID : " << get_track_id()
-       << std::endl;
+  out << indent << datatools::i_tree_dumpable::tag << "Track ID : " << get_track_id() << std::endl;
 
-  out_ << indent_ << datatools::i_tree_dumpable::tag << "Trajectory : ";
+  out << indent << datatools::i_tree_dumpable::tag << "Trajectory : ";
   if (has_trajectory()) {
-    out_ << _trajectory_->get_id();
+    out << trajectory_->get_id();
   } else {
-    out_ << "<No>";
+    out << "<none>";
   }
-  out_ << std::endl;
+  out << std::endl;
 
-  out_ << indent_ << datatools::i_tree_dumpable::tag << "Particle charge : ";
+  out << indent << datatools::i_tree_dumpable::tag << "Particle charge : ";
   if (get_charge() == UNDEFINED) {
-    out_ << "invalid";
+    out << "invalid";
   } else if (get_charge() == NEGATIVE) {
-    out_ << "negative";
+    out << "negative";
   } else if (get_charge() == POSITIVE) {
-    out_ << "positive";
+    out << "positive";
   } else if (get_charge() == NEUTRAL) {
-    out_ << "neutral";
+    out << "neutral";
   }
-  out_ << std::endl;
+  out << std::endl;
 
-  out_ << indent_ << datatools::i_tree_dumpable::tag << "Vertices : ";
-  if (has_vertices()) {
-    out_ << _vertices_.size();
-  } else {
-    out_ << "<No>";
-  }
-  out_ << std::endl;
-  for (auto i = _vertices_.begin(); i != _vertices_.end(); i++) {
-    out_ << indent_ << datatools::i_tree_dumpable::skip_tag;
+  out << indent << datatools::i_tree_dumpable::tag << "Vertices[" << vertices_.size()
+      << "] :" << std::endl;
+  for (auto i = vertices_.begin(); i != vertices_.end(); i++) {
+    out << indent << datatools::i_tree_dumpable::skip_tag;
     auto j = i;
     j++;
-    if (j == _vertices_.end()) {
-      out_ << datatools::i_tree_dumpable::last_tag;
+    if (j == vertices_.end()) {
+      out << datatools::i_tree_dumpable::last_tag;
     } else {
-      out_ << datatools::i_tree_dumpable::tag;
+      out << datatools::i_tree_dumpable::tag;
     }
-    const geomtools::blur_spot& spot = i->get();
-    out_ << "Vertex Id=" << spot.get_hit_id() << " @ "
-         << spot.get_placement().get_translation() / CLHEP::mm << " mm"
-         << " (" << spot.get_auxiliaries().fetch_string(vertex_type_key()) << ")";
-
-    out_ << std::endl;
+    out << "Vertex Id=" << (*i)->get_hit_id() << " @ "
+        << (*i)->get_placement().get_translation() / CLHEP::mm << " mm"
+        << " (" << (*i)->get_auxiliaries().fetch_string(vertex_type_key()) << ")" << std::endl;
   }
 
-  out_ << indent_ << datatools::i_tree_dumpable::inherit_tag(inherit_)
-       << "Associated calorimeter hit(s) : ";
+  out << indent << datatools::i_tree_dumpable::inherit_tag(is_last)
+      << "Associated calorimeter hit(s) : ";
   if (has_associated_calorimeter_hits()) {
-    out_ << _associated_calorimeter_hits_.size();
+    out << associated_calorimeters_.size();
   } else {
-    out_ << "<No>";
+    out << "<No>";
   }
-  out_ << std::endl;
-  for (auto i = _associated_calorimeter_hits_.begin(); i != _associated_calorimeter_hits_.end();
-       i++) {
-    out_ << indent_ << datatools::i_tree_dumpable::inherit_skip_tag(inherit_);
+  out << std::endl;
+  for (auto i = associated_calorimeters_.begin(); i != associated_calorimeters_.end(); i++) {
+    out << indent << datatools::i_tree_dumpable::inherit_skip_tag(is_last);
     auto j = i;
     j++;
-    if (j == _associated_calorimeter_hits_.end()) {
-      out_ << datatools::i_tree_dumpable::last_tag;
+    if (j == associated_calorimeters_.end()) {
+      out << datatools::i_tree_dumpable::last_tag;
     } else {
-      out_ << datatools::i_tree_dumpable::tag;
+      out << datatools::i_tree_dumpable::tag;
     }
-    const calibrated_calorimeter_hit& calo_hit = i->get();
-    out_ << "Hit Id=" << calo_hit.get_hit_id() << " @ " << calo_hit.get_geom_id();
-    out_ << std::endl;
+    out << "Hit Id=" << (*i)->get_hit_id() << " @ " << (*i)->get_geom_id() << std::endl;
   }
 }
 

--- a/source/falaise/snemo/datamodels/particle_track.h
+++ b/source/falaise/snemo/datamodels/particle_track.h
@@ -148,19 +148,19 @@ class particle_track : public geomtools::base_hit {
   void detach_trajectory();
 
   /// Attach a trajectory by handle
-  void set_trajectory_handle(const tracker_trajectory::handle_type &trajectory_handle_);
+  void set_trajectory_handle(const TrackerTrajectoryHdl &trajectory_handle_);
 
   /// Return a mutable reference on the trajectory handle
-  tracker_trajectory::handle_type &get_trajectory_handle();
+  TrackerTrajectoryHdl &get_trajectory_handle();
 
   /// Return a non mutable reference on the trajectory handle
-  const tracker_trajectory::handle_type &get_trajectory_handle() const;
+  const TrackerTrajectoryHdl &get_trajectory_handle() const;
 
   /// Return a mutable reference on the trajectory
-  tracker_trajectory &get_trajectory();
+  TrackerTrajectory &get_trajectory();
 
   /// Return a non mutable reference on the trajectory
-  const tracker_trajectory &get_trajectory() const;
+  const TrackerTrajectory &get_trajectory() const;
 
   /// Check if there are some vertices along the fitted trajectory
   bool has_vertices() const;
@@ -203,9 +203,9 @@ class particle_track : public geomtools::base_hit {
                          const std::string &indent_ = "", bool inherit_ = false) const;
 
  private:
-  charge_type _charge_from_source_{invalid};       //!< Particle charge
-  tracker_trajectory::handle_type _trajectory_{};  //!< Handle to the fitted trajectory
-  vertex_collection_type _vertices_{};             //!< Collection of vertices
+  charge_type _charge_from_source_{invalid};  //!< Particle charge
+  TrackerTrajectoryHdl _trajectory_{};        //!< Handle to the fitted trajectory
+  vertex_collection_type _vertices_{};        //!< Collection of vertices
   CalorimeterHitHdlCollection
       _associated_calorimeter_hits_{};  //!< Collection of associated calorimeter hits
 

--- a/source/falaise/snemo/datamodels/particle_track.h
+++ b/source/falaise/snemo/datamodels/particle_track.h
@@ -187,10 +187,10 @@ class particle_track : public geomtools::base_hit {
   void reset_associated_calorimeter_hits();
 
   /// Return a mutable reference on the collection of associated calorimeter hits (handles)
-  calibrated_calorimeter_hit::collection_type &get_associated_calorimeter_hits();
+  CalorimeterHitHdlCollection &get_associated_calorimeter_hits();
 
   /// Return a non mutable reference on the collection of associated calorimeter hits (handles)
-  const calibrated_calorimeter_hit::collection_type &get_associated_calorimeter_hits() const;
+  const CalorimeterHitHdlCollection &get_associated_calorimeter_hits() const;
 
   /// Empty the contents of the particle track
   void clear();
@@ -203,10 +203,10 @@ class particle_track : public geomtools::base_hit {
                          const std::string &indent_ = "", bool inherit_ = false) const;
 
  private:
-  charge_type _charge_from_source_{invalid};              //!< Particle charge
+  charge_type _charge_from_source_{invalid};       //!< Particle charge
   tracker_trajectory::handle_type _trajectory_{};  //!< Handle to the fitted trajectory
   vertex_collection_type _vertices_{};             //!< Collection of vertices
-  calibrated_calorimeter_hit::collection_type
+  CalorimeterHitHdlCollection
       _associated_calorimeter_hits_{};  //!< Collection of associated calorimeter hits
 
   DATATOOLS_SERIALIZATION_DECLARATION()

--- a/source/falaise/snemo/datamodels/particle_track.h
+++ b/source/falaise/snemo/datamodels/particle_track.h
@@ -123,9 +123,6 @@ class particle_track : public geomtools::base_hit {
   /// Collection of vertex spots
   typedef std::vector<handle_spot> vertex_collection_type;
 
-  /// Handle on particle track
-  typedef datatools::handle<particle_track> handle_type;
-
   /// Check if there is a valid track ID
   bool has_track_id() const;
 
@@ -214,6 +211,13 @@ class particle_track : public geomtools::base_hit {
 
   DATATOOLS_SERIALIZATION_DECLARATION()
 };
+
+/// Handle on particle track
+using Particle = particle_track;
+using ParticleHdl = datatools::handle<Particle>;
+
+using ParticleCollection = std::vector<Particle>;
+using ParticleHdlCollection = std::vector<ParticleHdl>;
 
 }  // end of namespace datamodel
 

--- a/source/falaise/snemo/datamodels/particle_track.h
+++ b/source/falaise/snemo/datamodels/particle_track.h
@@ -35,32 +35,11 @@ class particle_track : public geomtools::base_hit {
  public:
   /// Electric charge enumeration
   enum charge_type {
-    INVALID = 0x0,
-    invalid = INVALID,
     UNDEFINED = datatools::bit_mask::bit00,  /// Particle with undefined charge
-    undefined = UNDEFINED,
-    NEUTRAL = datatools::bit_mask::bit01,  /// Neutral particle
-    neutral = NEUTRAL,
-    POSITIVE = datatools::bit_mask::bit02,  /// Positively charged particle
-    positive = POSITIVE,
-    NEGATIVE = datatools::bit_mask::bit03,  /// Negatively charged particle
-    negative = NEGATIVE
+    NEUTRAL = datatools::bit_mask::bit01,    /// Neutral particle
+    POSITIVE = datatools::bit_mask::bit02,   /// Positively charged particle
+    NEGATIVE = datatools::bit_mask::bit03,   /// Negatively charged particle
   };
-
-  /// Check a particle charge type
-  static bool particle_has(const particle_track &, charge_type);
-
-  /// Check a particle is electron
-  static bool particle_has_negative_charge(const particle_track &);
-
-  /// Check a particle is positron
-  static bool particle_has_positive_charge(const particle_track &);
-
-  /// Check a particle is alpha
-  static bool particle_has_undefined_charge(const particle_track &);
-
-  /// Check a particle is gamma
-  static bool particle_has_neutral_charge(const particle_track &);
 
   /// Vertex flags
   enum vertex_type {
@@ -203,9 +182,9 @@ class particle_track : public geomtools::base_hit {
                          const std::string &indent_ = "", bool inherit_ = false) const;
 
  private:
-  charge_type _charge_from_source_{invalid};  //!< Particle charge
-  TrackerTrajectoryHdl _trajectory_{};        //!< Handle to the fitted trajectory
-  vertex_collection_type _vertices_{};        //!< Collection of vertices
+  charge_type _charge_from_source_{UNDEFINED};  //!< Particle charge
+  TrackerTrajectoryHdl _trajectory_{};          //!< Handle to the fitted trajectory
+  vertex_collection_type _vertices_{};          //!< Collection of vertices
   CalorimeterHitHdlCollection
       _associated_calorimeter_hits_{};  //!< Collection of associated calorimeter hits
 
@@ -218,6 +197,22 @@ using ParticleHdl = datatools::handle<Particle>;
 
 using ParticleCollection = std::vector<Particle>;
 using ParticleHdlCollection = std::vector<ParticleHdl>;
+
+// Free functions
+/// Check a particle charge type
+bool particle_has(const Particle &, Particle::charge_type);
+
+/// Check a particle is electron
+bool particle_has_negative_charge(const Particle &);
+
+/// Checck a particle is positron
+bool particle_has_positive_charge(const Particle &);
+
+/// Check a particle is alpha
+bool particle_has_undefined_charge(const Particle &);
+
+/// Check a particle is gamma
+bool particle_has_neutral_charge(const Particle &);
 
 }  // end of namespace datamodel
 

--- a/source/falaise/snemo/datamodels/particle_track_data.cc
+++ b/source/falaise/snemo/datamodels/particle_track_data.cc
@@ -7,36 +7,36 @@ namespace snemo {
 
 namespace datamodel {
 
-bool particle_track_data::hasParticles() const { return !_particles_.empty(); }
+bool particle_track_data::hasParticles() const { return !particles_.empty(); }
 
-size_t particle_track_data::numberOfParticles() const { return _particles_.size(); }
+size_t particle_track_data::numberOfParticles() const { return particles_.size(); }
 
-void particle_track_data::insertParticle(const ParticleHdl& particle_handle_) {
-  for (const auto& h : _particles_) {
+void particle_track_data::insertParticle(const ParticleHdl& particle) {
+  for (const auto& h : particles_) {
     // "Duplicated" means same address
-    DT_THROW_IF((&*h == &*particle_handle_), std::logic_error, "Duplicated particles not allowed!");
+    DT_THROW_IF((&*h == &*particle), std::logic_error, "Duplicated particles not allowed!");
   }
-  _particles_.push_back(particle_handle_);
+  particles_.push_back(particle);
 }
 
-ParticleHdlCollection& particle_track_data::particles() { return _particles_; }
+ParticleHdlCollection& particle_track_data::particles() { return particles_; }
 
-const ParticleHdlCollection& particle_track_data::particles() const { return _particles_; }
+const ParticleHdlCollection& particle_track_data::particles() const { return particles_; }
 
-void particle_track_data::clearParticles() { _particles_.clear(); }
+void particle_track_data::clearParticles() { particles_.clear(); }
 
-ParticleHdlCollection particle_track_data::getParticlesByCharge(const uint32_t charge) const {
+ParticleHdlCollection particle_track_data::getParticlesByCharge(const uint32_t charge_types) const {
   ParticleHdlCollection selection;
 
   for (const auto& a_particle : particles()) {
     const bool has_negative_charge =
-        ((charge & particle_track::NEGATIVE) != 0u) && particle_has_negative_charge(*a_particle);
+        ((charge_types & particle_track::NEGATIVE) != 0u) && particle_has_negative_charge(*a_particle);
     const bool has_positive_charge =
-        ((charge & particle_track::POSITIVE) != 0u) && particle_has_positive_charge(*a_particle);
+        ((charge_types & particle_track::POSITIVE) != 0u) && particle_has_positive_charge(*a_particle);
     const bool has_undefined_charge =
-        ((charge & particle_track::UNDEFINED) != 0u) && particle_has_undefined_charge(*a_particle);
+        ((charge_types & particle_track::UNDEFINED) != 0u) && particle_has_undefined_charge(*a_particle);
     const bool has_neutral_charge =
-        ((charge & particle_track::NEUTRAL) != 0u) && particle_has_neutral_charge(*a_particle);
+        ((charge_types & particle_track::NEUTRAL) != 0u) && particle_has_neutral_charge(*a_particle);
 
     if (has_negative_charge || has_positive_charge || has_undefined_charge || has_neutral_charge) {
       selection.push_back(a_particle);
@@ -46,65 +46,65 @@ ParticleHdlCollection particle_track_data::getParticlesByCharge(const uint32_t c
 }
 
 bool particle_track_data::hasIsolatedCalorimeters() const {
-  return !_non_associated_calorimeters_.empty();
+  return !isolated_calorimeters_.empty();
 }
 
 CalorimeterHitHdlCollection& particle_track_data::isolatedCalorimeters() {
-  return _non_associated_calorimeters_;
+  return isolated_calorimeters_;
 }
 
 const CalorimeterHitHdlCollection& particle_track_data::isolatedCalorimeters() const {
-  return _non_associated_calorimeters_;
+  return isolated_calorimeters_;
 }
 
-void particle_track_data::clearIsolatedCalorimeters() { _non_associated_calorimeters_.clear(); }
+void particle_track_data::clearIsolatedCalorimeters() { isolated_calorimeters_.clear(); }
 
 void particle_track_data::clear() {
-  _particles_.clear();
-  _non_associated_calorimeters_.clear();
+  particles_.clear();
+  isolated_calorimeters_.clear();
 }
 
-void particle_track_data::tree_dump(std::ostream& out_, const std::string& title_,
-                                    const std::string& indent_, bool /*inherit_*/) const {
-  if (!title_.empty()) {
-    out_ << indent_ << title_ << std::endl;
+void particle_track_data::tree_dump(std::ostream& out, const std::string& title,
+                                    const std::string& indent, bool /*inherit_*/) const {
+  if (!title.empty()) {
+    out << indent << title << std::endl;
   }
 
-  out_ << indent_ << datatools::i_tree_dumpable::tag << "Particle(s) : " << _particles_.size()
-       << std::endl;
+  out << indent << datatools::i_tree_dumpable::tag << "Particle(s) : " << particles_.size()
+      << std::endl;
 
   for (size_t i = 0; i < numberOfParticles(); i++) {
     std::ostringstream indent2;
-    out_ << indent_ << datatools::i_tree_dumpable::skip_tag;
-    indent2 << indent_ << datatools::i_tree_dumpable::skip_tag;
+    out << indent << datatools::i_tree_dumpable::skip_tag;
+    indent2 << indent << datatools::i_tree_dumpable::skip_tag;
     if (i == numberOfParticles() - 1) {
-      out_ << datatools::i_tree_dumpable::last_tag;
+      out << datatools::i_tree_dumpable::last_tag;
       indent2 << datatools::i_tree_dumpable::last_skip_tag;
     } else {
-      out_ << datatools::i_tree_dumpable::tag;
+      out << datatools::i_tree_dumpable::tag;
       indent2 << datatools::i_tree_dumpable::skip_tag;
     }
-    out_ << "Particle #" << i << " : " << std::endl;
-    _particles_[i]->tree_dump(out_, "", indent2.str());
+    out << "Particle #" << i << " : " << std::endl;
+    particles_[i]->tree_dump(out, "", indent2.str());
   }
 
   const auto& the_calos = isolatedCalorimeters();
-  out_ << indent_ << datatools::i_tree_dumpable::tag
-       << "Unassociated calorimeter(s) : " << the_calos.size() << std::endl;
+  out << indent << datatools::i_tree_dumpable::tag
+      << "Isolated calorimeter(s) : " << the_calos.size() << std::endl;
   for (size_t i = 0; i < the_calos.size(); i++) {
     const calibrated_calorimeter_hit& a_calo_hit = the_calos.at(i).get();
     std::ostringstream indent2;
-    out_ << indent_ << datatools::i_tree_dumpable::skip_tag;
-    indent2 << indent_ << datatools::i_tree_dumpable::skip_tag;
+    out << indent << datatools::i_tree_dumpable::skip_tag;
+    indent2 << indent << datatools::i_tree_dumpable::skip_tag;
     if (i == the_calos.size() - 1) {
-      out_ << datatools::i_tree_dumpable::last_tag;
+      out << datatools::i_tree_dumpable::last_tag;
       indent2 << datatools::i_tree_dumpable::last_skip_tag;
     } else {
-      out_ << datatools::i_tree_dumpable::tag;
+      out << datatools::i_tree_dumpable::tag;
       indent2 << datatools::i_tree_dumpable::skip_tag;
     }
-    out_ << "Hit Id=" << a_calo_hit.get_hit_id() << " @ " << a_calo_hit.get_geom_id();
-    out_ << std::endl;
+    out << "Hit Id=" << a_calo_hit.get_hit_id() << " @ " << a_calo_hit.get_geom_id();
+    out << std::endl;
   }
 }
 

--- a/source/falaise/snemo/datamodels/particle_track_data.cc
+++ b/source/falaise/snemo/datamodels/particle_track_data.cc
@@ -29,15 +29,14 @@ ParticleHdlCollection particle_track_data::getParticlesByCharge(const uint32_t c
   ParticleHdlCollection selection;
 
   for (const auto& a_particle : particles()) {
-    // const particle_track::handle_type& a_particle = *i;
-    const bool has_negative_charge = ((charge & particle_track::NEGATIVE) != 0u) &&
-                                     particle_track::particle_has_negative_charge(*a_particle);
-    const bool has_positive_charge = ((charge & particle_track::POSITIVE) != 0u) &&
-                                     particle_track::particle_has_positive_charge(*a_particle);
-    const bool has_undefined_charge = ((charge & particle_track::UNDEFINED) != 0u) &&
-                                      particle_track::particle_has_undefined_charge(*a_particle);
-    const bool has_neutral_charge = ((charge & particle_track::NEUTRAL) != 0u) &&
-                                    particle_track::particle_has_neutral_charge(*a_particle);
+    const bool has_negative_charge =
+        ((charge & particle_track::NEGATIVE) != 0u) && particle_has_negative_charge(*a_particle);
+    const bool has_positive_charge =
+        ((charge & particle_track::POSITIVE) != 0u) && particle_has_positive_charge(*a_particle);
+    const bool has_undefined_charge =
+        ((charge & particle_track::UNDEFINED) != 0u) && particle_has_undefined_charge(*a_particle);
+    const bool has_neutral_charge =
+        ((charge & particle_track::NEUTRAL) != 0u) && particle_has_neutral_charge(*a_particle);
 
     if (has_negative_charge || has_positive_charge || has_undefined_charge || has_neutral_charge) {
       selection.push_back(a_particle);
@@ -54,14 +53,11 @@ CalorimeterHitHdlCollection& particle_track_data::isolatedCalorimeters() {
   return _non_associated_calorimeters_;
 }
 
-const CalorimeterHitHdlCollection& particle_track_data::isolatedCalorimeters()
-    const {
+const CalorimeterHitHdlCollection& particle_track_data::isolatedCalorimeters() const {
   return _non_associated_calorimeters_;
 }
 
-void particle_track_data::clearIsolatedCalorimeters() {
-  _non_associated_calorimeters_.clear();
-}
+void particle_track_data::clearIsolatedCalorimeters() { _non_associated_calorimeters_.clear(); }
 
 void particle_track_data::clear() {
   _particles_.clear();

--- a/source/falaise/snemo/datamodels/particle_track_data.cc
+++ b/source/falaise/snemo/datamodels/particle_track_data.cc
@@ -50,11 +50,11 @@ bool particle_track_data::hasIsolatedCalorimeters() const {
   return !_non_associated_calorimeters_.empty();
 }
 
-calibrated_calorimeter_hit::collection_type& particle_track_data::isolatedCalorimeters() {
+CalorimeterHitHdlCollection& particle_track_data::isolatedCalorimeters() {
   return _non_associated_calorimeters_;
 }
 
-const calibrated_calorimeter_hit::collection_type& particle_track_data::isolatedCalorimeters()
+const CalorimeterHitHdlCollection& particle_track_data::isolatedCalorimeters()
     const {
   return _non_associated_calorimeters_;
 }

--- a/source/falaise/snemo/datamodels/particle_track_data.cc
+++ b/source/falaise/snemo/datamodels/particle_track_data.cc
@@ -7,6 +7,26 @@ namespace snemo {
 
 namespace datamodel {
 
+ParticleHdlCollection get_particles_by_charge(const particle_track_data& ptd, uint32_t charge_types) {
+  ParticleHdlCollection selection;
+
+  for (const auto& a_particle : ptd.particles()) {
+    const bool has_negative_charge =
+        ((charge_types & particle_track::NEGATIVE) != 0u) && particle_has_negative_charge(*a_particle);
+    const bool has_positive_charge =
+        ((charge_types & particle_track::POSITIVE) != 0u) && particle_has_positive_charge(*a_particle);
+    const bool has_undefined_charge =
+        ((charge_types & particle_track::UNDEFINED) != 0u) && particle_has_undefined_charge(*a_particle);
+    const bool has_neutral_charge =
+        ((charge_types & particle_track::NEUTRAL) != 0u) && particle_has_neutral_charge(*a_particle);
+
+    if (has_negative_charge || has_positive_charge || has_undefined_charge || has_neutral_charge) {
+      selection.push_back(a_particle);
+    }
+  }
+  return selection;
+}
+
 bool particle_track_data::hasParticles() const { return !particles_.empty(); }
 
 size_t particle_track_data::numberOfParticles() const { return particles_.size(); }
@@ -25,25 +45,6 @@ const ParticleHdlCollection& particle_track_data::particles() const { return par
 
 void particle_track_data::clearParticles() { particles_.clear(); }
 
-ParticleHdlCollection particle_track_data::getParticlesByCharge(const uint32_t charge_types) const {
-  ParticleHdlCollection selection;
-
-  for (const auto& a_particle : particles()) {
-    const bool has_negative_charge =
-        ((charge_types & particle_track::NEGATIVE) != 0u) && particle_has_negative_charge(*a_particle);
-    const bool has_positive_charge =
-        ((charge_types & particle_track::POSITIVE) != 0u) && particle_has_positive_charge(*a_particle);
-    const bool has_undefined_charge =
-        ((charge_types & particle_track::UNDEFINED) != 0u) && particle_has_undefined_charge(*a_particle);
-    const bool has_neutral_charge =
-        ((charge_types & particle_track::NEUTRAL) != 0u) && particle_has_neutral_charge(*a_particle);
-
-    if (has_negative_charge || has_positive_charge || has_undefined_charge || has_neutral_charge) {
-      selection.push_back(a_particle);
-    }
-  }
-  return selection;
-}
 
 bool particle_track_data::hasIsolatedCalorimeters() const {
   return !isolated_calorimeters_.empty();

--- a/source/falaise/snemo/datamodels/particle_track_data.cc
+++ b/source/falaise/snemo/datamodels/particle_track_data.cc
@@ -7,11 +7,11 @@ namespace snemo {
 
 namespace datamodel {
 
-bool particle_track_data::has_particles() const { return get_number_of_particles() > 0; }
+bool particle_track_data::hasParticles() const { return !_particles_.empty(); }
 
-size_t particle_track_data::get_number_of_particles() const { return _particles_.size(); }
+size_t particle_track_data::numberOfParticles() const { return _particles_.size(); }
 
-void particle_track_data::add_particle(const particle_track::handle_type& particle_handle_) {
+void particle_track_data::insertParticle(const ParticleHdl& particle_handle_) {
   for (const auto& h : _particles_) {
     // "Duplicated" means same address
     DT_THROW_IF((&*h == &*particle_handle_), std::logic_error, "Duplicated particles not allowed!");
@@ -19,86 +19,53 @@ void particle_track_data::add_particle(const particle_track::handle_type& partic
   _particles_.push_back(particle_handle_);
 }
 
-const particle_track& particle_track_data::get_particle(size_t index_) const {
-  return *(_particles_.at(index_));
-}
+ParticleHdlCollection& particle_track_data::particles() { return _particles_; }
 
-particle_track_data::particle_collection_type& particle_track_data::grab_particles() {
-  return _particles_;
-}
+const ParticleHdlCollection& particle_track_data::particles() const { return _particles_; }
 
-const particle_track_data::particle_collection_type& particle_track_data::get_particles() const {
-  return _particles_;
-}
+void particle_track_data::clearParticles() { _particles_.clear(); }
 
-void particle_track_data::remove_particle(size_t index_) {
-  DT_THROW_IF(index_ > _particles_.size(), std::logic_error,
-              "Particle index does not exist ! Index must be smaller than " << _particles_.size());
-  _particles_.erase(_particles_.begin() + index_);
-}
+ParticleHdlCollection particle_track_data::getParticlesByCharge(const uint32_t charge) const {
+  ParticleHdlCollection selection;
 
-void particle_track_data::remove_particles(std::vector<size_t>& indexes_) {
-  std::sort(indexes_.begin(), indexes_.end());
-  for (size_t i = 0; i < indexes_.size(); i++) {
-    // Not sure about this implementation, why subtract the counter from the index?
-    remove_particle(indexes_.at(i) - i);
-  }
-}
-
-void particle_track_data::invalidate_particles() { _particles_.clear(); }
-
-size_t particle_track_data::fetch_particles(particle_collection_type& particles_,
-                                            const uint32_t flags_, const bool clear_) const {
-  if (clear_) {
-    particles_.clear();
-  }
-  size_t ipart = 0;
-
-  for (const auto& a_particle : get_particles()) {
+  for (const auto& a_particle : particles()) {
     // const particle_track::handle_type& a_particle = *i;
-    const bool has_negative_charge = ((flags_ & particle_track::NEGATIVE) != 0u) &&
+    const bool has_negative_charge = ((charge & particle_track::NEGATIVE) != 0u) &&
                                      particle_track::particle_has_negative_charge(*a_particle);
-    const bool has_positive_charge = ((flags_ & particle_track::POSITIVE) != 0u) &&
+    const bool has_positive_charge = ((charge & particle_track::POSITIVE) != 0u) &&
                                      particle_track::particle_has_positive_charge(*a_particle);
-    const bool has_undefined_charge = ((flags_ & particle_track::UNDEFINED) != 0u) &&
+    const bool has_undefined_charge = ((charge & particle_track::UNDEFINED) != 0u) &&
                                       particle_track::particle_has_undefined_charge(*a_particle);
-    const bool has_neutral_charge = ((flags_ & particle_track::NEUTRAL) != 0u) &&
+    const bool has_neutral_charge = ((charge & particle_track::NEUTRAL) != 0u) &&
                                     particle_track::particle_has_neutral_charge(*a_particle);
 
     if (has_negative_charge || has_positive_charge || has_undefined_charge || has_neutral_charge) {
-      particles_.push_back(a_particle);
-      ipart++;
+      selection.push_back(a_particle);
     }
   }
-  return ipart;
+  return selection;
 }
 
-bool particle_track_data::has_non_associated_calorimeters() const {
-  return !get_non_associated_calorimeters().empty();
+bool particle_track_data::hasIsolatedCalorimeters() const {
+  return !_non_associated_calorimeters_.empty();
 }
 
-calibrated_calorimeter_hit::collection_type&
-particle_track_data::grab_non_associated_calorimeters() {
+calibrated_calorimeter_hit::collection_type& particle_track_data::isolatedCalorimeters() {
   return _non_associated_calorimeters_;
 }
 
-const calibrated_calorimeter_hit::collection_type&
-particle_track_data::get_non_associated_calorimeters() const {
+const calibrated_calorimeter_hit::collection_type& particle_track_data::isolatedCalorimeters()
+    const {
   return _non_associated_calorimeters_;
 }
 
-void particle_track_data::reset_non_associated_calorimeters() {
+void particle_track_data::clearIsolatedCalorimeters() {
   _non_associated_calorimeters_.clear();
 }
 
-const datatools::properties& particle_track_data::get_auxiliaries() const { return _auxiliaries_; }
-
-void particle_track_data::reset() { this->clear(); }
-
 void particle_track_data::clear() {
-  invalidate_particles();
-  reset_non_associated_calorimeters();
-  _auxiliaries_.clear();
+  _particles_.clear();
+  _non_associated_calorimeters_.clear();
 }
 
 void particle_track_data::tree_dump(std::ostream& out_, const std::string& title_,
@@ -110,12 +77,11 @@ void particle_track_data::tree_dump(std::ostream& out_, const std::string& title
   out_ << indent_ << datatools::i_tree_dumpable::tag << "Particle(s) : " << _particles_.size()
        << std::endl;
 
-  for (size_t i = 0; i < get_number_of_particles(); i++) {
-    const particle_track& ptrack = get_particle(i);
+  for (size_t i = 0; i < numberOfParticles(); i++) {
     std::ostringstream indent2;
     out_ << indent_ << datatools::i_tree_dumpable::skip_tag;
     indent2 << indent_ << datatools::i_tree_dumpable::skip_tag;
-    if (i == get_number_of_particles() - 1) {
+    if (i == numberOfParticles() - 1) {
       out_ << datatools::i_tree_dumpable::last_tag;
       indent2 << datatools::i_tree_dumpable::last_skip_tag;
     } else {
@@ -123,10 +89,10 @@ void particle_track_data::tree_dump(std::ostream& out_, const std::string& title
       indent2 << datatools::i_tree_dumpable::skip_tag;
     }
     out_ << "Particle #" << i << " : " << std::endl;
-    ptrack.tree_dump(out_, "", indent2.str());
+    _particles_[i]->tree_dump(out_, "", indent2.str());
   }
 
-  const auto& the_calos = get_non_associated_calorimeters();
+  const auto& the_calos = isolatedCalorimeters();
   out_ << indent_ << datatools::i_tree_dumpable::tag
        << "Unassociated calorimeter(s) : " << the_calos.size() << std::endl;
   for (size_t i = 0; i < the_calos.size(); i++) {
@@ -143,18 +109,6 @@ void particle_track_data::tree_dump(std::ostream& out_, const std::string& title
     }
     out_ << "Hit Id=" << a_calo_hit.get_hit_id() << " @ " << a_calo_hit.get_geom_id();
     out_ << std::endl;
-  }
-
-  out_ << indent_ << datatools::i_tree_dumpable::inherit_tag(inherit_) << "Auxiliaries : ";
-  if (_auxiliaries_.empty()) {
-    out_ << "<empty>";
-  }
-  out_ << std::endl;
-  {
-    std::ostringstream indent_oss;
-    indent_oss << indent_;
-    indent_oss << datatools::i_tree_dumpable::inherit_skip_tag(inherit_);
-    _auxiliaries_.tree_dump(out_, "", indent_oss.str());
   }
 }
 

--- a/source/falaise/snemo/datamodels/particle_track_data.cc
+++ b/source/falaise/snemo/datamodels/particle_track_data.cc
@@ -69,7 +69,7 @@ void particle_track_data::clear() {
 }
 
 void particle_track_data::tree_dump(std::ostream& out_, const std::string& title_,
-                                    const std::string& indent_, bool inherit_) const {
+                                    const std::string& indent_, bool /*inherit_*/) const {
   if (!title_.empty()) {
     out_ << indent_ << title_ << std::endl;
   }

--- a/source/falaise/snemo/datamodels/particle_track_data.h
+++ b/source/falaise/snemo/datamodels/particle_track_data.h
@@ -65,10 +65,10 @@ class particle_track_data : public datatools::i_serializable,
   bool hasIsolatedCalorimeters() const;
 
   /// Return a non mutable reference to non associated calorimeters
-  const calibrated_calorimeter_hit::collection_type& isolatedCalorimeters() const;
+  const CalorimeterHitHdlCollection& isolatedCalorimeters() const;
 
   /// Return a mutable reference to non associated calorimeters
-  calibrated_calorimeter_hit::collection_type& isolatedCalorimeters();
+  CalorimeterHitHdlCollection& isolatedCalorimeters();
 
   /// Reset the non associated calorimeters
   void clearIsolatedCalorimeters();
@@ -82,9 +82,10 @@ class particle_track_data : public datatools::i_serializable,
 
  private:
   ParticleHdlCollection _particles_;  //!< Collection of particle track handles
-  calibrated_calorimeter_hit::collection_type
-      _non_associated_calorimeters_;    //!< Collection of calorimeter hit handles
-  datatools::properties _auxiliaries_;  //!< Auxiliary properties (retained for serialization back compatibility)
+  CalorimeterHitHdlCollection
+      _non_associated_calorimeters_;  //!< Collection of calorimeter hit handles
+  datatools::properties
+      _auxiliaries_;  //!< Auxiliary properties (retained for serialization back compatibility)
 
   DATATOOLS_SERIALIZATION_DECLARATION()
 };

--- a/source/falaise/snemo/datamodels/particle_track_data.h
+++ b/source/falaise/snemo/datamodels/particle_track_data.h
@@ -84,6 +84,7 @@ class particle_track_data : public datatools::i_serializable,
   ParticleHdlCollection _particles_;  //!< Collection of particle track handles
   CalorimeterHitHdlCollection
       _non_associated_calorimeters_;  //!< Collection of calorimeter hit handles
+
   datatools::properties
       _auxiliaries_;  //!< Auxiliary properties (retained for serialization back compatibility)
 

--- a/source/falaise/snemo/datamodels/particle_track_data.h
+++ b/source/falaise/snemo/datamodels/particle_track_data.h
@@ -47,7 +47,7 @@ class particle_track_data : public datatools::i_serializable,
   size_t numberOfParticles() const;
 
   /// Add a particle track
-  void insertParticle(const ParticleHdl& handle_);
+  void insertParticle(const ParticleHdl& particle);
 
   /// Return a mutable reference to particles
   ParticleHdlCollection& particles();
@@ -59,7 +59,8 @@ class particle_track_data : public datatools::i_serializable,
   void clearParticles();
 
   /// Retrieve particles given their charge
-  ParticleHdlCollection getParticlesByCharge(const uint32_t flags_) const;
+  /// TODO: Refactor into free function/functor
+  ParticleHdlCollection getParticlesByCharge(const uint32_t charge_types) const;
 
   /// Check if there are some non associated calorimeters
   bool hasIsolatedCalorimeters() const;
@@ -77,13 +78,12 @@ class particle_track_data : public datatools::i_serializable,
   virtual void clear();
 
   /// Smart print
-  virtual void tree_dump(std::ostream& out_ = std::clog, const std::string& title_ = "",
-                         const std::string& indent_ = "", bool inherit_ = false) const;
+  virtual void tree_dump(std::ostream& out = std::clog, const std::string& title = "",
+                         const std::string& indent = "", bool is_last = false) const;
 
  private:
-  ParticleHdlCollection _particles_;  //!< Collection of particle track handles
-  CalorimeterHitHdlCollection
-      _non_associated_calorimeters_;  //!< Collection of calorimeter hit handles
+  ParticleHdlCollection particles_;                    //!< Collection of particle track handles
+  CalorimeterHitHdlCollection isolated_calorimeters_;  //!< Collection of calorimeter hit handles
 
   datatools::properties
       _auxiliaries_;  //!< Auxiliary properties (retained for serialization back compatibility)

--- a/source/falaise/snemo/datamodels/particle_track_data.h
+++ b/source/falaise/snemo/datamodels/particle_track_data.h
@@ -58,10 +58,6 @@ class particle_track_data : public datatools::i_serializable,
   /// Reset the particle tracks
   void clearParticles();
 
-  /// Retrieve particles given their charge
-  /// TODO: Refactor into free function/functor
-  ParticleHdlCollection getParticlesByCharge(const uint32_t charge_types) const;
-
   /// Check if there are some non associated calorimeters
   bool hasIsolatedCalorimeters() const;
 
@@ -85,11 +81,14 @@ class particle_track_data : public datatools::i_serializable,
   ParticleHdlCollection particles_;                    //!< Collection of particle track handles
   CalorimeterHitHdlCollection isolated_calorimeters_;  //!< Collection of calorimeter hit handles
 
-  datatools::properties
-      _auxiliaries_;  //!< Auxiliary properties (retained for serialization back compatibility)
+  datatools::properties _auxiliaries_;  // unused, retained for serialization back compatibility
 
   DATATOOLS_SERIALIZATION_DECLARATION()
 };
+
+/// Retrieve particles given their charge
+ParticleHdlCollection get_particles_by_charge(const particle_track_data& ptd,
+                                              uint32_t charge_types);
 
 }  // end of namespace datamodel
 

--- a/source/falaise/snemo/datamodels/particle_track_data.h
+++ b/source/falaise/snemo/datamodels/particle_track_data.h
@@ -34,65 +34,44 @@ namespace snemo {
 namespace datamodel {
 
 /// \brief SuperNEMO particle track model
-//  To be done...
+//  Just a composition of a vector of particle_tracks and a vector of isolated calorimeter hits
+//  TODO: split, or implement as pure dumb struct
 class particle_track_data : public datatools::i_serializable,
                             public datatools::i_tree_dumpable,
                             public datatools::i_clear {
  public:
-  /// Collection of handles on particle tracks
-  typedef std::vector<particle_track::handle_type> particle_collection_type;
-
   /// Check if there are some particles
-  bool has_particles() const;
+  bool hasParticles() const;
 
   /// Returns the number of particle
-  size_t get_number_of_particles() const;
+  size_t numberOfParticles() const;
 
   /// Add a particle track
-  void add_particle(const particle_track::handle_type& handle_);
-
-  /// Return a non mutable reference to a particle by index
-  const particle_track& get_particle(size_t index_) const;
+  void insertParticle(const ParticleHdl& handle_);
 
   /// Return a mutable reference to particles
-  particle_collection_type& grab_particles();
+  ParticleHdlCollection& particles();
 
   /// Return a non mutable reference to particles
-  const particle_collection_type& get_particles() const;
-
-  /// Remove a particle given its index
-  void remove_particle(size_t index_);
-
-  /// Remove particles given a list of indexes
-  void remove_particles(std::vector<size_t>& indexes_);
+  const ParticleHdlCollection& particles() const;
 
   /// Reset the particle tracks
-  void invalidate_particles();
+  void clearParticles();
 
   /// Retrieve particles given their charge
-  size_t fetch_particles(particle_collection_type& particles_, const uint32_t flags_,
-                         const bool clear_ = false) const;
+  ParticleHdlCollection getParticlesByCharge(const uint32_t flags_) const;
 
   /// Check if there are some non associated calorimeters
-  bool has_non_associated_calorimeters() const;
+  bool hasIsolatedCalorimeters() const;
 
   /// Return a non mutable reference to non associated calorimeters
-  const calibrated_calorimeter_hit::collection_type& get_non_associated_calorimeters() const;
+  const calibrated_calorimeter_hit::collection_type& isolatedCalorimeters() const;
 
   /// Return a mutable reference to non associated calorimeters
-  calibrated_calorimeter_hit::collection_type& grab_non_associated_calorimeters();
+  calibrated_calorimeter_hit::collection_type& isolatedCalorimeters();
 
   /// Reset the non associated calorimeters
-  void reset_non_associated_calorimeters();
-
-  /// Reset the internals
-  void reset();
-
-  /// Check if the object has a valid internal structure
-  bool is_valid() const;
-
-  /// Return const reference container of auxiliary properties
-  const datatools::properties& get_auxiliaries() const;
+  void clearIsolatedCalorimeters();
 
   /// Clear the object
   virtual void clear();
@@ -102,10 +81,10 @@ class particle_track_data : public datatools::i_serializable,
                          const std::string& indent_ = "", bool inherit_ = false) const;
 
  private:
-  particle_collection_type _particles_;  //!< Collection of particle track handles
+  ParticleHdlCollection _particles_;  //!< Collection of particle track handles
   calibrated_calorimeter_hit::collection_type
       _non_associated_calorimeters_;    //!< Collection of calorimeter hit handles
-  datatools::properties _auxiliaries_;  //!< Auxiliary properties
+  datatools::properties _auxiliaries_;  //!< Auxiliary properties (retained for serialization back compatibility)
 
   DATATOOLS_SERIALIZATION_DECLARATION()
 };

--- a/source/falaise/snemo/datamodels/timestamp.cc
+++ b/source/falaise/snemo/datamodels/timestamp.cc
@@ -29,56 +29,52 @@ const int64_t timestamp::INVALID_SECONDS = std::numeric_limits<int64_t>::min();
 const int64_t timestamp::INVALID_PICOSECONDS = std::numeric_limits<int64_t>::min();
 
 bool timestamp::is_valid() const {
-  return _seconds_ != INVALID_SECONDS && _picoseconds_ != INVALID_PICOSECONDS;
+  return seconds_ != INVALID_SECONDS && picoseconds_ != INVALID_PICOSECONDS;
 }
 
 
-int timestamp::compare(const timestamp& ts_) const {
+int timestamp::compare(const timestamp& ts) const {
   DT_THROW_IF(!is_valid(), std::logic_error, "Invalid timestamp (this) !");
-  DT_THROW_IF(!ts_.is_valid(), std::logic_error, "Invalid timestamp (argument) !");
-  if (_seconds_ < ts_._seconds_) {
+  DT_THROW_IF(!ts.is_valid(), std::logic_error, "Invalid timestamp (argument) !");
+  if (seconds_ < ts.seconds_) {
     return -1;
   }
-  if (_seconds_ > ts_._seconds_) {
+  if (seconds_ > ts.seconds_) {
     return +1;
   }
-  if (_picoseconds_ < ts_._picoseconds_) {
+  if (picoseconds_ < ts.picoseconds_) {
     return -1;
   }
-  if (_picoseconds_ > ts_._picoseconds_) {
+  if (picoseconds_ > ts.picoseconds_) {
     return +1;
   }
   return 0;
 }
 
-int64_t timestamp::get_seconds() const { return _seconds_; }
+int64_t timestamp::get_seconds() const { return seconds_; }
 
-void timestamp::set_seconds(int64_t new_value_) { _seconds_ = new_value_; }
+void timestamp::set_seconds(int64_t s) { seconds_ = s; }
 
-int64_t timestamp::get_picoseconds() const { return _picoseconds_; }
+int64_t timestamp::get_picoseconds() const { return picoseconds_; }
 
-void timestamp::set_picoseconds(int64_t new_value_) { _picoseconds_ = new_value_; }
+void timestamp::set_picoseconds(int64_t ps) { picoseconds_ = ps; }
 
 double timestamp::to_real() const {
-  double time = _seconds_ * CLHEP::second;
-  time += _picoseconds_ * CLHEP::picosecond;
-  return time;
+  return seconds_ * CLHEP::second + picoseconds_ * CLHEP::picosecond;
 }
 
-bool operator==(const timestamp& ts1_, const timestamp& ts2_) { return ts1_.compare(ts2_) == 0; }
+bool operator==(const timestamp& lhs, const timestamp& rhs) { return lhs.compare(rhs) == 0; }
 
-bool operator<(const timestamp& ts1_, const timestamp& ts2_) { return ts1_.compare(ts2_) == -1; }
+bool operator<(const timestamp& lhs, const timestamp& rhs) { return lhs.compare(rhs) == -1; }
 
-bool operator>(const timestamp& ts1_, const timestamp& ts2_) { return ts1_.compare(ts2_) == +1; }
+bool operator>(const timestamp& lhs, const timestamp& rhs) { return lhs.compare(rhs) == +1; }
 
-bool operator<=(const timestamp& ts1_, const timestamp& ts2_) { return ts1_.compare(ts2_) <= 0; }
+bool operator<=(const timestamp& lhs, const timestamp& rhs) { return lhs.compare(rhs) <= 0; }
 
-bool operator>=(const timestamp& ts1_, const timestamp& ts2_) { return ts1_.compare(ts2_) >= 0; }
+bool operator>=(const timestamp& lhs, const timestamp& rhs) { return lhs.compare(rhs) >= 0; }
 
-void timestamp::to_string(std::string& str_) const {
-  std::ostringstream out;
-  out << *this;
-  str_ = out.str();
+void timestamp::to_string(std::string& s) const {
+  s = to_string();
 }
 
 std::string timestamp::to_string() const {
@@ -87,32 +83,32 @@ std::string timestamp::to_string() const {
   return out.str();
 }
 
-void timestamp::from_string(const std::string& str_) {
+void timestamp::from_string(const std::string& str) {
   timestamp ts;
-  std::istringstream in(str_);
+  std::istringstream in(str);
   in >> ts;
   DT_THROW_IF(!in, std::logic_error, "Format error !");
   *this = ts;
 }
 
-std::ostream& operator<<(std::ostream& out_, const timestamp& ts_) {
-  out_ << ::IO_FORMAT_OPEN;
-  if (ts_._seconds_ != timestamp::INVALID_SECONDS) {
-    out_ << ts_._seconds_;
+std::ostream& operator<<(std::ostream& os, const timestamp& ts) {
+  os << ::IO_FORMAT_OPEN;
+  if (ts.seconds_ != timestamp::INVALID_SECONDS) {
+    os << ts.seconds_;
   } else {
-    out_ << ::IO_FORMAT_INVALID;
+    os << ::IO_FORMAT_INVALID;
   }
-  out_ << ::IO_FORMAT_SEP;
-  if (ts_._picoseconds_ != timestamp::INVALID_PICOSECONDS) {
-    out_ << ts_._picoseconds_;
+  os << ::IO_FORMAT_SEP;
+  if (ts.picoseconds_ != timestamp::INVALID_PICOSECONDS) {
+    os << ts.picoseconds_;
   } else {
-    out_ << ::IO_FORMAT_INVALID;
+    os << ::IO_FORMAT_INVALID;
   }
-  out_ << ::IO_FORMAT_CLOSE;
-  return out_;
+  os << ::IO_FORMAT_CLOSE;
+  return os;
 }
 
-std::istream& operator>>(std::istream& a_in, timestamp& ts_) {
+std::istream& operator>>(std::istream& a_in, timestamp& ts) {
   char c = 0;
   a_in >> c;
   if (!a_in) {
@@ -160,8 +156,8 @@ std::istream& operator>>(std::istream& a_in, timestamp& ts_) {
     a_in.setstate(std::ios_base::failbit);
     return a_in;
   }
-  ts_.set_seconds(s);
-  ts_.set_picoseconds(ps);
+  ts.set_seconds(s);
+  ts.set_picoseconds(ps);
   return a_in;
 }
 

--- a/source/falaise/snemo/datamodels/timestamp.cc
+++ b/source/falaise/snemo/datamodels/timestamp.cc
@@ -32,10 +32,6 @@ bool timestamp::is_valid() const {
   return _seconds_ != INVALID_SECONDS && _picoseconds_ != INVALID_PICOSECONDS;
 }
 
-void timestamp::invalidate() {
-  _seconds_ = INVALID_SECONDS;
-  _picoseconds_ = INVALID_PICOSECONDS;
-}
 
 int timestamp::compare(const timestamp& ts_) const {
   DT_THROW_IF(!is_valid(), std::logic_error, "Invalid timestamp (this) !");

--- a/source/falaise/snemo/datamodels/timestamp.h
+++ b/source/falaise/snemo/datamodels/timestamp.h
@@ -35,18 +35,17 @@ class timestamp : public datatools::i_serializable {
   timestamp() = default;
 
   /// Overloaded constructor
-  timestamp(int64_t sec_, int64_t picosec_)
-      : datatools::i_serializable{}, _seconds_{sec_}, _picoseconds_{picosec_} {}
+  timestamp(int64_t s, int64_t ps)
+      : datatools::i_serializable{}, seconds_{s}, picoseconds_{ps} {}
 
   /// Destructor
   virtual ~timestamp() = default;
 
   /// Copy/Move operations to get Ro5
-  timestamp(const timestamp&) = default;
-  timestamp& operator=(const timestamp&) = default; 
-  timestamp(timestamp&&) = default;
-  timestamp& operator=(timestamp&&) = default;
-
+  timestamp(const timestamp &) = default;
+  timestamp &operator=(const timestamp &) = default;
+  timestamp(timestamp &&) = default;
+  timestamp &operator=(timestamp &&) = default;
 
   /// Return the number of seconds
   int64_t get_seconds() const;
@@ -88,9 +87,9 @@ class timestamp : public datatools::i_serializable {
   int compare(const timestamp &) const;
   static const int64_t INVALID_SECONDS;
   static const int64_t INVALID_PICOSECONDS;
-  
-  int64_t _seconds_{INVALID_SECONDS};          //!< Number of seconds
-  int64_t _picoseconds_{INVALID_PICOSECONDS};  //!< Number of picoseconds
+
+  int64_t seconds_{INVALID_SECONDS};          //!< Number of seconds
+  int64_t picoseconds_{INVALID_PICOSECONDS};  //!< Number of picoseconds
 
   DATATOOLS_SERIALIZATION_DECLARATION()
 };

--- a/source/falaise/snemo/datamodels/timestamp.h
+++ b/source/falaise/snemo/datamodels/timestamp.h
@@ -63,9 +63,6 @@ class timestamp : public datatools::i_serializable {
   /// Check if the timestamp object is valid
   bool is_valid() const;
 
-  /// Invalidate the timestamp object
-  void invalidate();
-
   /// Convert timestamp to real value (explicit time unit)
   double to_real() const;
 

--- a/source/falaise/snemo/datamodels/tracker_cluster.cc
+++ b/source/falaise/snemo/datamodels/tracker_cluster.cc
@@ -39,9 +39,9 @@ void tracker_cluster::set_cluster_id(int32_t cluster_id_) { set_hit_id(cluster_i
 
 void tracker_cluster::invalidate_cluster_id() { invalidate_hit_id(); }
 
-calibrated_tracker_hit::collection_type& tracker_cluster::get_hits() { return _hits_; }
+TrackerHitHdlCollection& tracker_cluster::get_hits() { return _hits_; }
 
-const calibrated_tracker_hit::collection_type& tracker_cluster::get_hits() const { return _hits_; }
+const TrackerHitHdlCollection& tracker_cluster::get_hits() const { return _hits_; }
 
 void tracker_cluster::reset() { this->clear(); }
 

--- a/source/falaise/snemo/datamodels/tracker_cluster.cc
+++ b/source/falaise/snemo/datamodels/tracker_cluster.cc
@@ -30,40 +30,40 @@ void tracker_cluster::make_prompt() { grab_auxiliaries().unset_flag(delayed_clus
 
 int tracker_cluster::get_cluster_id() const { return get_hit_id(); }
 
-void tracker_cluster::set_cluster_id(int32_t cluster_id_) { set_hit_id(cluster_id_); }
+void tracker_cluster::set_cluster_id(int32_t id) { set_hit_id(id); }
 
-TrackerHitHdlCollection& tracker_cluster::hits() { return _hits_; }
+TrackerHitHdlCollection& tracker_cluster::hits() { return hits_; }
 
-const TrackerHitHdlCollection& tracker_cluster::hits() const { return _hits_; }
+const TrackerHitHdlCollection& tracker_cluster::hits() const { return hits_; }
 
 void tracker_cluster::clear() {
-  _hits_.clear();
+  hits_.clear();
   base_hit::clear();
 }
 
-size_t tracker_cluster::size() const { return _hits_.size(); }
+size_t tracker_cluster::size() const { return hits_.size(); }
 
 const calibrated_tracker_hit& tracker_cluster::at(size_t index) const {
-  return *(_hits_.at(index));
+  return *(hits_.at(index));
 }
 
-void tracker_cluster::tree_dump(std::ostream& out_, const std::string& title_,
-                                const std::string& indent_, bool inherit_) const {
-  base_hit::tree_dump(out_, title_, indent_, true);
+void tracker_cluster::tree_dump(std::ostream& out, const std::string& title,
+                                const std::string& indent, bool is_last) const {
+  base_hit::tree_dump(out, title, indent, true);
 
-  out_ << indent_ << datatools::i_tree_dumpable::tag << "Hit(s) : " << _hits_.size() << std::endl;
-  for (int i = 0; i < (int)_hits_.size(); i++) {
-    const calibrated_tracker_hit& gg_calib_hit = _hits_.at(i).get();
-    out_ << indent_ << datatools::i_tree_dumpable::skip_tag;
-    if (i + 1 == (int)_hits_.size()) {
-      out_ << datatools::i_tree_dumpable::last_tag;
+  out << indent << datatools::i_tree_dumpable::tag << "Hits[" << hits_.size() << "]:" << std::endl;
+  for (size_t i = 0; i < hits_.size(); ++i) {
+    //const calibrated_tracker_hit& gg_calib_hit = hits_.at(i).get();
+    out << indent << datatools::i_tree_dumpable::skip_tag;
+    if (i + 1 == hits_.size()) {
+      out << datatools::i_tree_dumpable::last_tag;
     } else {
-      out_ << datatools::i_tree_dumpable::tag;
+      out << datatools::i_tree_dumpable::tag;
     }
-    out_ << "Hit #" << i << " : Id=" << gg_calib_hit.get_hit_id()
-         << " GID=" << gg_calib_hit.get_geom_id() << std::endl;
+    out << "Hit[" << i << "] : (Id : " << hits_[i]->get_hit_id()
+         << ", GID : " << hits_[i]->get_geom_id() << ")" << std::endl;
   }
-  out_ << indent_ << datatools::i_tree_dumpable::inherit_tag(inherit_)
+  out << indent << datatools::i_tree_dumpable::inherit_tag(is_last)
        << "Cluster ID  : " << get_cluster_id() << std::endl;
 }
 

--- a/source/falaise/snemo/datamodels/tracker_cluster.cc
+++ b/source/falaise/snemo/datamodels/tracker_cluster.cc
@@ -3,6 +3,13 @@
 // Ourselves:
 #include <falaise/snemo/datamodels/tracker_cluster.h>
 
+namespace {
+const std::string& delayed_cluster_flag() {
+  static const std::string _flag("delayed");
+  return _flag;
+}
+}  // namespace
+
 namespace snemo {
 
 namespace datamodel {
@@ -11,51 +18,33 @@ namespace datamodel {
 DATATOOLS_SERIALIZATION_SERIAL_TAG_IMPLEMENTATION(tracker_cluster,
                                                   "snemo::datamodel::tracker_cluster")
 
-// static
-const std::string& tracker_cluster::delayed_cluster_flag() {
-  static const std::string _flag("delayed");
-  return _flag;
-}
-
 bool tracker_cluster::is_delayed() const {
-  return get_auxiliaries().has_flag(tracker_cluster::delayed_cluster_flag());
+  return get_auxiliaries().has_flag(delayed_cluster_flag());
 }
 
 bool tracker_cluster::is_prompt() const { return !is_delayed(); }
 
-void tracker_cluster::make_delayed() {
-  grab_auxiliaries().update_flag(tracker_cluster::delayed_cluster_flag());
-}
+void tracker_cluster::make_delayed() { grab_auxiliaries().update_flag(delayed_cluster_flag()); }
 
-void tracker_cluster::make_prompt() {
-  grab_auxiliaries().unset_flag(tracker_cluster::delayed_cluster_flag());
-}
-
-bool tracker_cluster::has_cluster_id() const { return has_hit_id(); }
+void tracker_cluster::make_prompt() { grab_auxiliaries().unset_flag(delayed_cluster_flag()); }
 
 int tracker_cluster::get_cluster_id() const { return get_hit_id(); }
 
 void tracker_cluster::set_cluster_id(int32_t cluster_id_) { set_hit_id(cluster_id_); }
 
-void tracker_cluster::invalidate_cluster_id() { invalidate_hit_id(); }
+TrackerHitHdlCollection& tracker_cluster::hits() { return _hits_; }
 
-TrackerHitHdlCollection& tracker_cluster::get_hits() { return _hits_; }
-
-const TrackerHitHdlCollection& tracker_cluster::get_hits() const { return _hits_; }
-
-void tracker_cluster::reset() { this->clear(); }
+const TrackerHitHdlCollection& tracker_cluster::hits() const { return _hits_; }
 
 void tracker_cluster::clear() {
   _hits_.clear();
   base_hit::clear();
 }
 
-unsigned int tracker_cluster::get_number_of_hits() const { return _hits_.size(); }
+size_t tracker_cluster::size() const { return _hits_.size(); }
 
-const calibrated_tracker_hit& tracker_cluster::get_hit(int i_) const {
-  DT_THROW_IF(i_ < 0 || i_ >= (int)_hits_.size(), std::range_error,
-              "Invalid clustered hit index (" << i_ << ") !");
-  return *(_hits_[i_]);
+const calibrated_tracker_hit& tracker_cluster::at(size_t index) const {
+  return *(_hits_.at(index));
 }
 
 void tracker_cluster::tree_dump(std::ostream& out_, const std::string& title_,

--- a/source/falaise/snemo/datamodels/tracker_cluster.h
+++ b/source/falaise/snemo/datamodels/tracker_cluster.h
@@ -27,9 +27,6 @@ namespace datamodel {
 /// \brief A cluster of Geiger calibrated hits referenced by handles
 class tracker_cluster : public geomtools::base_hit {
  public:
-  /// Flag for a auxiliary property
-  static const std::string& delayed_cluster_flag();
-
   /// Check if the cluster is associated to delayed hits
   bool is_delayed() const;
 
@@ -42,35 +39,26 @@ class tracker_cluster : public geomtools::base_hit {
   /// Mark the cluster as associated to prompt hits
   void make_prompt();
 
-  /// Check if there is a valid cluster ID
-  bool has_cluster_id() const;
-
   /// Get the cluster ID
   int get_cluster_id() const;
 
   /// Set the cluster ID
   void set_cluster_id(int32_t);
 
-  /// Invalidate the cluster ID
-  void invalidate_cluster_id();
-
   /// Return a mutable reference on the container of handles on calibrated tracker hits
-  TrackerHitHdlCollection& get_hits();
+  TrackerHitHdlCollection& hits();
 
   /// Return a non mutable reference on the container of handles on calibrated tracker hits
-  const TrackerHitHdlCollection& get_hits() const;
+  const TrackerHitHdlCollection& hits() const;
 
   /// Return the number of hits in the cluster
-  unsigned int get_number_of_hits() const;
+  size_t size() const;
 
   /// Return a non mutable reference on the calibrated tracker hit given its index
-  const calibrated_tracker_hit& get_hit(int i_) const;
+  const calibrated_tracker_hit& at(size_t index) const;
 
   /// Reset/invalidate the contents of the tracker cluster
   void clear();
-
-  /// Reset/invalidate the tracker cluster(see clear)
-  void reset();
 
   /// Smart print
   virtual void tree_dump(std::ostream& out_ = std::clog, const std::string& title_ = "",
@@ -87,7 +75,6 @@ using TrackerClusterCollection = std::vector<TrackerCluster>;
 
 using TrackerClusterHdl = datatools::handle<TrackerCluster>;
 using TrackerClusterHdlCollection = std::vector<TrackerClusterHdl>;
-
 
 }  // end of namespace datamodel
 

--- a/source/falaise/snemo/datamodels/tracker_cluster.h
+++ b/source/falaise/snemo/datamodels/tracker_cluster.h
@@ -76,23 +76,6 @@ using TrackerClusterCollection = std::vector<TrackerCluster>;
 using TrackerClusterHdl = datatools::handle<TrackerCluster>;
 using TrackerClusterHdlCollection = std::vector<TrackerClusterHdl>;
 
-/*
-inline auto begin(TrackerCluster& tc) -> decltype(tc.hits().begin()) {
-  return tc.hits().begin();
-}
-
-inline auto begin(const TrackerCluster& tc) -> decltype(tc.hits().begin()) {
-  return tc.hits().begin();
-}
-
-inline auto end(TrackerCluster& tc) -> decltype(tc.hits().end()) {
-  return tc.hits().end();
-}
-
-inline auto end(const TrackerCluster& tc) -> decltype(tc.hits().end()) {
-  return tc.hits().end();
-}
-*/
 }  // end of namespace datamodel
 
 }  // end of namespace snemo

--- a/source/falaise/snemo/datamodels/tracker_cluster.h
+++ b/source/falaise/snemo/datamodels/tracker_cluster.h
@@ -61,11 +61,11 @@ class tracker_cluster : public geomtools::base_hit {
   void clear();
 
   /// Smart print
-  virtual void tree_dump(std::ostream& out_ = std::clog, const std::string& title_ = "",
-                         const std::string& indent_ = "", bool inherit_ = false) const;
+  virtual void tree_dump(std::ostream& out = std::clog, const std::string& title = "",
+                         const std::string& indent = "", bool is_last = false) const;
 
  private:
-  TrackerHitHdlCollection _hits_;  //!< Collection of Geiger hit handles
+  TrackerHitHdlCollection hits_;  //!< Collection of Geiger hit handles
 
   DATATOOLS_SERIALIZATION_DECLARATION()
 };

--- a/source/falaise/snemo/datamodels/tracker_cluster.h
+++ b/source/falaise/snemo/datamodels/tracker_cluster.h
@@ -76,6 +76,23 @@ using TrackerClusterCollection = std::vector<TrackerCluster>;
 using TrackerClusterHdl = datatools::handle<TrackerCluster>;
 using TrackerClusterHdlCollection = std::vector<TrackerClusterHdl>;
 
+/*
+inline auto begin(TrackerCluster& tc) -> decltype(tc.hits().begin()) {
+  return tc.hits().begin();
+}
+
+inline auto begin(const TrackerCluster& tc) -> decltype(tc.hits().begin()) {
+  return tc.hits().begin();
+}
+
+inline auto end(TrackerCluster& tc) -> decltype(tc.hits().end()) {
+  return tc.hits().end();
+}
+
+inline auto end(const TrackerCluster& tc) -> decltype(tc.hits().end()) {
+  return tc.hits().end();
+}
+*/
 }  // end of namespace datamodel
 
 }  // end of namespace snemo

--- a/source/falaise/snemo/datamodels/tracker_cluster.h
+++ b/source/falaise/snemo/datamodels/tracker_cluster.h
@@ -27,9 +27,6 @@ namespace datamodel {
 /// \brief A cluster of Geiger calibrated hits referenced by handles
 class tracker_cluster : public geomtools::base_hit {
  public:
-  /// Handle on tracker cluster
-  typedef datatools::handle<tracker_cluster> handle_type;
-
   /// Flag for a auxiliary property
   static const std::string& delayed_cluster_flag();
 
@@ -58,10 +55,10 @@ class tracker_cluster : public geomtools::base_hit {
   void invalidate_cluster_id();
 
   /// Return a mutable reference on the container of handles on calibrated tracker hits
-  calibrated_tracker_hit::collection_type& get_hits();
+  TrackerHitHdlCollection& get_hits();
 
   /// Return a non mutable reference on the container of handles on calibrated tracker hits
-  const calibrated_tracker_hit::collection_type& get_hits() const;
+  const TrackerHitHdlCollection& get_hits() const;
 
   /// Return the number of hits in the cluster
   unsigned int get_number_of_hits() const;
@@ -80,10 +77,17 @@ class tracker_cluster : public geomtools::base_hit {
                          const std::string& indent_ = "", bool inherit_ = false) const;
 
  private:
-  calibrated_tracker_hit::collection_type _hits_;  //!< Collection of Geiger hit handles
+  TrackerHitHdlCollection _hits_;  //!< Collection of Geiger hit handles
 
   DATATOOLS_SERIALIZATION_DECLARATION()
 };
+
+using TrackerCluster = tracker_cluster;
+using TrackerClusterCollection = std::vector<TrackerCluster>;
+
+using TrackerClusterHdl = datatools::handle<TrackerCluster>;
+using TrackerClusterHdlCollection = std::vector<TrackerClusterHdl>;
+
 
 }  // end of namespace datamodel
 

--- a/source/falaise/snemo/datamodels/tracker_clustering_data.cc
+++ b/source/falaise/snemo/datamodels/tracker_clustering_data.cc
@@ -7,84 +7,78 @@ namespace snemo {
 
 namespace datamodel {
 
-bool tracker_clustering_data::empty() const { return _solutions_.empty(); }
+bool tracker_clustering_data::empty() const { return solutions_.empty(); }
 
-size_t tracker_clustering_data::size() const { return _solutions_.size(); }
+size_t tracker_clustering_data::size() const { return solutions_.size(); }
 
 const tracker_clustering_solution& tracker_clustering_data::at(size_t index) const {
-  return *(_solutions_.at(index));
+  return *(solutions_.at(index));
 }
 
 void tracker_clustering_data::push_back(const TrackerClusteringSolutionHdl& solution,
                                         bool isDefault) {
   DT_THROW_IF(!solution, std::logic_error, "Cannot store a null handle !");
 
-  for (const auto& addr : _solutions_) {
+  for (const auto& addr : solutions_) {
     DT_THROW_IF(&(*addr) == &(*solution), std::logic_error, "Duplicated solutions is not allowed!");
   }
-  _solutions_.push_back(solution);
-  if (isDefault || _solutions_.size() == 1) {
-    _default_solution_ = solution;
+  solutions_.push_back(solution);
+  if (isDefault || solutions_.size() == 1) {
+    default_ = solution;
   }
 }
 
-bool tracker_clustering_data::has_default() const { return _default_solution_; }
+bool tracker_clustering_data::has_default() const { return default_; }
 
 tracker_clustering_solution& tracker_clustering_data::get_default() {
   DT_THROW_IF(empty(), std::logic_error, "No default solution is available !");
-  return *_default_solution_;
+  return *default_;
 }
 
 const tracker_clustering_solution& tracker_clustering_data::get_default() const {
   DT_THROW_IF(empty(), std::logic_error, "No default solution is available !");
-  return *_default_solution_;
+  return *default_;
 }
 
-void tracker_clustering_data::set_default(size_t index_) {
-  _default_solution_ = _solutions_.at(index_);
-}
+void tracker_clustering_data::set_default(size_t index_) { default_ = solutions_.at(index_); }
 
-TrackerClusteringSolutionHdlCollection& tracker_clustering_data::solutions() { return _solutions_; }
+TrackerClusteringSolutionHdlCollection& tracker_clustering_data::solutions() { return solutions_; }
 
 const TrackerClusteringSolutionHdlCollection& tracker_clustering_data::solutions() const {
-  return _solutions_;
+  return solutions_;
 }
 
 void tracker_clustering_data::clear() {
-  _solutions_.clear();
-  _default_solution_ = TrackerClusteringSolutionHdl{};
+  solutions_.clear();
+  default_ = TrackerClusteringSolutionHdl{};
   _auxiliaries_.clear();
 }
 
-void tracker_clustering_data::tree_dump(std::ostream& out_, const std::string& title_,
-                                        const std::string& indent_, bool /*inherit_*/) const {
-  std::string indent;
-  if (!indent_.empty()) {
-    indent = indent_;
-  }
-  if (!title_.empty()) {
-    out_ << indent << title_ << std::endl;
+void tracker_clustering_data::tree_dump(std::ostream& out, const std::string& title,
+                                        const std::string& indent, bool /*inherit_*/) const {
+  if (!title.empty()) {
+    out << indent << title << std::endl;
   }
 
-  out_ << indent << datatools::i_tree_dumpable::tag << "Solution(s) : " << _solutions_.size()
-       << std::endl;
+  out << indent << datatools::i_tree_dumpable::tag << "Solutions[" << solutions_.size() << "]: "
+      << std::endl;
   for (size_t i = 0; i < size(); i++) {
     std::ostringstream indent2;
-    out_ << indent << datatools::i_tree_dumpable::skip_tag;
+    out << indent << datatools::i_tree_dumpable::skip_tag;
     indent2 << indent << datatools::i_tree_dumpable::skip_tag;
     if (i == size() - 1) {
-      out_ << datatools::i_tree_dumpable::last_tag;
+      out << datatools::i_tree_dumpable::last_tag;
       indent2 << datatools::i_tree_dumpable::last_skip_tag;
     } else {
-      out_ << datatools::i_tree_dumpable::tag;
+      out << datatools::i_tree_dumpable::tag;
       indent2 << datatools::i_tree_dumpable::skip_tag;
     }
-    out_ << "Solution #" << i << " : " << std::endl;
-    at(i).tree_dump(out_, "", indent2.str());
+    out << "Solution #" << i << " : " << std::endl;
+    at(i).tree_dump(out, "", indent2.str());
   }
 
-  out_ << indent << datatools::i_tree_dumpable::tag
-       << "Default solution : " << (!_default_solution_ ? "No" : "Yes") << std::endl;
+  out << indent << datatools::i_tree_dumpable::tag
+      << "Default solution : " << (default_ ? "Yes" : "No") << std::endl;
 }
 
 // Serial tag for datatools::serialization::i_serializable interface :

--- a/source/falaise/snemo/datamodels/tracker_clustering_data.cc
+++ b/source/falaise/snemo/datamodels/tracker_clustering_data.cc
@@ -33,7 +33,6 @@ const std::string& tracker_clustering_data::clusterizer_id_key() {
 }
 // ----- ABOVE TO BE MOVED -----
 
-
 bool tracker_clustering_data::has_solutions() const { return get_number_of_solutions() > 0; }
 
 size_t tracker_clustering_data::get_number_of_solutions() const { return _solutions_.size(); }
@@ -42,11 +41,11 @@ const tracker_clustering_solution& tracker_clustering_data::get_solution(int i_)
   return *(_solutions_.at(i_));
 }
 
-void tracker_clustering_data::add_solution(
-    const tracker_clustering_solution::handle_type& solution_handle_, bool default_solution_) {
+void tracker_clustering_data::add_solution(const TrackerClusteringSolutionHdl& solution_handle_,
+                                           bool default_solution_) {
   DT_THROW_IF(!solution_handle_, std::logic_error, "Cannot store a null handle !");
 
-  for(const auto& addr : _solutions_) {
+  for (const auto& addr : _solutions_) {
     DT_THROW_IF(&(*addr) == &(*solution_handle_), std::logic_error,
                 "Duplicated solutions is not allowed!");
   }
@@ -56,9 +55,7 @@ void tracker_clustering_data::add_solution(
   }
 }
 
-void tracker_clustering_data::invalidate_solutions() {
-  _solutions_.clear();
-}
+void tracker_clustering_data::invalidate_solutions() { _solutions_.clear(); }
 
 bool tracker_clustering_data::has_default_solution() const { return _default_solution_.has_data(); }
 
@@ -76,21 +73,17 @@ void tracker_clustering_data::set_default_solution(int index_) {
   _default_solution_ = _solutions_.at(index_);
 }
 
-void tracker_clustering_data::invalidate_default_solution() {
-  _default_solution_.reset();
-}
+void tracker_clustering_data::invalidate_default_solution() { _default_solution_.reset(); }
 
-tracker_clustering_data::solution_col_type& tracker_clustering_data::get_solutions() {
+TrackerClusteringSolutionHdlCollection& tracker_clustering_data::get_solutions() {
   return _solutions_;
 }
 
-const tracker_clustering_data::solution_col_type& tracker_clustering_data::get_solutions() const {
+const TrackerClusteringSolutionHdlCollection& tracker_clustering_data::get_solutions() const {
   return _solutions_;
 }
 
-void tracker_clustering_data::reset() {
-  this->clear();
-}
+void tracker_clustering_data::reset() { this->clear(); }
 
 void tracker_clustering_data::clear() {
   invalidate_solutions();

--- a/source/falaise/snemo/datamodels/tracker_clustering_data.h
+++ b/source/falaise/snemo/datamodels/tracker_clustering_data.h
@@ -130,68 +130,38 @@ class tracker_clustering_data : public datatools::i_serializable,
                                 public datatools::i_tree_dumpable,
                                 public datatools::i_clear {
  public:
-  // s'Far as I can tell, these statics are ONLY used by base_tracker_clusterizer
-  // They therefore make zero sense here (more to the point DONT STORE IN PROPERTIES)
-  // ----- NOT RELEVANT TO THIS CLASS -----
-  /// Key for the boolean property associated to prompt clustering solutions
-  static const std::string& prompt_key();
-
-  /// Key for the boolean property associated to delayed clustering solutions
-  static const std::string& delayed_key();
-
-  /// Key for the integer property associated to delayed clustering solutions
-  static const std::string& delayed_id_key();
-
-  /// Key for the string Id property documenting the clustering algorithm used to build a given
-  /// clustering solution
-  static const std::string& clusterizer_id_key();
-  // ----- ABOVE ARE NOT RELEVANT TO THIS CLASS ----
-
   /// Check if there are some clustering solutions
-  bool has_solutions() const;
+  bool empty() const;
 
   /// Returns the number of solutions
-  size_t get_number_of_solutions() const;
+  size_t size() const;
 
   /// Add a clustering solution
-  void add_solution(const TrackerClusteringSolutionHdl& handle_,
-                    bool default_solution_ = false);
+  void push_back(const TrackerClusteringSolutionHdl& solution, bool isDefault = false);
 
   /// Return a non mutable reference to a clustering solution by index
-  const tracker_clustering_solution& get_solution(int i_) const;
+  const tracker_clustering_solution& at(size_t index) const;
 
   /// Reset the clustering solutions
-  void invalidate_solutions();
+  virtual void clear();
 
   /// Check if there is some default clustering solution
-  bool has_default_solution() const;
+  bool has_default() const;
 
   /// Return the non mutable reference to the collection of clustering solutions
-  const TrackerClusteringSolutionHdlCollection& get_solutions() const;
+  const TrackerClusteringSolutionHdlCollection& solutions() const;
 
   /// Return the mutable reference to the collection of clustering solutions
-  TrackerClusteringSolutionHdlCollection& get_solutions();
+  TrackerClusteringSolutionHdlCollection& solutions();
 
   /// Return a non mutable reference to the default clustering solution is any
-  const tracker_clustering_solution& get_default_solution() const;
+  const tracker_clustering_solution& get_default() const;
 
   /// Return a mutable reference to the default clustering solution is any
-  tracker_clustering_solution& get_default_solution();
-
-  /// Reset the default clustering solution is any
-  void invalidate_default_solution();
+  tracker_clustering_solution& get_default();
 
   /// Set the default clustering solution
-  void set_default_solution(int index_);
-
-  /// Reset the internals
-  void reset();
-
-  /// Check if the object has a valid internal structure
-  bool is_valid() const;
-
-  /// Clear the object
-  virtual void clear();
+  void set_default(size_t index);
 
   /// Smart print
   virtual void tree_dump(std::ostream& out_ = std::clog, const std::string& title_ = "",
@@ -201,6 +171,7 @@ class tracker_clustering_data : public datatools::i_serializable,
   TrackerClusteringSolutionHdlCollection
       _solutions_{};  //!< Collection of Geiger cluster solution handles
   TrackerClusteringSolutionHdl _default_solution_{};  //!< Handle to the default/best solution
+
   datatools::properties
       _auxiliaries_{};  //!< Auxiliary properties (maintained for backward serialization compat)
   DATATOOLS_SERIALIZATION_DECLARATION()

--- a/source/falaise/snemo/datamodels/tracker_clustering_data.h
+++ b/source/falaise/snemo/datamodels/tracker_clustering_data.h
@@ -164,13 +164,12 @@ class tracker_clustering_data : public datatools::i_serializable,
   void set_default(size_t index);
 
   /// Smart print
-  virtual void tree_dump(std::ostream& out_ = std::clog, const std::string& title_ = "",
-                         const std::string& indent_ = "", bool inherit_ = false) const;
+  virtual void tree_dump(std::ostream& out = std::clog, const std::string& title = "",
+                         const std::string& indent = "", bool is_last = false) const;
 
  private:
-  TrackerClusteringSolutionHdlCollection
-      _solutions_{};  //!< Collection of Geiger cluster solution handles
-  TrackerClusteringSolutionHdl _default_solution_{};  //!< Handle to the default/best solution
+  TrackerClusteringSolutionHdlCollection solutions_{};  //!< Collection of Geiger cluster solutions
+  TrackerClusteringSolutionHdl default_{};              //!< Handle to the default solution
 
   datatools::properties
       _auxiliaries_{};  //!< Auxiliary properties (maintained for backward serialization compat)

--- a/source/falaise/snemo/datamodels/tracker_clustering_data.h
+++ b/source/falaise/snemo/datamodels/tracker_clustering_data.h
@@ -171,8 +171,7 @@ class tracker_clustering_data : public datatools::i_serializable,
   TrackerClusteringSolutionHdlCollection solutions_{};  //!< Collection of Geiger cluster solutions
   TrackerClusteringSolutionHdl default_{};              //!< Handle to the default solution
 
-  datatools::properties
-      _auxiliaries_{};  //!< Auxiliary properties (maintained for backward serialization compat)
+  datatools::properties _auxiliaries_{};  // unused, kept for backward serialization compatibility
   DATATOOLS_SERIALIZATION_DECLARATION()
 };
 

--- a/source/falaise/snemo/datamodels/tracker_clustering_data.h
+++ b/source/falaise/snemo/datamodels/tracker_clustering_data.h
@@ -147,9 +147,6 @@ class tracker_clustering_data : public datatools::i_serializable,
   static const std::string& clusterizer_id_key();
   // ----- ABOVE ARE NOT RELEVANT TO THIS CLASS ----
 
-  /// Collection of handles on tracker clustering solutions
-  typedef std::vector<tracker_clustering_solution::handle_type> solution_col_type;
-
   /// Check if there are some clustering solutions
   bool has_solutions() const;
 
@@ -157,7 +154,7 @@ class tracker_clustering_data : public datatools::i_serializable,
   size_t get_number_of_solutions() const;
 
   /// Add a clustering solution
-  void add_solution(const tracker_clustering_solution::handle_type& handle_,
+  void add_solution(const TrackerClusteringSolutionHdl& handle_,
                     bool default_solution_ = false);
 
   /// Return a non mutable reference to a clustering solution by index
@@ -170,10 +167,10 @@ class tracker_clustering_data : public datatools::i_serializable,
   bool has_default_solution() const;
 
   /// Return the non mutable reference to the collection of clustering solutions
-  const tracker_clustering_data::solution_col_type& get_solutions() const;
+  const TrackerClusteringSolutionHdlCollection& get_solutions() const;
 
   /// Return the mutable reference to the collection of clustering solutions
-  tracker_clustering_data::solution_col_type& get_solutions();
+  TrackerClusteringSolutionHdlCollection& get_solutions();
 
   /// Return a non mutable reference to the default clustering solution is any
   const tracker_clustering_solution& get_default_solution() const;
@@ -201,10 +198,11 @@ class tracker_clustering_data : public datatools::i_serializable,
                          const std::string& indent_ = "", bool inherit_ = false) const;
 
  private:
-  solution_col_type _solutions_{};  //!< Collection of Geiger cluster solution handles
-  tracker_clustering_solution::handle_type
-      _default_solution_{};               //!< Handle to the default/best solution
-  datatools::properties _auxiliaries_{};  //!< Auxiliary properties (maintained for backward serialization compat)
+  TrackerClusteringSolutionHdlCollection
+      _solutions_{};  //!< Collection of Geiger cluster solution handles
+  TrackerClusteringSolutionHdl _default_solution_{};  //!< Handle to the default/best solution
+  datatools::properties
+      _auxiliaries_{};  //!< Auxiliary properties (maintained for backward serialization compat)
   DATATOOLS_SERIALIZATION_DECLARATION()
 };
 

--- a/source/falaise/snemo/datamodels/tracker_clustering_solution.cc
+++ b/source/falaise/snemo/datamodels/tracker_clustering_solution.cc
@@ -34,22 +34,17 @@ bool tracker_clustering_solution::has_unclustered_hits() const {
   return !_unclustered_hits_.empty();
 }
 
-tracker_clustering_solution::hit_collection_type &
-tracker_clustering_solution::get_unclustered_hits() {
+TrackerHitHdlCollection &tracker_clustering_solution::get_unclustered_hits() {
   return _unclustered_hits_;
 }
 
-const tracker_clustering_solution::hit_collection_type &
-tracker_clustering_solution::get_unclustered_hits() const {
+const TrackerHitHdlCollection &tracker_clustering_solution::get_unclustered_hits() const {
   return _unclustered_hits_;
 }
 
-tracker_clustering_solution::cluster_col_type &tracker_clustering_solution::get_clusters() {
-  return _clusters_;
-}
+TrackerClusterHdlCollection &tracker_clustering_solution::get_clusters() { return _clusters_; }
 
-const tracker_clustering_solution::cluster_col_type &tracker_clustering_solution::get_clusters()
-    const {
+const TrackerClusterHdlCollection &tracker_clustering_solution::get_clusters() const {
   return _clusters_;
 }
 
@@ -197,7 +192,7 @@ void tracker_clustering_solution::compute_hit_belonging_from_solution(
 
       if (hbc_.find(hit_id) == hbc_.end()) {
         {
-          cluster_col_type dummy_col;
+          TrackerClusterHdlCollection dummy_col;
           hbc_[hit_id] = dummy_col;
         }
         hbc_[hit_id].push_back(the_cluster);
@@ -227,7 +222,7 @@ int tracker_clustering_solution::copy_one_solution_in_one(
   int max_cluster_id = -1;
 
   if (!tgt_clusters.empty()) {
-    auto id_comp = [](const cluster_handle_type &a, const cluster_handle_type &b) {
+    auto id_comp = [](const TrackerClusterHdl &a, const TrackerClusterHdl &b) {
       return a->get_cluster_id() < b->get_cluster_id();
     };
 
@@ -296,7 +291,7 @@ int tracker_clustering_solution::merge_two_solutions_in_ones(
       // Pickup a cluster from the solution:
       const tracker_cluster &a_cluster = rsol.get_clusters().at(icluster_source).get();
       // Create a new cluster:
-      tracker_cluster::handle_type hcl(new tracker_cluster);
+      auto hcl = datatools::make_handle<tracker_cluster>();
       tracker_cluster &cl = hcl.grab();
       // Copy the original cluster into the new one:
       cl = a_cluster;

--- a/source/falaise/snemo/datamodels/tracker_clustering_solution.cc
+++ b/source/falaise/snemo/datamodels/tracker_clustering_solution.cc
@@ -10,70 +10,70 @@ namespace snemo {
 
 namespace datamodel {
 
-bool tracker_clustering_solution::has_solution_id() const { return _solution_id_ >= 0; }
+bool tracker_clustering_solution::has_solution_id() const { return id_ >= 0; }
 
-int tracker_clustering_solution::get_solution_id() const { return _solution_id_; }
+int tracker_clustering_solution::get_solution_id() const { return id_; }
 
-void tracker_clustering_solution::set_solution_id(int32_t solution_id_) {
-  if (solution_id_ >= 0) {
-    _solution_id_ = solution_id_;
+void tracker_clustering_solution::set_solution_id(int32_t id) {
+  if (id >= 0) {
+    id_ = id;
   } else {
     invalidate_solution_id();
   }
 }
 
-void tracker_clustering_solution::invalidate_solution_id() { _solution_id_ = -1; }
+void tracker_clustering_solution::invalidate_solution_id() { id_ = -1; }
 
-datatools::properties &tracker_clustering_solution::get_auxiliaries() { return _auxiliaries_; }
+datatools::properties &tracker_clustering_solution::get_auxiliaries() { return auxiliaries_; }
 
 const datatools::properties &tracker_clustering_solution::get_auxiliaries() const {
-  return _auxiliaries_;
+  return auxiliaries_;
 }
 
 bool tracker_clustering_solution::has_unclustered_hits() const {
-  return !_unclustered_hits_.empty();
+  return !unclustered_hits_.empty();
 }
 
 TrackerHitHdlCollection &tracker_clustering_solution::get_unclustered_hits() {
-  return _unclustered_hits_;
+  return unclustered_hits_;
 }
 
 const TrackerHitHdlCollection &tracker_clustering_solution::get_unclustered_hits() const {
-  return _unclustered_hits_;
+  return unclustered_hits_;
 }
 
-TrackerClusterHdlCollection &tracker_clustering_solution::get_clusters() { return _clusters_; }
+TrackerClusterHdlCollection &tracker_clustering_solution::get_clusters() { return clusters_; }
 
 const TrackerClusterHdlCollection &tracker_clustering_solution::get_clusters() const {
-  return _clusters_;
+  return clusters_;
 }
 
 void tracker_clustering_solution::reset() { this->clear(); }
 
 void tracker_clustering_solution::clear() {
   reset_hit_belonging();
-  _clusters_.clear();
-  _unclustered_hits_.clear();
+  clusters_.clear();
+  unclustered_hits_.clear();
   invalidate_solution_id();
-  _auxiliaries_.clear();
+  auxiliaries_.clear();
 }
 
-bool tracker_clustering_solution::hit_belongs_to_cluster(const calibrated_tracker_hit &hit_,
-                                                         const tracker_cluster &cluster_) const {
-  return hit_belongs_to_cluster(hit_.get_hit_id(), cluster_.get_cluster_id());
+bool tracker_clustering_solution::hit_belongs_to_cluster(const calibrated_tracker_hit &hit,
+                                                         const tracker_cluster &cluster) const {
+  return hit_belongs_to_cluster(hit.get_hit_id(), cluster.get_cluster_id());
 }
 
-bool tracker_clustering_solution::hit_is_clustered(const calibrated_tracker_hit &hit_) const {
-  return hit_is_clustered(hit_.get_hit_id());
+bool tracker_clustering_solution::hit_is_clustered(const calibrated_tracker_hit &hit) const {
+  return hit_is_clustered(hit.get_hit_id());
 }
 
 bool tracker_clustering_solution::hit_is_clustered(int32_t hit_id_) const {
-  if (!_hit_belonging_.empty()) {
-    auto found = _hit_belonging_.find(hit_id_);
-    return found != _hit_belonging_.end() && !found->second.empty();
+  if (!hit_belonging_.empty()) {
+    auto found = hit_belonging_.find(hit_id_);
+    return found != hit_belonging_.end() && !found->second.empty();
   }
 
-  for (const auto &ihit : _unclustered_hits_) {
+  for (const auto &ihit : unclustered_hits_) {
     if (!ihit.has_data()) {
       continue;
     }
@@ -85,26 +85,26 @@ bool tracker_clustering_solution::hit_is_clustered(int32_t hit_id_) const {
 }
 
 bool tracker_clustering_solution::hit_belongs_to_several_clusters(
-    const calibrated_tracker_hit &hit_) const {
-  return hit_belongs_to_several_clusters(hit_.get_hit_id());
+    const calibrated_tracker_hit &hit) const {
+  return hit_belongs_to_several_clusters(hit.get_hit_id());
 }
 
 bool tracker_clustering_solution::hit_belongs_to_several_clusters(int32_t hit_id_) const {
   // If available, use the' hit_belonging' collection :
-  if (!_hit_belonging_.empty()) {
-    auto found = _hit_belonging_.find(hit_id_);
-    return found != _hit_belonging_.end() && found->second.size() > 1;
+  if (!hit_belonging_.empty()) {
+    auto found = hit_belonging_.find(hit_id_);
+    return found != hit_belonging_.end() && found->second.size() > 1;
   }
 
   // Shortcut :
-  if (_clusters_.size() < 2) {
+  if (clusters_.size() < 2) {
     return false;
   }
 
   // Traverse all clusters to count belongings for this hit
   // TODO: Review use of has_data, since a cluster by definition should have valid data
   int cluster_counter = 0;
-  for (const auto &the_cluster : _clusters_) {
+  for (const auto &the_cluster : clusters_) {
     if (!the_cluster.has_data()) {
       continue;
     }
@@ -126,9 +126,9 @@ bool tracker_clustering_solution::hit_belongs_to_several_clusters(int32_t hit_id
 bool tracker_clustering_solution::hit_belongs_to_cluster(int32_t hit_id_,
                                                          int32_t cluster_id_) const {
   // If available, use the' hit_belonging' collection :
-  if (!_hit_belonging_.empty()) {
-    auto found_iter = _hit_belonging_.find(hit_id_);
-    if (found_iter == _hit_belonging_.end()) {
+  if (!hit_belonging_.empty()) {
+    auto found_iter = hit_belonging_.find(hit_id_);
+    if (found_iter == hit_belonging_.end()) {
       return false;
     }
 
@@ -141,11 +141,11 @@ bool tracker_clustering_solution::hit_belongs_to_cluster(int32_t hit_id_,
     }
   } else {
     // Shortcut :
-    if (_clusters_.empty()) {
+    if (clusters_.empty()) {
       return false;
     }
     // Traverse all clusters to detect belongings for this hit :
-    for (const auto &the_cluster : _clusters_) {
+    for (const auto &the_cluster : clusters_) {
       if (the_cluster.has_data()) {
         if (the_cluster->get_cluster_id() != cluster_id_) {
           continue;
@@ -166,12 +166,12 @@ bool tracker_clustering_solution::hit_belongs_to_cluster(int32_t hit_id_,
 
 const tracker_clustering_solution::hit_belonging_col_type &
 tracker_clustering_solution::get_hit_belonging() const {
-  return _hit_belonging_;
+  return hit_belonging_;
 }
 
-void tracker_clustering_solution::reset_hit_belonging() { _hit_belonging_.clear(); }
+void tracker_clustering_solution::reset_hit_belonging() { hit_belonging_.clear(); }
 
-bool tracker_clustering_solution::has_hit_belonging() const { return !_hit_belonging_.empty(); }
+bool tracker_clustering_solution::has_hit_belonging() const { return !hit_belonging_.empty(); }
 
 // static
 void tracker_clustering_solution::compute_hit_belonging_from_solution(
@@ -202,7 +202,7 @@ void tracker_clustering_solution::compute_hit_belonging_from_solution(
 }
 
 void tracker_clustering_solution::compute_hit_belonging() {
-  compute_hit_belonging_from_solution(*this, _hit_belonging_);
+  compute_hit_belonging_from_solution(*this, hit_belonging_);
 }
 
 // static
@@ -333,8 +333,7 @@ void tracker_clustering_solution::tree_dump(std::ostream &out_, const std::strin
     out_ << indent_ << title_ << std::endl;
   }
 
-  out_ << indent_ << datatools::i_tree_dumpable::tag << "Solution ID  : " << _solution_id_
-       << std::endl;
+  out_ << indent_ << datatools::i_tree_dumpable::tag << "Solution ID  : " << id_ << std::endl;
 
   out_ << indent_ << datatools::i_tree_dumpable::tag << "Cluster(s)   : " << get_clusters().size()
        << std::endl;
@@ -357,12 +356,12 @@ void tracker_clustering_solution::tree_dump(std::ostream &out_, const std::strin
   {
     int hit_index = 0;
     out_ << indent_ << datatools::i_tree_dumpable::tag
-         << "Unclustered hit(s) : " << _unclustered_hits_.size() << std::endl;
-    for (auto i = _unclustered_hits_.begin(); i != _unclustered_hits_.end(); i++) {
+         << "Unclustered hit(s) : " << unclustered_hits_.size() << std::endl;
+    for (auto i = unclustered_hits_.begin(); i != unclustered_hits_.end(); i++) {
       out_ << indent_ << datatools::i_tree_dumpable::skip_tag;
       auto j = i;
       j++;
-      if (j == _unclustered_hits_.end()) {
+      if (j == unclustered_hits_.end()) {
         out_ << datatools::i_tree_dumpable::last_tag;
       } else {
         out_ << datatools::i_tree_dumpable::tag;
@@ -375,10 +374,10 @@ void tracker_clustering_solution::tree_dump(std::ostream &out_, const std::strin
   }
 
   out_ << indent_ << datatools::i_tree_dumpable::tag
-       << "Hits belonging : " << _hit_belonging_.size() << std::endl;
+       << "Hits belonging : " << hit_belonging_.size() << std::endl;
 
   out_ << indent_ << datatools::i_tree_dumpable::inherit_tag(inherit_) << "Auxiliaries : ";
-  if (_auxiliaries_.empty()) {
+  if (auxiliaries_.empty()) {
     out_ << "<empty>";
   }
   out_ << std::endl;
@@ -386,7 +385,7 @@ void tracker_clustering_solution::tree_dump(std::ostream &out_, const std::strin
     std::ostringstream indent_oss;
     indent_oss << indent_;
     indent_oss << datatools::i_tree_dumpable::inherit_skip_tag(inherit_);
-    _auxiliaries_.tree_dump(out_, "", indent_oss.str());
+    auxiliaries_.tree_dump(out_, "", indent_oss.str());
   }
 }
 

--- a/source/falaise/snemo/datamodels/tracker_clustering_solution.cc
+++ b/source/falaise/snemo/datamodels/tracker_clustering_solution.cc
@@ -109,7 +109,7 @@ bool tracker_clustering_solution::hit_belongs_to_several_clusters(int32_t hit_id
       continue;
     }
 
-    for (const auto &the_hit : the_cluster->get_hits()) {
+    for (const auto &the_hit : the_cluster->hits()) {
       if (!the_hit.has_data()) {
         continue;
       }
@@ -152,7 +152,7 @@ bool tracker_clustering_solution::hit_belongs_to_cluster(int32_t hit_id_,
         }
       }
       // Traverse all hits in the current cluster :
-      for (const auto &the_hit : the_cluster->get_hits()) {
+      for (const auto &the_hit : the_cluster->hits()) {
         if (the_hit.has_data()) {
           if (the_hit->get_hit_id() == hit_id_) {
             return true;
@@ -183,7 +183,7 @@ void tracker_clustering_solution::compute_hit_belonging_from_solution(
       continue;
     }
 
-    for (const auto &the_hit : the_cluster->get_hits()) {
+    for (const auto &the_hit : the_cluster->hits()) {
       if (!the_hit.has_data()) {
         continue;
       }
@@ -298,7 +298,7 @@ int tracker_clustering_solution::merge_two_solutions_in_ones(
       // But give it an unique Id:
       cl.set_cluster_id(max_cluster_id + icluster_source + 1);  // target_.grab_clusters().size());
       // Record the hit Ids in the check set for this source:
-      for (auto &iclustered_hit : cl.get_hits()) {
+      for (auto &iclustered_hit : cl.hits()) {
         int hit_id = iclustered_hit.get().get_hit_id();
         check_hits[source].insert(hit_id);
       }

--- a/source/falaise/snemo/datamodels/tracker_clustering_solution.h
+++ b/source/falaise/snemo/datamodels/tracker_clustering_solution.h
@@ -87,20 +87,8 @@ namespace datamodel {
  */
 class tracker_clustering_solution : public datatools::i_serializable {
  public:
-  /// Handle on tracker cluster
-  typedef tracker_cluster::handle_type cluster_handle_type;
-
-  /// Collection of handles on tracker clusters
-  typedef std::vector<cluster_handle_type> cluster_col_type;
-
-  /// Handle on tracker cluster solution
-  typedef datatools::handle<tracker_clustering_solution> handle_type;
-
-  /// Collection of calibrated hit handles
-  typedef calibrated_tracker_hit::collection_type hit_collection_type;
-
   /// Dictionary of hit/cluster belonging
-  typedef std::map<int32_t, cluster_col_type> hit_belonging_col_type;
+  typedef std::map<int32_t, TrackerClusterHdlCollection> hit_belonging_col_type;
 
   /// Check if there is a valid solution ID
   bool has_solution_id() const;
@@ -115,26 +103,26 @@ class tracker_clustering_solution : public datatools::i_serializable {
   void invalidate_solution_id();
 
   /// Return a mutable reference on the container of auxiliary properties
-  datatools::properties& get_auxiliaries();
+  datatools::properties &get_auxiliaries();
 
   /// Return a non mutable reference on the container of auxiliary properties
-  const datatools::properties& get_auxiliaries() const;
+  const datatools::properties &get_auxiliaries() const;
 
   /// Return a mutable reference on the container of clusters
-  cluster_col_type& get_clusters();
+  TrackerClusterHdlCollection &get_clusters();
 
   /// Return a non mutable reference on the container of clusters
-  const cluster_col_type& get_clusters() const;
+  const TrackerClusterHdlCollection &get_clusters() const;
 
   /// Check if there is some unclustered hits
   bool has_unclustered_hits() const;
 
   /// Return a mutable reference on the container of handles on unclustered calibrated tracker hits
-  hit_collection_type& get_unclustered_hits();
+  TrackerHitHdlCollection &get_unclustered_hits();
 
   /// Return a non mutable reference on the container of handles on unclustered calibrated tracker
   /// hits
-  const hit_collection_type& get_unclustered_hits() const;
+  const TrackerHitHdlCollection &get_unclustered_hits() const;
 
   /// Empty the contents of the tracker cluster solution
   void clear();
@@ -192,16 +180,24 @@ class tracker_clustering_solution : public datatools::i_serializable {
                                       tracker_clustering_solution &target_);
 
  private:
-  int32_t _solution_id_{-1};                   //!< Unique solution ID
-  cluster_col_type _clusters_{};             //!< Collection of handles on prompt Geiger hits clusters
-  hit_collection_type _unclustered_hits_{};  //!< Collection of handles on unclustered Geiger hits
-  datatools::properties _auxiliaries_{};     //!< List of auxiliary properties
+  int32_t _solution_id_{-1};  //!< Unique solution ID
+  TrackerClusterHdlCollection
+      _clusters_{};  //!< Collection of handles on prompt Geiger hits clusters
+  TrackerHitHdlCollection
+      _unclustered_hits_{};               //!< Collection of handles on unclustered Geiger hits
+  datatools::properties _auxiliaries_{};  //!< List of auxiliary properties
 
   // Non persistent information :
   hit_belonging_col_type _hit_belonging_{};  //!< List of clusters for each clustered hits
 
   DATATOOLS_SERIALIZATION_DECLARATION()
 };
+
+using TrackerClusteringSolution = tracker_clustering_solution;
+using TrackerClusteringSolutionCollection = std::vector<TrackerClusteringSolution>;
+
+using TrackerClusteringSolutionHdl = datatools::handle<TrackerClusteringSolution>;
+using TrackerClusteringSolutionHdlCollection = std::vector<TrackerClusteringSolutionHdl>;
 
 }  // end of namespace datamodel
 

--- a/source/falaise/snemo/datamodels/tracker_clustering_solution.h
+++ b/source/falaise/snemo/datamodels/tracker_clustering_solution.h
@@ -130,10 +130,6 @@ class tracker_clustering_solution : public datatools::i_serializable {
   /// Reset the tracker cluster solution(see clear)
   void reset();
 
-  /// Smart print
-  virtual void tree_dump(std::ostream &out_ = std::clog, const std::string &title_ = "",
-                         const std::string &indent_ = "", bool inherit_ = false) const;
-
   /// Compute hit belonging
   void compute_hit_belonging();
 
@@ -165,6 +161,10 @@ class tracker_clustering_solution : public datatools::i_serializable {
   /// Test if some hit belonging information is available
   bool has_hit_belonging() const;
 
+  /// Smart print
+  virtual void tree_dump(std::ostream &out = std::clog, const std::string &title = "",
+                         const std::string &indent = "", bool inherit = false) const;
+
   /// Compute the hit belonging informations from a given clustering solution
   static void compute_hit_belonging_from_solution(const tracker_clustering_solution &tcs_,
                                                   hit_belonging_col_type &hbc_);
@@ -180,15 +180,13 @@ class tracker_clustering_solution : public datatools::i_serializable {
                                       tracker_clustering_solution &target_);
 
  private:
-  int32_t _solution_id_{-1};  //!< Unique solution ID
-  TrackerClusterHdlCollection
-      _clusters_{};  //!< Collection of handles on prompt Geiger hits clusters
-  TrackerHitHdlCollection
-      _unclustered_hits_{};               //!< Collection of handles on unclustered Geiger hits
-  datatools::properties _auxiliaries_{};  //!< List of auxiliary properties
+  int32_t id_{-1};                              //!< Unique solution ID
+  TrackerClusterHdlCollection clusters_{};      //!< Collection of Tracker hit clusters
+  TrackerHitHdlCollection unclustered_hits_{};  //!< Collection of unclustered Trackernja hits
+  datatools::properties auxiliaries_{};         //!< List of auxiliary properties
 
   // Non persistent information :
-  hit_belonging_col_type _hit_belonging_{};  //!< List of clusters for each clustered hits
+  hit_belonging_col_type hit_belonging_{};  //!< List of clusters for each clustered hits
 
   DATATOOLS_SERIALIZATION_DECLARATION()
 };

--- a/source/falaise/snemo/datamodels/tracker_trajectory.cc
+++ b/source/falaise/snemo/datamodels/tracker_trajectory.cc
@@ -18,61 +18,51 @@ bool tracker_trajectory::has_id() const { return has_hit_id(); }
 
 int tracker_trajectory::get_id() const { return get_hit_id(); }
 
-void tracker_trajectory::set_id(int trajectory_id_) { set_hit_id(trajectory_id_); }
+void tracker_trajectory::set_id(int id) { set_hit_id(id); }
 
-bool tracker_trajectory::has_cluster() const { return _cluster_.has_data(); }
+bool tracker_trajectory::has_cluster() const { return cluster_.has_data(); }
 
-void tracker_trajectory::detach_cluster() { _cluster_.reset(); }
+void tracker_trajectory::detach_cluster() { cluster_.reset(); }
 
 void tracker_trajectory::set_cluster_handle(const TrackerClusterHdl& cluster) {
-  _cluster_ = cluster;
+  cluster_ = cluster;
 }
 
-tracker_cluster& tracker_trajectory::get_cluster() { return *_cluster_; }
+tracker_cluster& tracker_trajectory::get_cluster() { return *cluster_; }
 
-const tracker_cluster& tracker_trajectory::get_cluster() const { return *_cluster_; }
+const tracker_cluster& tracker_trajectory::get_cluster() const { return *cluster_; }
 
-bool tracker_trajectory::has_pattern() const { return _pattern_.has_data(); }
+bool tracker_trajectory::has_pattern() const { return pattern_.has_data(); }
 
 void tracker_trajectory::set_pattern_handle(const TrajectoryPatternHdl& pattern) {
-  _pattern_ = pattern;
+  pattern_ = pattern;
 }
 
-void tracker_trajectory::detach_pattern() { _pattern_.reset(); }
+void tracker_trajectory::detach_pattern() { pattern_.reset(); }
 
-TrajectoryPattern& tracker_trajectory::get_pattern() { return *_pattern_; }
+TrajectoryPattern& tracker_trajectory::get_pattern() { return *pattern_; }
 
-const TrajectoryPattern& tracker_trajectory::get_pattern() const { return *_pattern_; }
+const TrajectoryPattern& tracker_trajectory::get_pattern() const { return *pattern_; }
 
 void tracker_trajectory::clear() {
   detach_pattern();
-  _orphans_.clear();
+  orphans_.clear();
   detach_cluster();
   base_hit::clear();
 }
 
-void tracker_trajectory::tree_dump(std::ostream& out_, const std::string& title_,
-                                   const std::string& indent_, bool inherit_) const {
-  base_hit::tree_dump(out_, title_, indent_, true);
+void tracker_trajectory::tree_dump(std::ostream& out, const std::string& title,
+                                   const std::string& indent, bool is_last) const {
+  base_hit::tree_dump(out, title, indent, true);
 
-  out_ << indent_ << datatools::i_tree_dumpable::tag << "Cluster : ";
-  if (has_cluster()) {
-    out_ << _cluster_->get_cluster_id();
-  } else {
-    out_ << "<none>";
-  }
-  out_ << std::endl;
-
-  out_ << indent_ << datatools::i_tree_dumpable::tag << "Pattern : ";
-  if (has_pattern()) {
-    out_ << "'" << _pattern_->get_pattern_id() << "'";
-  } else {
-    out_ << "<none>";
-  }
-  out_ << std::endl;
-
-  out_ << indent_ << datatools::i_tree_dumpable::inherit_tag(inherit_)
-       << "Trajectory ID  : " << get_id() << std::endl;
+  out << indent << datatools::i_tree_dumpable::tag << "Cluster : "
+      << (has_cluster() ? std::to_string(cluster_->get_cluster_id()) : "<none>")
+      << std::endl;
+  out << indent << datatools::i_tree_dumpable::tag << "Pattern : "
+      << (has_pattern() ? pattern_->get_pattern_id() : "<none>")
+      << std::endl;
+  out << indent << datatools::i_tree_dumpable::inherit_tag(is_last)
+      << "Trajectory ID  : " << get_id() << std::endl;
 }
 
 }  // end of namespace datamodel

--- a/source/falaise/snemo/datamodels/tracker_trajectory.cc
+++ b/source/falaise/snemo/datamodels/tracker_trajectory.cc
@@ -14,26 +14,18 @@ namespace datamodel {
 DATATOOLS_SERIALIZATION_SERIAL_TAG_IMPLEMENTATION(tracker_trajectory,
                                                   "snemo::datamodel::tracker_trajectory")
 
-bool tracker_trajectory::has_trajectory_id() const { return has_hit_id(); }
+bool tracker_trajectory::has_id() const { return has_hit_id(); }
 
-int tracker_trajectory::get_trajectory_id() const { return get_hit_id(); }
+int tracker_trajectory::get_id() const { return get_hit_id(); }
 
-void tracker_trajectory::set_trajectory_id(int trajectory_id_) { set_hit_id(trajectory_id_); }
-
-void tracker_trajectory::invalidate_trajectory_id() { invalidate_hit_id(); }
+void tracker_trajectory::set_id(int trajectory_id_) { set_hit_id(trajectory_id_); }
 
 bool tracker_trajectory::has_cluster() const { return _cluster_.has_data(); }
 
 void tracker_trajectory::detach_cluster() { _cluster_.reset(); }
 
-TrackerClusterHdl& tracker_trajectory::get_cluster_handle() { return _cluster_; }
-
-const TrackerClusterHdl& tracker_trajectory::get_cluster_handle() const {
-  return _cluster_;
-}
-
-void tracker_trajectory::set_cluster_handle(const TrackerClusterHdl& cluster_handle_) {
-  _cluster_ = cluster_handle_;
+void tracker_trajectory::set_cluster_handle(const TrackerClusterHdl& cluster) {
+  _cluster_ = cluster;
 }
 
 tracker_cluster& tracker_trajectory::get_cluster() { return *_cluster_; }
@@ -42,21 +34,15 @@ const tracker_cluster& tracker_trajectory::get_cluster() const { return *_cluste
 
 bool tracker_trajectory::has_pattern() const { return _pattern_.has_data(); }
 
-void tracker_trajectory::set_pattern_handle(const TrajectoryPatternHdl& pattern_handle_) {
-  _pattern_ = pattern_handle_;
+void tracker_trajectory::set_pattern_handle(const TrajectoryPatternHdl& pattern) {
+  _pattern_ = pattern;
 }
 
 void tracker_trajectory::detach_pattern() { _pattern_.reset(); }
 
-TrajectoryPatternHdl& tracker_trajectory::get_pattern_handle() { return _pattern_; }
-
-const TrajectoryPatternHdl& tracker_trajectory::get_pattern_handle() const { return _pattern_; }
-
 TrajectoryPattern& tracker_trajectory::get_pattern() { return *_pattern_; }
 
 const TrajectoryPattern& tracker_trajectory::get_pattern() const { return *_pattern_; }
-
-void tracker_trajectory::reset() { this->clear(); }
 
 void tracker_trajectory::clear() {
   detach_pattern();
@@ -78,15 +64,15 @@ void tracker_trajectory::tree_dump(std::ostream& out_, const std::string& title_
   out_ << std::endl;
 
   out_ << indent_ << datatools::i_tree_dumpable::tag << "Pattern : ";
-  if (!has_pattern()) {
-    out_ << "<none>";
-  } else {
+  if (has_pattern()) {
     out_ << "'" << _pattern_->get_pattern_id() << "'";
+  } else {
+    out_ << "<none>";
   }
   out_ << std::endl;
 
   out_ << indent_ << datatools::i_tree_dumpable::inherit_tag(inherit_)
-       << "Trajectory ID  : " << get_trajectory_id() << std::endl;
+       << "Trajectory ID  : " << get_id() << std::endl;
 }
 
 }  // end of namespace datamodel

--- a/source/falaise/snemo/datamodels/tracker_trajectory.cc
+++ b/source/falaise/snemo/datamodels/tracker_trajectory.cc
@@ -18,27 +18,21 @@ bool tracker_trajectory::has_trajectory_id() const { return has_hit_id(); }
 
 int tracker_trajectory::get_trajectory_id() const { return get_hit_id(); }
 
-void tracker_trajectory::set_trajectory_id(int trajectory_id_) {
-  set_hit_id(trajectory_id_);
-}
+void tracker_trajectory::set_trajectory_id(int trajectory_id_) { set_hit_id(trajectory_id_); }
 
-void tracker_trajectory::invalidate_trajectory_id() {
-  invalidate_hit_id();
-}
+void tracker_trajectory::invalidate_trajectory_id() { invalidate_hit_id(); }
 
 bool tracker_trajectory::has_cluster() const { return _cluster_.has_data(); }
 
-void tracker_trajectory::detach_cluster() {
-  _cluster_.reset();
-}
+void tracker_trajectory::detach_cluster() { _cluster_.reset(); }
 
-tracker_trajectory::handle_cluster& tracker_trajectory::get_cluster_handle() { return _cluster_; }
+TrackerClusterHdl& tracker_trajectory::get_cluster_handle() { return _cluster_; }
 
-const tracker_trajectory::handle_cluster& tracker_trajectory::get_cluster_handle() const {
+const TrackerClusterHdl& tracker_trajectory::get_cluster_handle() const {
   return _cluster_;
 }
 
-void tracker_trajectory::set_cluster_handle(const handle_cluster& cluster_handle_) {
+void tracker_trajectory::set_cluster_handle(const TrackerClusterHdl& cluster_handle_) {
   _cluster_ = cluster_handle_;
 }
 
@@ -48,27 +42,21 @@ const tracker_cluster& tracker_trajectory::get_cluster() const { return *_cluste
 
 bool tracker_trajectory::has_pattern() const { return _pattern_.has_data(); }
 
-void tracker_trajectory::set_pattern_handle(const handle_pattern& pattern_handle_) {
+void tracker_trajectory::set_pattern_handle(const TrajectoryPatternHdl& pattern_handle_) {
   _pattern_ = pattern_handle_;
 }
 
-void tracker_trajectory::detach_pattern() {
-  _pattern_.reset();
-}
+void tracker_trajectory::detach_pattern() { _pattern_.reset(); }
 
-tracker_trajectory::handle_pattern& tracker_trajectory::get_pattern_handle() { return _pattern_; }
+TrajectoryPatternHdl& tracker_trajectory::get_pattern_handle() { return _pattern_; }
 
-const tracker_trajectory::handle_pattern& tracker_trajectory::get_pattern_handle() const {
-  return _pattern_;
-}
+const TrajectoryPatternHdl& tracker_trajectory::get_pattern_handle() const { return _pattern_; }
 
-base_trajectory_pattern& tracker_trajectory::get_pattern() { return *_pattern_; }
+TrajectoryPattern& tracker_trajectory::get_pattern() { return *_pattern_; }
 
-const base_trajectory_pattern& tracker_trajectory::get_pattern() const { return *_pattern_; }
+const TrajectoryPattern& tracker_trajectory::get_pattern() const { return *_pattern_; }
 
-void tracker_trajectory::reset() {
-  this->clear();
-}
+void tracker_trajectory::reset() { this->clear(); }
 
 void tracker_trajectory::clear() {
   detach_pattern();
@@ -99,7 +87,6 @@ void tracker_trajectory::tree_dump(std::ostream& out_, const std::string& title_
 
   out_ << indent_ << datatools::i_tree_dumpable::inherit_tag(inherit_)
        << "Trajectory ID  : " << get_trajectory_id() << std::endl;
-
 }
 
 }  // end of namespace datamodel

--- a/source/falaise/snemo/datamodels/tracker_trajectory.h
+++ b/source/falaise/snemo/datamodels/tracker_trajectory.h
@@ -28,21 +28,6 @@ namespace datamodel {
 /// A trajectory of Geiger calibrated hits referenced by handles
 class tracker_trajectory : public geomtools::base_hit {
  public:
-  /// Handle on tracker trajectory
-  typedef datatools::handle<tracker_trajectory> handle_type;
-
-  /// Handle on tracker cluster
-  typedef tracker_cluster::handle_type handle_cluster;
-
-  /// Collection of handles on tracker clusters
-  typedef std::vector<handle_cluster> clusters_collection_type;
-
-  /// Handle on trajectory pattern
-  typedef datatools::handle<base_trajectory_pattern> handle_pattern;
-
-  /// Collection of handles of calibrated tracker hit
-  typedef calibrated_tracker_hit::collection_type orphans_collection_type;
-
   /// Check if there is a valid trajectory ID
   bool has_trajectory_id() const;
 
@@ -62,13 +47,13 @@ class tracker_trajectory : public geomtools::base_hit {
   void detach_cluster();
 
   /// Attach a cluster by handle
-  void set_cluster_handle(const handle_cluster& cluster_handle_);
+  void set_cluster_handle(const TrackerClusterHdl& cluster_handle_);
 
   /// Return a mutable reference on the cluster handle
-  handle_cluster& get_cluster_handle();
+  TrackerClusterHdl& get_cluster_handle();
 
   /// Return a non mutable reference on the cluster handle
-  const handle_cluster& get_cluster_handle() const;
+  const TrackerClusterHdl& get_cluster_handle() const;
 
   /// Return a mutable reference on the cluster
   tracker_cluster& get_cluster();
@@ -83,19 +68,19 @@ class tracker_trajectory : public geomtools::base_hit {
   void detach_pattern();
 
   /// Attach a pattern by handle
-  void set_pattern_handle(const handle_pattern& pattern_handle_);
+  void set_pattern_handle(const TrajectoryPatternHdl& pattern_handle_);
 
   /// Return a mutable reference on the pattern handle
-  handle_pattern& get_pattern_handle();
+  TrajectoryPatternHdl& get_pattern_handle();
 
   /// Return a non mutable reference on the pattern handle
-  const handle_pattern& get_pattern_handle() const;
+  const TrajectoryPatternHdl& get_pattern_handle() const;
 
   /// Return a mutable reference on the pattern
-  base_trajectory_pattern& get_pattern();
+  TrajectoryPattern& get_pattern();
 
   /// Return a non mutable reference on the pattern
-  const base_trajectory_pattern& get_pattern() const;
+  const TrajectoryPattern& get_pattern() const;
 
   /// Reset the tracker trajectory (see clear)
   void reset();
@@ -108,12 +93,23 @@ class tracker_trajectory : public geomtools::base_hit {
                          const std::string& indent_ = "", bool inherit_ = false) const;
 
  private:
-  handle_cluster _cluster_;           ///< Handle to the fitted cluster
-  orphans_collection_type _orphans_;  ///< Collection of orphan Geiger hit handles (retained only for serialization back-compatibility)
-  handle_pattern _pattern_;           ///< Handle to a trajectory fitted pattern
+  /// Collection of handles of calibrated tracker hit
+  typedef TrackerHitHdlCollection orphans_collection_type;
+
+  TrackerClusterHdl _cluster_;        ///< Handle to the fitted cluster
+  orphans_collection_type _orphans_;  ///< Collection of orphan Geiger hit handles (retained only
+                                      ///< for serialization back-compatibility)
+  TrajectoryPatternHdl _pattern_;     ///< Handle to a trajectory fitted pattern
 
   DATATOOLS_SERIALIZATION_DECLARATION()
 };
+
+/// Handle on tracker trajectory
+using TrackerTrajectory = tracker_trajectory;
+using TrackerTrajectoryCollection = std::vector<TrackerTrajectory>;
+
+using TrackerTrajectoryHdl = datatools::handle<TrackerTrajectory>;
+using TrackerTrajectoryHdlCollection = std::vector<TrackerTrajectoryHdl>;
 
 }  // end of namespace datamodel
 

--- a/source/falaise/snemo/datamodels/tracker_trajectory.h
+++ b/source/falaise/snemo/datamodels/tracker_trajectory.h
@@ -65,8 +65,8 @@ class tracker_trajectory : public geomtools::base_hit {
   virtual void clear();
 
   /// Smart print
-  virtual void tree_dump(std::ostream& out = std::clog, const std::string& title_ = "",
-                         const std::string& indent_ = "", bool inherit_ = false) const;
+  virtual void tree_dump(std::ostream& out = std::clog, const std::string& title = "",
+                         const std::string& indent = "", bool is_last = false) const;
 
  private:
   /// Detach the cluster
@@ -74,12 +74,12 @@ class tracker_trajectory : public geomtools::base_hit {
   /// Detach the pattern
   void detach_pattern();
 
-  TrackerClusterHdl _cluster_;     ///< Handle to the fitted cluster
-  TrajectoryPatternHdl _pattern_;  ///< Handle to a trajectory fitted pattern
+  TrackerClusterHdl cluster_;     ///< Handle to the fitted cluster
+  TrajectoryPatternHdl pattern_;  ///< Handle to a trajectory fitted pattern
 
   /// Collection of handles of calibrated tracker hit
   typedef TrackerHitHdlCollection orphans_collection_type;
-  orphans_collection_type _orphans_;  ///< Collection of orphan Geiger hit handles (retained only
+  orphans_collection_type orphans_;  ///< Collection of orphan Geiger hit handles (retained only
                                       ///< for serialization back-compatibility)
 
   DATATOOLS_SERIALIZATION_DECLARATION()

--- a/source/falaise/snemo/datamodels/tracker_trajectory.h
+++ b/source/falaise/snemo/datamodels/tracker_trajectory.h
@@ -29,31 +29,19 @@ namespace datamodel {
 class tracker_trajectory : public geomtools::base_hit {
  public:
   /// Check if there is a valid trajectory ID
-  bool has_trajectory_id() const;
+  bool has_id() const;
 
   /// Get the trajectory ID
-  int get_trajectory_id() const;
+  int get_id() const;
 
   /// Set the trajectory ID
-  void set_trajectory_id(int32_t);
-
-  /// Invalidate the trajectory ID
-  void invalidate_trajectory_id();
+  void set_id(int32_t);
 
   /// Check if the cluster is present
   bool has_cluster() const;
 
-  /// Detach the cluster
-  void detach_cluster();
-
   /// Attach a cluster by handle
-  void set_cluster_handle(const TrackerClusterHdl& cluster_handle_);
-
-  /// Return a mutable reference on the cluster handle
-  TrackerClusterHdl& get_cluster_handle();
-
-  /// Return a non mutable reference on the cluster handle
-  const TrackerClusterHdl& get_cluster_handle() const;
+  void set_cluster_handle(const TrackerClusterHdl& cluster);
 
   /// Return a mutable reference on the cluster
   tracker_cluster& get_cluster();
@@ -64,26 +52,14 @@ class tracker_trajectory : public geomtools::base_hit {
   /// Check if the pattern is present
   bool has_pattern() const;
 
-  /// Detach the pattern
-  void detach_pattern();
-
   /// Attach a pattern by handle
-  void set_pattern_handle(const TrajectoryPatternHdl& pattern_handle_);
-
-  /// Return a mutable reference on the pattern handle
-  TrajectoryPatternHdl& get_pattern_handle();
-
-  /// Return a non mutable reference on the pattern handle
-  const TrajectoryPatternHdl& get_pattern_handle() const;
+  void set_pattern_handle(const TrajectoryPatternHdl& pattern);
 
   /// Return a mutable reference on the pattern
   TrajectoryPattern& get_pattern();
 
   /// Return a non mutable reference on the pattern
   const TrajectoryPattern& get_pattern() const;
-
-  /// Reset the tracker trajectory (see clear)
-  void reset();
 
   /// Empty the contents of the tracker trajectory
   virtual void clear();
@@ -93,13 +69,18 @@ class tracker_trajectory : public geomtools::base_hit {
                          const std::string& indent_ = "", bool inherit_ = false) const;
 
  private:
+  /// Detach the cluster
+  void detach_cluster();
+  /// Detach the pattern
+  void detach_pattern();
+
+  TrackerClusterHdl _cluster_;     ///< Handle to the fitted cluster
+  TrajectoryPatternHdl _pattern_;  ///< Handle to a trajectory fitted pattern
+
   /// Collection of handles of calibrated tracker hit
   typedef TrackerHitHdlCollection orphans_collection_type;
-
-  TrackerClusterHdl _cluster_;        ///< Handle to the fitted cluster
   orphans_collection_type _orphans_;  ///< Collection of orphan Geiger hit handles (retained only
                                       ///< for serialization back-compatibility)
-  TrajectoryPatternHdl _pattern_;     ///< Handle to a trajectory fitted pattern
 
   DATATOOLS_SERIALIZATION_DECLARATION()
 };

--- a/source/falaise/snemo/datamodels/tracker_trajectory_data.cc
+++ b/source/falaise/snemo/datamodels/tracker_trajectory_data.cc
@@ -12,16 +12,15 @@ bool tracker_trajectory_data::has_solutions() const { return get_number_of_solut
 
 size_t tracker_trajectory_data::get_number_of_solutions() const { return _solutions_.size(); }
 
-
 const tracker_trajectory_solution& tracker_trajectory_data::get_solution(size_t index) const {
   return _solutions_.at(index).get();
 }
 
-void tracker_trajectory_data::add_solution(
-    const tracker_trajectory_solution::handle_type& solution_handle_, bool default_solution_) {
+void tracker_trajectory_data::add_solution(const TrackerTrajectorySolutionHdl& solution_handle_,
+                                           bool default_solution_) {
   DT_THROW_IF(!solution_handle_, std::logic_error, "Cannot store a null handle !");
 
-  for(const auto& addr : _solutions_) {
+  for (const auto& addr : _solutions_) {
     DT_THROW_IF(&*addr == &*solution_handle_, std::logic_error,
                 "Duplicated solutions is not allowed!");
   }
@@ -31,9 +30,7 @@ void tracker_trajectory_data::add_solution(
   }
 }
 
-void tracker_trajectory_data::invalidate_solutions() {
-  _solutions_.clear();
-}
+void tracker_trajectory_data::invalidate_solutions() { _solutions_.clear(); }
 
 bool tracker_trajectory_data::has_default_solution() const { return _default_solution_.has_data(); }
 
@@ -47,21 +44,17 @@ void tracker_trajectory_data::set_default_solution(size_t index) {
   _default_solution_ = _solutions_.at(index);
 }
 
-void tracker_trajectory_data::invalidate_default_solution() {
-  _default_solution_.reset();
-}
+void tracker_trajectory_data::invalidate_default_solution() { _default_solution_.reset(); }
 
-tracker_trajectory_data::solution_col_type& tracker_trajectory_data::get_solutions() {
+TrackerTrajectorySolutionHdlCollection& tracker_trajectory_data::get_solutions() {
   return _solutions_;
 }
 
-const tracker_trajectory_data::solution_col_type& tracker_trajectory_data::get_solutions() const {
+const TrackerTrajectorySolutionHdlCollection& tracker_trajectory_data::get_solutions() const {
   return _solutions_;
 }
 
-void tracker_trajectory_data::reset() {
-  this->clear();
-}
+void tracker_trajectory_data::reset() { this->clear(); }
 
 void tracker_trajectory_data::clear() {
   invalidate_solutions();

--- a/source/falaise/snemo/datamodels/tracker_trajectory_data.cc
+++ b/source/falaise/snemo/datamodels/tracker_trajectory_data.cc
@@ -10,48 +10,47 @@ namespace datamodel {
 
 bool tracker_trajectory_data::has_solutions() const { return get_number_of_solutions() > 0; }
 
-size_t tracker_trajectory_data::get_number_of_solutions() const { return _solutions_.size(); }
+size_t tracker_trajectory_data::get_number_of_solutions() const { return solutions_.size(); }
 
 const tracker_trajectory_solution& tracker_trajectory_data::get_solution(size_t index) const {
-  return _solutions_.at(index).get();
+  return solutions_.at(index).get();
 }
 
-void tracker_trajectory_data::add_solution(const TrackerTrajectorySolutionHdl& solution_handle_,
-                                           bool default_solution_) {
-  DT_THROW_IF(!solution_handle_, std::logic_error, "Cannot store a null handle !");
+void tracker_trajectory_data::add_solution(const TrackerTrajectorySolutionHdl& solution,
+                                           bool is_default) {
+  DT_THROW_IF(!solution, std::logic_error, "Cannot store a null handle !");
 
-  for (const auto& addr : _solutions_) {
-    DT_THROW_IF(&*addr == &*solution_handle_, std::logic_error,
-                "Duplicated solutions is not allowed!");
+  for (const auto& addr : solutions_) {
+    DT_THROW_IF(&*addr == &*solution, std::logic_error, "Duplicated solutions are not allowed!");
   }
-  _solutions_.push_back(solution_handle_);
-  if (default_solution_ || _solutions_.size() == 1) {
-    _default_solution_ = solution_handle_;
+  solutions_.push_back(solution);
+  if (is_default || solutions_.size() == 1) {
+    default_ = solution;
   }
 }
 
-void tracker_trajectory_data::invalidate_solutions() { _solutions_.clear(); }
+void tracker_trajectory_data::invalidate_solutions() { solutions_.clear(); }
 
-bool tracker_trajectory_data::has_default_solution() const { return _default_solution_.has_data(); }
+bool tracker_trajectory_data::has_default_solution() const { return default_.has_data(); }
 
 const tracker_trajectory_solution& tracker_trajectory_data::get_default_solution() const {
-  DT_THROW_IF(!has_default_solution(), std::logic_error, "No default solution is available !");
-  return *_default_solution_;
+  DT_THROW_IF(!has_default_solution(), std::logic_error, "No default solution available");
+  return *default_;
 }
 
 /// Set the default trajectory solution
 void tracker_trajectory_data::set_default_solution(size_t index) {
-  _default_solution_ = _solutions_.at(index);
+  default_ = solutions_.at(index);
 }
 
-void tracker_trajectory_data::invalidate_default_solution() { _default_solution_.reset(); }
+void tracker_trajectory_data::invalidate_default_solution() { default_.reset(); }
 
 TrackerTrajectorySolutionHdlCollection& tracker_trajectory_data::get_solutions() {
-  return _solutions_;
+  return solutions_;
 }
 
 const TrackerTrajectorySolutionHdlCollection& tracker_trajectory_data::get_solutions() const {
-  return _solutions_;
+  return solutions_;
 }
 
 void tracker_trajectory_data::reset() { this->clear(); }
@@ -62,34 +61,22 @@ void tracker_trajectory_data::clear() {
   _auxiliaries_.clear();
 }
 
-void tracker_trajectory_data::tree_dump(std::ostream& out_, const std::string& title_,
-                                        const std::string& indent_, bool inherit_) const {
-  if (!title_.empty()) {
-    out_ << indent_ << title_ << std::endl;
+void tracker_trajectory_data::tree_dump(std::ostream& out, const std::string& title,
+                                        const std::string& indent, bool is_last) const {
+  if (!title.empty()) {
+    out << indent << title << std::endl;
   }
 
-  out_ << indent_ << datatools::i_tree_dumpable::tag << "Solutions : " << _solutions_.size()
-       << std::endl;
+  out << indent << datatools::i_tree_dumpable::tag << "Solutions : " << solutions_.size()
+      << std::endl;
 
-  out_ << indent_ << datatools::i_tree_dumpable::tag
-       << "Default solution : " << (_default_solution_ ? "Yes" : "No") << std::endl;
-  if (_default_solution_) {
+  out << indent << datatools::i_tree_dumpable::inherit_tag(is_last)
+      << "Default solution : " << (default_ ? "" : "none") << std::endl;
+  if (default_) {
     std::ostringstream indent_oss;
-    indent_oss << indent_;
-    indent_oss << datatools::i_tree_dumpable::skip_tag;
-    _default_solution_.get().tree_dump(out_, "", indent_oss.str());
-  }
-
-  out_ << indent_ << datatools::i_tree_dumpable::inherit_tag(inherit_) << "Auxiliaries : ";
-  if (_auxiliaries_.empty()) {
-    out_ << "<empty>";
-  }
-  out_ << std::endl;
-  {
-    std::ostringstream indent_oss;
-    indent_oss << indent_;
-    indent_oss << datatools::i_tree_dumpable::inherit_skip_tag(inherit_);
-    _auxiliaries_.tree_dump(out_, "", indent_oss.str());
+    indent_oss << indent;
+    indent_oss << datatools::i_tree_dumpable::inherit_skip_tag(is_last);
+    default_->tree_dump(out, "", indent_oss.str());
   }
 }
 

--- a/source/falaise/snemo/datamodels/tracker_trajectory_data.h
+++ b/source/falaise/snemo/datamodels/tracker_trajectory_data.h
@@ -33,9 +33,6 @@ class tracker_trajectory_data : public datatools::i_serializable,
                                 public datatools::i_tree_dumpable,
                                 public datatools::i_clear {
  public:
-  /// Collection of handles on tracker trajectory solutions
-  typedef std::vector<tracker_trajectory_solution::handle_type> solution_col_type;
-
   /// Check if there are some trajectory solutions
   bool has_solutions() const;
 
@@ -43,8 +40,7 @@ class tracker_trajectory_data : public datatools::i_serializable,
   size_t get_number_of_solutions() const;
 
   /// Add a trajectory solution
-  void add_solution(const tracker_trajectory_solution::handle_type& handle_,
-                    bool default_solution_ = false);
+  void add_solution(const TrackerTrajectorySolutionHdl& handle_, bool default_solution_ = false);
 
   /// Return a non mutable reference to a trajectory solution by index
   const tracker_trajectory_solution& get_solution(size_t index) const;
@@ -55,9 +51,9 @@ class tracker_trajectory_data : public datatools::i_serializable,
   /// Check if there is some default trajectory solution
   bool has_default_solution() const;
 
-  const tracker_trajectory_data::solution_col_type& get_solutions() const;
+  const TrackerTrajectorySolutionHdlCollection& get_solutions() const;
 
-  tracker_trajectory_data::solution_col_type& get_solutions();
+  TrackerTrajectorySolutionHdlCollection& get_solutions();
 
   /// Return a non mutable reference to the default trajectory solution is any
   const tracker_trajectory_solution& get_default_solution() const;
@@ -79,10 +75,12 @@ class tracker_trajectory_data : public datatools::i_serializable,
                          const std::string& indent_ = "", bool inherit_ = false) const;
 
  private:
-  solution_col_type _solutions_;  //!< Collection of tracker trajectory solution handles
-  tracker_trajectory_solution::handle_type
-      _default_solution_;               //!< Handle to the default/best solution
-  datatools::properties _auxiliaries_;  //!< Auxiliary properties (retained for back compatibility with serialization)
+  TrackerTrajectorySolutionHdlCollection
+      _solutions_;  //!< Collection of tracker trajectory solution handles
+  TrackerTrajectorySolutionHdl _default_solution_;  //!< Handle to the default/best solution
+
+  datatools::properties
+      _auxiliaries_;  //!< Auxiliary properties (retained for back compatibility with serialization)
 
   DATATOOLS_SERIALIZATION_DECLARATION()
 

--- a/source/falaise/snemo/datamodels/tracker_trajectory_data.h
+++ b/source/falaise/snemo/datamodels/tracker_trajectory_data.h
@@ -79,8 +79,7 @@ class tracker_trajectory_data : public datatools::i_serializable,
       solutions_;                         //!< Collection of tracker trajectory solutions
   TrackerTrajectorySolutionHdl default_;  //!< The default/best solution
 
-  datatools::properties
-      _auxiliaries_;  //!< Auxiliary properties (retained for back compatibility with serialization)
+  datatools::properties _auxiliaries_;  // unused, retained for serialization backward compatibility
 
   DATATOOLS_SERIALIZATION_DECLARATION()
 

--- a/source/falaise/snemo/datamodels/tracker_trajectory_data.h
+++ b/source/falaise/snemo/datamodels/tracker_trajectory_data.h
@@ -40,7 +40,7 @@ class tracker_trajectory_data : public datatools::i_serializable,
   size_t get_number_of_solutions() const;
 
   /// Add a trajectory solution
-  void add_solution(const TrackerTrajectorySolutionHdl& handle_, bool default_solution_ = false);
+  void add_solution(const TrackerTrajectorySolutionHdl& solution, bool is_default = false);
 
   /// Return a non mutable reference to a trajectory solution by index
   const tracker_trajectory_solution& get_solution(size_t index) const;

--- a/source/falaise/snemo/datamodels/tracker_trajectory_data.h
+++ b/source/falaise/snemo/datamodels/tracker_trajectory_data.h
@@ -71,13 +71,13 @@ class tracker_trajectory_data : public datatools::i_serializable,
   virtual void clear();
 
   /// Smart print
-  virtual void tree_dump(std::ostream& out_ = std::clog, const std::string& title_ = "",
-                         const std::string& indent_ = "", bool inherit_ = false) const;
+  virtual void tree_dump(std::ostream& out = std::clog, const std::string& title = "",
+                         const std::string& indent = "", bool is_last = false) const;
 
  private:
   TrackerTrajectorySolutionHdlCollection
-      _solutions_;  //!< Collection of tracker trajectory solution handles
-  TrackerTrajectorySolutionHdl _default_solution_;  //!< Handle to the default/best solution
+      solutions_;                         //!< Collection of tracker trajectory solutions
+  TrackerTrajectorySolutionHdl default_;  //!< The default/best solution
 
   datatools::properties
       _auxiliaries_;  //!< Auxiliary properties (retained for back compatibility with serialization)

--- a/source/falaise/snemo/datamodels/tracker_trajectory_solution.cc
+++ b/source/falaise/snemo/datamodels/tracker_trajectory_solution.cc
@@ -19,56 +19,51 @@ namespace datamodel {
 DATATOOLS_SERIALIZATION_SERIAL_TAG_IMPLEMENTATION(tracker_trajectory_solution,
                                                   "snemo::datamodel::tracker_trajectory_solution")
 
-bool tracker_trajectory_solution::has_solution_id() const { return _solution_id_ >= 0; }
+bool tracker_trajectory_solution::has_solution_id() const { return id_ >= 0; }
 
-int tracker_trajectory_solution::get_solution_id() const { return _solution_id_; }
+int tracker_trajectory_solution::get_solution_id() const { return id_; }
 
-void tracker_trajectory_solution::set_solution_id(int32_t solution_id_) {
-  if (solution_id_ >= 0) {
-    _solution_id_ = solution_id_;
+void tracker_trajectory_solution::set_solution_id(int32_t id) {
+  if (id >= 0) {
+    id_ = id;
   } else {
     invalidate_solution_id();
   }
 }
 
-void tracker_trajectory_solution::invalidate_solution_id() { _solution_id_ = -1; }
+void tracker_trajectory_solution::invalidate_solution_id() { id_ = -1; }
 
 /*** Reference clustering solution ***/
 
 tracker_clustering_solution& tracker_trajectory_solution::grab_clustering_solution() {
-  return _clustering_solution_.grab();
+  return solutions_.grab();
 }
 
-void tracker_trajectory_solution::set_clustering_solution(
-    const TrackerClusteringSolutionHdl& clustering_solution_) {
-  _clustering_solution_ = clustering_solution_;
+void tracker_trajectory_solution::set_clustering_solution(const TrackerClusteringSolutionHdl& s) {
+  solutions_ = s;
 }
 
 const tracker_clustering_solution& tracker_trajectory_solution::get_clustering_solution() const {
-  return _clustering_solution_.get();
+  return solutions_.get();
 }
 
-bool tracker_trajectory_solution::has_clustering_solution() const {
-  return _clustering_solution_.has_data();
-}
+bool tracker_trajectory_solution::has_clustering_solution() const { return solutions_.has_data(); }
 
-void tracker_trajectory_solution::invalidate_clustering_solution() {
-  _clustering_solution_.reset();
-}
+void tracker_trajectory_solution::invalidate_clustering_solution() { solutions_.reset(); }
 
 bool tracker_trajectory_solution::has_unfitted_clusters() const {
-  return !_unfitted_clusters_.empty();
+  return !unfitted_.empty();
 }
 
 TrackerClusterHdlCollection& tracker_trajectory_solution::grab_unfitted_clusters() {
-  return _unfitted_clusters_;
+  return unfitted_;
 }
 
 const TrackerClusterHdlCollection& tracker_trajectory_solution::get_unfitted_clusters() const {
-  return _unfitted_clusters_;
+  return unfitted_;
 }
 
-void tracker_trajectory_solution::invalidate_unfitted_clusters() { _unfitted_clusters_.clear(); }
+void tracker_trajectory_solution::invalidate_unfitted_clusters() { unfitted_.clear(); }
 
 datatools::properties& tracker_trajectory_solution::get_auxiliaries() { return _auxiliaries_; }
 
@@ -76,17 +71,17 @@ const datatools::properties& tracker_trajectory_solution::get_auxiliaries() cons
   return _auxiliaries_;
 }
 
-bool tracker_trajectory_solution::has_trajectories() const { return !_trajectories_.empty(); }
+bool tracker_trajectory_solution::has_trajectories() const { return !trajectories_.empty(); }
 
 TrackerTrajectoryHdlCollection& tracker_trajectory_solution::grab_trajectories() {
-  return _trajectories_;
+  return trajectories_;
 }
 
 const TrackerTrajectoryHdlCollection& tracker_trajectory_solution::get_trajectories() const {
-  return _trajectories_;
+  return trajectories_;
 }
 
-void tracker_trajectory_solution::invalidate_trajectories() { _trajectories_.clear(); }
+void tracker_trajectory_solution::invalidate_trajectories() { trajectories_.clear(); }
 
 void tracker_trajectory_solution::reset() { this->clear(); }
 
@@ -98,57 +93,68 @@ void tracker_trajectory_solution::clear() {
   _auxiliaries_.clear();
 }
 
-void tracker_trajectory_solution::tree_dump(std::ostream& out_, const std::string& title_,
-                                            const std::string& indent_, bool inherit_) const {
-  if (!title_.empty()) {
-    out_ << indent_ << title_ << std::endl;
+void tracker_trajectory_solution::tree_dump(std::ostream& out, const std::string& title,
+                                            const std::string& indent, bool is_last) const {
+  if (!title.empty()) {
+    out << indent << title << std::endl;
   }
 
-  out_ << indent_ << datatools::i_tree_dumpable::tag << "Solution ID  : " << _solution_id_
-       << std::endl;
+  // make_tag
+  // make_skip_tag
+  // make_last_tag
+  // make_last_skip_tag
+  // make_inherit_tag
+  // make_inherit_skip_tag
+  std::string tag = indent + datatools::i_tree_dumpable::tags::item();
+  std::string skip_tag = indent + datatools::i_tree_dumpable::tags::skip_item();
+  std::string last_tag = indent + datatools::i_tree_dumpable::tags::last_item();
+  std::string last_skip_tag = indent + datatools::i_tree_dumpable::tags::last_skip_item();
+  // Last two are functions of indent and is_last;
 
-  out_ << indent_ << datatools::i_tree_dumpable::tag << "Reference clustering solution : ";
+  out << indent << datatools::i_tree_dumpable::tag << "Solution ID  : " << id_ << std::endl;
+
+  out << indent << datatools::i_tree_dumpable::tag << "Reference clustering solution : ";
   if (has_clustering_solution()) {
-    out_ << _clustering_solution_->get_solution_id();
+    out << solutions_->get_solution_id();
   } else {
-    out_ << "<none>";
+    out << "<none>";
   }
-  out_ << std::endl;
+  out << std::endl;
 
-  out_ << indent_ << datatools::i_tree_dumpable::tag << "Trajectories : " << _trajectories_.size()
+  out << indent << datatools::i_tree_dumpable::tag << "Trajectories : " << trajectories_.size()
        << std::endl;
-  for (size_t i = 0; i < _trajectories_.size(); i++) {
-    const datatools::handle<tracker_trajectory>& htraj = _trajectories_.at(i);
+  for (size_t i = 0; i < trajectories_.size(); i++) {
+    const datatools::handle<tracker_trajectory>& htraj = trajectories_.at(i);
     const tracker_trajectory& traj = htraj.get();
-    out_ << indent_ << datatools::i_tree_dumpable::skip_tag;
+    out << indent << datatools::i_tree_dumpable::skip_tag;
     std::ostringstream indent2_oss;
-    indent2_oss << indent_ << datatools::i_tree_dumpable::skip_tag;
+    indent2_oss << indent << datatools::i_tree_dumpable::skip_tag;
     size_t j = i;
     j++;
-    if (j == _trajectories_.size()) {
-      out_ << datatools::i_tree_dumpable::last_tag;
+    if (j == trajectories_.size()) {
+      out << datatools::i_tree_dumpable::last_tag;
       indent2_oss << datatools::i_tree_dumpable::last_skip_tag;
     } else {
-      out_ << datatools::i_tree_dumpable::tag;
+      out << datatools::i_tree_dumpable::tag;
       indent2_oss << datatools::i_tree_dumpable::skip_tag;
     }
-    out_ << "Trajectory #" << i << " : " << std::endl;
-    traj.tree_dump(out_, "", indent2_oss.str());
+    out << "Trajectory #" << i << " : " << std::endl;
+    traj.tree_dump(out, "", indent2_oss.str());
   }
 
-  out_ << indent_ << datatools::i_tree_dumpable::tag
-       << "Unfitted clusters : " << _unfitted_clusters_.size() << std::endl;
+  out << indent << datatools::i_tree_dumpable::tag
+       << "Unfitted clusters : " << unfitted_.size() << std::endl;
 
-  out_ << indent_ << datatools::i_tree_dumpable::inherit_tag(inherit_) << "Auxiliaries : ";
+  out << indent << datatools::i_tree_dumpable::inherit_tag(is_last) << "Auxiliaries : ";
   if (_auxiliaries_.empty()) {
-    out_ << "<empty>";
+    out << "<empty>";
   }
-  out_ << std::endl;
+  out << std::endl;
   {
     std::ostringstream indent_oss;
-    indent_oss << indent_;
-    indent_oss << datatools::i_tree_dumpable::inherit_skip_tag(inherit_);
-    _auxiliaries_.tree_dump(out_, "", indent_oss.str());
+    indent_oss << indent;
+    indent_oss << datatools::i_tree_dumpable::inherit_skip_tag(is_last);
+    _auxiliaries_.tree_dump(out, "", indent_oss.str());
   }
 }
 

--- a/source/falaise/snemo/datamodels/tracker_trajectory_solution.cc
+++ b/source/falaise/snemo/datamodels/tracker_trajectory_solution.cc
@@ -31,9 +31,7 @@ void tracker_trajectory_solution::set_solution_id(int32_t solution_id_) {
   }
 }
 
-void tracker_trajectory_solution::invalidate_solution_id() {
-  _solution_id_ = -1;
-}
+void tracker_trajectory_solution::invalidate_solution_id() { _solution_id_ = -1; }
 
 /*** Reference clustering solution ***/
 
@@ -42,7 +40,7 @@ tracker_clustering_solution& tracker_trajectory_solution::grab_clustering_soluti
 }
 
 void tracker_trajectory_solution::set_clustering_solution(
-    const tracker_trajectory_solution::handle_clustering_solution_type& clustering_solution_) {
+    const TrackerClusteringSolutionHdl& clustering_solution_) {
   _clustering_solution_ = clustering_solution_;
 }
 
@@ -62,19 +60,15 @@ bool tracker_trajectory_solution::has_unfitted_clusters() const {
   return !_unfitted_clusters_.empty();
 }
 
-tracker_trajectory_solution::cluster_col_type&
-tracker_trajectory_solution::grab_unfitted_clusters() {
+TrackerClusterHdlCollection& tracker_trajectory_solution::grab_unfitted_clusters() {
   return _unfitted_clusters_;
 }
 
-const tracker_trajectory_solution::cluster_col_type&
-tracker_trajectory_solution::get_unfitted_clusters() const {
+const TrackerClusterHdlCollection& tracker_trajectory_solution::get_unfitted_clusters() const {
   return _unfitted_clusters_;
 }
 
-void tracker_trajectory_solution::invalidate_unfitted_clusters() {
-  _unfitted_clusters_.clear();
-}
+void tracker_trajectory_solution::invalidate_unfitted_clusters() { _unfitted_clusters_.clear(); }
 
 datatools::properties& tracker_trajectory_solution::get_auxiliaries() { return _auxiliaries_; }
 
@@ -84,22 +78,17 @@ const datatools::properties& tracker_trajectory_solution::get_auxiliaries() cons
 
 bool tracker_trajectory_solution::has_trajectories() const { return !_trajectories_.empty(); }
 
-tracker_trajectory_solution::trajectory_col_type& tracker_trajectory_solution::grab_trajectories() {
+TrackerTrajectoryHdlCollection& tracker_trajectory_solution::grab_trajectories() {
   return _trajectories_;
 }
 
-const tracker_trajectory_solution::trajectory_col_type&
-tracker_trajectory_solution::get_trajectories() const {
+const TrackerTrajectoryHdlCollection& tracker_trajectory_solution::get_trajectories() const {
   return _trajectories_;
 }
 
-void tracker_trajectory_solution::invalidate_trajectories() {
-  _trajectories_.clear();
-}
+void tracker_trajectory_solution::invalidate_trajectories() { _trajectories_.clear(); }
 
-void tracker_trajectory_solution::reset() {
-  this->clear();
-}
+void tracker_trajectory_solution::reset() { this->clear(); }
 
 void tracker_trajectory_solution::clear() {
   invalidate_solution_id();

--- a/source/falaise/snemo/datamodels/tracker_trajectory_solution.h
+++ b/source/falaise/snemo/datamodels/tracker_trajectory_solution.h
@@ -100,6 +100,9 @@ class tracker_trajectory_solution : public datatools::i_serializable,
                          const std::string& indent_ = "", bool inherit_ = false) const;
 
   /*** Auxiliaries ***/
+  // These are marked as deprecated to warn/fail compilation if they are used
+  // NOT removed because the EventBrowser uses them, and is very tightly coupled
+  // so cannot be removed just yet...
   /// Return a mutable reference on the container of auxiliary properties
   ///\deprecated properties should not be used in core data types
   datatools::properties& get_auxiliaries() __attribute__((deprecated));

--- a/source/falaise/snemo/datamodels/tracker_trajectory_solution.h
+++ b/source/falaise/snemo/datamodels/tracker_trajectory_solution.h
@@ -112,18 +112,17 @@ class tracker_trajectory_solution : public datatools::i_serializable,
   const datatools::properties& get_auxiliaries() const __attribute__((deprecated));
 
  private:
-  int32_t _solution_id_ = -1;                          //!< Unique solution ID
-  TrackerClusteringSolutionHdl _clustering_solution_;  //!< The reference clustering solution
-  TrackerTrajectoryHdlCollection
-      _trajectories_;  //!< Collection of handles on trajectories associated to clusters
-  TrackerClusterHdlCollection _unfitted_clusters_;  //!< Collection of handles on unfitted clusters
-  datatools::properties _auxiliaries_;              //!< List of auxiliary properties
+  int32_t id_ = -1;                              //!< Unique solution ID
+  TrackerClusteringSolutionHdl solutions_;       //!< The reference clustering solution
+  TrackerTrajectoryHdlCollection trajectories_;  //!< Trajectories associated to clusters
+  TrackerClusterHdlCollection unfitted_;         //!< Unfitted clusters
+  datatools::properties _auxiliaries_;           //!< List of auxiliary properties
 
   DATATOOLS_SERIALIZATION_DECLARATION()
 };
 
 /// Handle on tracker trajectory solution
-//typedef datatools::handle<tracker_trajectory_solution> handle_type;
+// typedef datatools::handle<tracker_trajectory_solution> handle_type;
 using TrackerTrajectorySolution = tracker_trajectory_solution;
 using TrackerTrajectorySolutionCollection = std::vector<TrackerTrajectorySolution>;
 

--- a/source/falaise/snemo/datamodels/tracker_trajectory_solution.h
+++ b/source/falaise/snemo/datamodels/tracker_trajectory_solution.h
@@ -57,7 +57,7 @@ class tracker_trajectory_solution : public datatools::i_serializable,
   bool has_clustering_solution() const;
 
   /// Set the reference clustering solution
-  void set_clustering_solution(const TrackerClusteringSolutionHdl& clustering_solution_);
+  void set_clustering_solution(const TrackerClusteringSolutionHdl& s);
 
   /// Reset the reference clustering solution
   void invalidate_clustering_solution();
@@ -96,8 +96,8 @@ class tracker_trajectory_solution : public datatools::i_serializable,
   virtual void clear();
 
   /// Smart print
-  virtual void tree_dump(std::ostream& out_ = std::clog, const std::string& title_ = "",
-                         const std::string& indent_ = "", bool inherit_ = false) const;
+  virtual void tree_dump(std::ostream& out = std::clog, const std::string& title = "",
+                         const std::string& indent = "", bool is_last = false) const;
 
   /*** Auxiliaries ***/
   // These are marked as deprecated to warn/fail compilation if they are used

--- a/source/falaise/snemo/datamodels/tracker_trajectory_solution.h
+++ b/source/falaise/snemo/datamodels/tracker_trajectory_solution.h
@@ -20,13 +20,13 @@
 #include <datatools/properties.h>
 
 // This project:
+#include <falaise/snemo/datamodels/tracker_clustering_solution.h>
 #include <falaise/snemo/datamodels/tracker_trajectory.h>
 
 namespace snemo {
 
 namespace datamodel {
 
-class tracker_clustering_solution;
 class tracker_cluster;
 
 /// \brief A collection of tracker clusters , solution of a trajectory algorithm
@@ -34,24 +34,6 @@ class tracker_trajectory_solution : public datatools::i_serializable,
                                     public datatools::i_tree_dumpable,
                                     public datatools::i_clear {
  public:
-  /// Handle on tracker cluster
-  typedef tracker_trajectory::handle_type trajectory_handle_type;
-
-  /// Collection of handles on tracker clusters
-  typedef std::vector<trajectory_handle_type> trajectory_col_type;
-
-  /// Handle on tracker cluster solution
-  typedef datatools::handle<tracker_clustering_solution> handle_clustering_solution_type;
-
-  /// Handle on tracker trajectory solution
-  typedef datatools::handle<tracker_trajectory_solution> handle_type;
-
-  /// Handle on tracker cluster
-  typedef datatools::handle<tracker_cluster> cluster_handle_type;
-
-  /// Collection of handles on tracker clusters
-  typedef std::vector<cluster_handle_type> cluster_col_type;
-
   /// Reset the tracker cluster solution
   void reset();
 
@@ -75,7 +57,7 @@ class tracker_trajectory_solution : public datatools::i_serializable,
   bool has_clustering_solution() const;
 
   /// Set the reference clustering solution
-  void set_clustering_solution(const handle_clustering_solution_type& clustering_solution_);
+  void set_clustering_solution(const TrackerClusteringSolutionHdl& clustering_solution_);
 
   /// Reset the reference clustering solution
   void invalidate_clustering_solution();
@@ -86,14 +68,14 @@ class tracker_trajectory_solution : public datatools::i_serializable,
   /// Return a non mutable reference on the reference clustering solution
   const tracker_clustering_solution& get_clustering_solution() const;
 
-   /// Check if there is trajectories
+  /// Check if there is trajectories
   bool has_trajectories() const;
 
   /// Return a mutable reference on the container of trajectories
-  trajectory_col_type& grab_trajectories();
+  TrackerTrajectoryHdlCollection& grab_trajectories();
 
   /// Return a non mutable reference on the container of trajectories
-  const trajectory_col_type& get_trajectories() const;
+  const TrackerTrajectoryHdlCollection& get_trajectories() const;
 
   /// Reset the trajectories
   void invalidate_trajectories();
@@ -102,10 +84,10 @@ class tracker_trajectory_solution : public datatools::i_serializable,
   bool has_unfitted_clusters() const;
 
   /// Return a mutable reference on the container of handles on unfitted clusters
-  cluster_col_type& grab_unfitted_clusters();
+  TrackerClusterHdlCollection& grab_unfitted_clusters();
 
   /// Return a non mutable reference on the container of handles on unfitted clusters
-  const cluster_col_type& get_unfitted_clusters() const;
+  const TrackerClusterHdlCollection& get_unfitted_clusters() const;
 
   /// Reset the unfitted clusters
   void invalidate_unfitted_clusters();
@@ -126,16 +108,24 @@ class tracker_trajectory_solution : public datatools::i_serializable,
   ///\deprecated properties should not be used in core data types
   const datatools::properties& get_auxiliaries() const __attribute__((deprecated));
 
-private:
-  int32_t _solution_id_ = -1;                                  //!< Unique solution ID
-  handle_clustering_solution_type _clustering_solution_;  //!< The reference clustering solution
-  trajectory_col_type
+ private:
+  int32_t _solution_id_ = -1;                          //!< Unique solution ID
+  TrackerClusteringSolutionHdl _clustering_solution_;  //!< The reference clustering solution
+  TrackerTrajectoryHdlCollection
       _trajectories_;  //!< Collection of handles on trajectories associated to clusters
-  cluster_col_type _unfitted_clusters_;  //!< Collection of handles on unfitted clusters
-  datatools::properties _auxiliaries_;   //!< List of auxiliary properties
+  TrackerClusterHdlCollection _unfitted_clusters_;  //!< Collection of handles on unfitted clusters
+  datatools::properties _auxiliaries_;              //!< List of auxiliary properties
 
   DATATOOLS_SERIALIZATION_DECLARATION()
 };
+
+/// Handle on tracker trajectory solution
+//typedef datatools::handle<tracker_trajectory_solution> handle_type;
+using TrackerTrajectorySolution = tracker_trajectory_solution;
+using TrackerTrajectorySolutionCollection = std::vector<TrackerTrajectorySolution>;
+
+using TrackerTrajectorySolutionHdl = datatools::handle<TrackerTrajectorySolution>;
+using TrackerTrajectorySolutionHdlCollection = std::vector<TrackerTrajectorySolutionHdl>;
 
 }  // end of namespace datamodel
 

--- a/source/falaise/snemo/processing/base_gamma_builder.cc
+++ b/source/falaise/snemo/processing/base_gamma_builder.cc
@@ -217,7 +217,6 @@ int base_gamma_builder::_post_process(const base_gamma_builder::hit_collection_t
   snemo::datamodel::ParticleHdlCollection gamma_particles =
       ptd_.getParticlesByCharge(snemo::datamodel::particle_track::NEUTRAL);
   if (gamma_particles.empty()) {
-    DT_LOG_DEBUG(get_logging_priority(), "No gamma particles have been found !");
     return 0;
   }
 
@@ -225,7 +224,6 @@ int base_gamma_builder::_post_process(const base_gamma_builder::hit_collection_t
       snemo::datamodel::particle_track::NEGATIVE | snemo::datamodel::particle_track::POSITIVE |
       snemo::datamodel::particle_track::UNDEFINED);
   if (charged_particles.empty()) {
-    DT_LOG_DEBUG(get_logging_priority(), "No charged particles have been found !");
     return 0;
   }
 
@@ -237,12 +235,16 @@ int base_gamma_builder::_post_process(const base_gamma_builder::hit_collection_t
 
     for (auto& a_gamma : gamma_particles) {
       snemo::datamodel::particle_track::vertex_collection_type the_vertices_2;
-      a_gamma->fetch_vertices(the_vertices_2,
-                              snemo::datamodel::particle_track::VERTEX_ON_MAIN_CALORIMETER |
-                                  snemo::datamodel::particle_track::VERTEX_ON_X_CALORIMETER |
-                                  snemo::datamodel::particle_track::VERTEX_ON_GAMMA_VETO);
+      for (const auto& vtx : a_gamma->get_vertices()) {
+        if (snemo::datamodel::vertex_matches(
+                vtx, snemo::datamodel::particle_track::VERTEX_ON_MAIN_CALORIMETER |
+                         snemo::datamodel::particle_track::VERTEX_ON_X_CALORIMETER |
+                         snemo::datamodel::particle_track::VERTEX_ON_GAMMA_VETO)) {
+          the_vertices_2.push_back(vtx);
+        }
+      }
+
       if (the_vertices_2.empty()) {
-        DT_LOG_DEBUG(get_logging_priority(), "Gamma track has no vertices associated !");
         continue;
       }
 
@@ -280,8 +282,12 @@ int base_gamma_builder::_post_process(const base_gamma_builder::hit_collection_t
           const double particle_track_length = a_shape.get_length();
 
           snemo::datamodel::particle_track::vertex_collection_type vertices;
-          a_particle->fetch_vertices(vertices,
-                                     snemo::datamodel::particle_track::VERTEX_ON_SOURCE_FOIL);
+          for(const auto& vtx : a_particle->get_vertices()) {
+            if(snemo::datamodel::vertex_matches(vtx, snemo::datamodel::particle_track::VERTEX_ON_SOURCE_FOIL)) {
+              vertices.push_back(vtx);
+            }
+          }
+
           if (vertices.empty()) {
             continue;
           }

--- a/source/falaise/snemo/processing/base_gamma_builder.cc
+++ b/source/falaise/snemo/processing/base_gamma_builder.cc
@@ -215,12 +215,12 @@ int base_gamma_builder::_post_process(const base_gamma_builder::hit_collection_t
 
   // Given charged particle then process gammas
   snemo::datamodel::ParticleHdlCollection gamma_particles =
-      ptd_.getParticlesByCharge(snemo::datamodel::particle_track::NEUTRAL);
+      get_particles_by_charge(ptd_, snemo::datamodel::particle_track::NEUTRAL);
   if (gamma_particles.empty()) {
     return 0;
   }
 
-  snemo::datamodel::ParticleHdlCollection charged_particles = ptd_.getParticlesByCharge(
+  snemo::datamodel::ParticleHdlCollection charged_particles = get_particles_by_charge(ptd_,
       snemo::datamodel::particle_track::NEGATIVE | snemo::datamodel::particle_track::POSITIVE |
       snemo::datamodel::particle_track::UNDEFINED);
   if (charged_particles.empty()) {

--- a/source/falaise/snemo/processing/base_gamma_builder.cc
+++ b/source/falaise/snemo/processing/base_gamma_builder.cc
@@ -292,7 +292,7 @@ int base_gamma_builder::_post_process(const base_gamma_builder::hit_collection_t
           const double gamma_time_th = gamma_track_length / CLHEP::c_light;
 
           // Assume particle are electron/positron
-          const snemo::datamodel::calibrated_calorimeter_hit::collection_type& the_calorimeters =
+          const snemo::datamodel::CalorimeterHitHdlCollection& the_calorimeters =
               a_particle->get_associated_calorimeter_hits();
           // Only take care of the first associated calorimeter
           const auto& a_calo_hit = the_calorimeters.front();
@@ -366,7 +366,7 @@ int base_gamma_builder::_post_process(const base_gamma_builder::hit_collection_t
           if (int_prob > int_prob_limit) {
             // Do not add the calorimeter hit from the charged particle to
             // the list of calorimeter hits of the gamma particle
-            // snemo::datamodel::calibrated_calorimeter_hit::collection_type & hits =
+            // snemo::datamodel::CalorimeterHitHdlCollection & hits =
             // a_gamma.grab_associated_calorimeter_hits(); hits.insert(hits.begin(),
             // the_calorimeters.front());
             auto hBSv = datatools::make_handle<geomtools::blur_spot>();

--- a/source/falaise/snemo/processing/base_gamma_builder.cc
+++ b/source/falaise/snemo/processing/base_gamma_builder.cc
@@ -210,21 +210,20 @@ int base_gamma_builder::_post_process(const base_gamma_builder::hit_collection_t
                                       snemo::datamodel::particle_track_data& ptd_) {
   // Add the ignored hits to the list of non associated calorimeters
   // ptd_.reset_non_associated_calorimeters();
-  auto& calos = ptd_.grab_non_associated_calorimeters();
+  auto& calos = ptd_.isolatedCalorimeters();
   calos.assign(ignoredHits_.begin(), ignoredHits_.end());
 
   // Given charged particle then process gammas
-  snemo::datamodel::particle_track_data::particle_collection_type gamma_particles;
-  ptd_.fetch_particles(gamma_particles, snemo::datamodel::particle_track::NEUTRAL);
+  snemo::datamodel::ParticleHdlCollection gamma_particles =
+      ptd_.getParticlesByCharge(snemo::datamodel::particle_track::NEUTRAL);
   if (gamma_particles.empty()) {
     DT_LOG_DEBUG(get_logging_priority(), "No gamma particles have been found !");
     return 0;
   }
 
-  snemo::datamodel::particle_track_data::particle_collection_type charged_particles;
-  ptd_.fetch_particles(charged_particles, snemo::datamodel::particle_track::NEGATIVE |
-                                              snemo::datamodel::particle_track::POSITIVE |
-                                              snemo::datamodel::particle_track::UNDEFINED);
+  snemo::datamodel::ParticleHdlCollection charged_particles = ptd_.getParticlesByCharge(
+      snemo::datamodel::particle_track::NEGATIVE | snemo::datamodel::particle_track::POSITIVE |
+      snemo::datamodel::particle_track::UNDEFINED);
   if (charged_particles.empty()) {
     DT_LOG_DEBUG(get_logging_priority(), "No charged particles have been found !");
     return 0;

--- a/source/falaise/snemo/processing/base_gamma_builder.h
+++ b/source/falaise/snemo/processing/base_gamma_builder.h
@@ -68,7 +68,7 @@ namespace processing {
 class base_gamma_builder {
  public:
   /// Typedef to calibrated calorimeter hits
-  using hit_collection_type = snemo::datamodel::calibrated_data::calorimeter_hit_collection_type;
+  using hit_collection_type = snemo::datamodel::CalorimeterHitHdlCollection;
 
   /// Default constructor
   base_gamma_builder(const std::string &name = "anonymous");

--- a/source/falaise/snemo/processing/base_tracker_clusterizer.cc
+++ b/source/falaise/snemo/processing/base_tracker_clusterizer.cc
@@ -374,7 +374,7 @@ int base_tracker_clusterizer::process(
 
   const bool merge_prompt_delayed_solutions = true;
   if (merge_prompt_delayed_solutions) {
-    snedm::tracker_clustering_data::solution_col_type &the_solutions = clustering_.get_solutions();
+    snedm::TrackerClusteringSolutionHdlCollection &the_solutions = clustering_.get_solutions();
     for (auto isol = the_solutions.begin(); isol != the_solutions.end(); ++isol) {
       snedm::tracker_clustering_solution &sol_prompt = *(*isol);
       datatools::properties &aux_prompt = sol_prompt.get_auxiliaries();

--- a/source/falaise/snemo/processing/base_tracker_clusterizer.h
+++ b/source/falaise/snemo/processing/base_tracker_clusterizer.h
@@ -72,9 +72,8 @@ class base_tracker_clusterizer {
   // Typedefs
   using hit_type = snemo::datamodel::calibrated_tracker_hit;
   using hit_handle_type = snemo::datamodel::TrackerHitHdl;
-  using hit_collection_type = snemo::datamodel::calibrated_data::tracker_hit_collection_type;
-  using calo_hit_collection_type =
-      snemo::datamodel::calibrated_data::calorimeter_hit_collection_type;
+  using hit_collection_type = snemo::datamodel::TrackerHitHdlCollection;
+  using calo_hit_collection_type = snemo::datamodel::CalorimeterHitHdlCollection;
 
   /// Default constructor
   base_tracker_clusterizer(const std::string &name = "anonymous");
@@ -168,11 +167,11 @@ class base_tracker_clusterizer {
   datatools::logger::priority _logging_priority;  /// Logging priority
 
  private:
-  bool isInitialized_;                                //!< Initialization status
-  std::string id_;                                    //!< Identifier of the clusterizer algorithm
-  const geomtools::manager *geoManager_;              //!< The SuperNEMO geometry manager
-  const snemo::geometry::gg_locator *geigerLocator_;  //!< Locator for geiger cells
-  geomtools::id_selector cellSelector_;               //!< A selector of GIDs
+  bool isInitialized_;                                  //!< Initialization status
+  std::string id_;                                      //!< Identifier of the clusterizer algorithm
+  const geomtools::manager *geoManager_;                //!< The SuperNEMO geometry manager
+  const snemo::geometry::gg_locator *geigerLocator_;    //!< Locator for geiger cells
+  geomtools::id_selector cellSelector_;                 //!< A selector of GIDs
   snreco::detail::GeigerTimePartitioner preClusterer_;  //!< The time-clustering algorithm
 
   // Internal work space:

--- a/source/falaise/snemo/processing/base_tracker_clusterizer.h
+++ b/source/falaise/snemo/processing/base_tracker_clusterizer.h
@@ -71,7 +71,7 @@ class base_tracker_clusterizer {
  public:
   // Typedefs
   using hit_type = snemo::datamodel::calibrated_tracker_hit;
-  using hit_handle_type = snemo::datamodel::calibrated_tracker_hit::handle_type;
+  using hit_handle_type = snemo::datamodel::TrackerHitHdl;
   using hit_collection_type = snemo::datamodel::calibrated_data::tracker_hit_collection_type;
   using calo_hit_collection_type =
       snemo::datamodel::calibrated_data::calorimeter_hit_collection_type;

--- a/source/falaise/snemo/processing/base_tracker_fitter.cc
+++ b/source/falaise/snemo/processing/base_tracker_fitter.cc
@@ -130,7 +130,7 @@ int base_tracker_fitter::_post_process(snemo::datamodel::tracker_trajectory_data
 
     // Define a map with index based on chi2 value : first elements are the
     // best fitted tracks
-    using chi2_dict_type = std::map<double, snemo::datamodel::tracker_trajectory::handle_type>;
+    using chi2_dict_type = std::map<double, snemo::datamodel::TrackerTrajectoryHdl>;
     using trajectory_dict_type = std::map<int32_t, chi2_dict_type>;
     trajectory_dict_type vtrajs;
 

--- a/source/falaise/snemo/processing/detail/mock_raw_tracker_hit.cc
+++ b/source/falaise/snemo/processing/detail/mock_raw_tracker_hit.cc
@@ -2,16 +2,16 @@
 // falaise/snemo/datamodels/mock_raw_tracker_hit.cc
 
 // Ourselves:
-#include <falaise/snemo/datamodels/mock_raw_tracker_hit.h>
+#include "mock_raw_tracker_hit.h"
 
 // Third party:
 // - Bayeux/datatools:
 #include <datatools/clhep_units.h>
 #include <datatools/utils.h>
 
-namespace snemo {
+namespace snreco {
 
-namespace datamodel {
+namespace detail {
 
 bool mock_raw_tracker_hit::is_ref_time_missing() const { return !datatools::is_valid(_ref_time_); }
 
@@ -142,6 +142,6 @@ void mock_raw_tracker_hit::dump() const {
   tree_dump(std::clog, "snemo::datamodel::mock_raw_tracker_hit");
 }
 
-}  // end of namespace datamodel
+}  // namespace detail
 
-}  // end of namespace snemo
+}  // namespace snreco

--- a/source/falaise/snemo/processing/detail/mock_raw_tracker_hit.h
+++ b/source/falaise/snemo/processing/detail/mock_raw_tracker_hit.h
@@ -22,9 +22,9 @@
 // - Bayeux/geomtools:
 #include <bayeux/geomtools/base_hit.h>
 
-namespace snemo {
+namespace snreco {
 
-namespace datamodel {
+namespace detail {
 
 /// \brief A mock class to represent SuperNEMO raw tracker hit
 class mock_raw_tracker_hit : public geomtools::base_hit {
@@ -91,21 +91,22 @@ class mock_raw_tracker_hit : public geomtools::base_hit {
   void dump() const;
 
  private:
-  double _ref_time_{datatools::invalid_real()};  //!< Relative time of the hit in relation to the absolute timestamp of the
-                      //!< current event
+  double _ref_time_{datatools::invalid_real()};  //!< Relative time of the hit in relation to the
+                                                 //!< absolute timestamp of the current event
   double _sigma_ref_time_{datatools::invalid_real()};  //!< Relative time error
 
   // Geiger regime anode/cathodes drift times:
-  double _drift_time_{datatools::invalid_real()};         //!< Anode drift time
-  double _sigma_drift_time_{datatools::invalid_real()};   //!< Anode drift time error
-  double _top_time_{datatools::invalid_real()};           //!< Top cathode signal drift time
-  double _sigma_top_time_{datatools::invalid_real()};     //!< Top cathode signal drift time error
-  double _bottom_time_{datatools::invalid_real()};        //!< Bottom cathode signal drift time
-  double _sigma_bottom_time_{datatools::invalid_real()};  //!< Bottom cathode signal drift time error
+  double _drift_time_{datatools::invalid_real()};        //!< Anode drift time
+  double _sigma_drift_time_{datatools::invalid_real()};  //!< Anode drift time error
+  double _top_time_{datatools::invalid_real()};          //!< Top cathode signal drift time
+  double _sigma_top_time_{datatools::invalid_real()};    //!< Top cathode signal drift time error
+  double _bottom_time_{datatools::invalid_real()};       //!< Bottom cathode signal drift time
+  double _sigma_bottom_time_{
+      datatools::invalid_real()};  //!< Bottom cathode signal drift time error
 };
 
-}  // end of namespace datamodel
+}  // namespace detail
 
-}  // end of namespace snemo
+}  // namespace snreco
 
 #endif  // FALAISE_SNEMO_DATAMODEL_MOCK_RAW_TRACKER_HIT_H

--- a/source/falaise/snemo/processing/event_header_utils_module.cc
+++ b/source/falaise/snemo/processing/event_header_utils_module.cc
@@ -3,7 +3,7 @@
  */
 
 // Ourselves:
-#include <falaise/snemo/processing/event_header_utils_module.h>
+#include "event_header_utils_module.h"
 
 // Third party:
 // // - Bayeux/datatools:

--- a/source/falaise/snemo/processing/event_header_utils_module.cc
+++ b/source/falaise/snemo/processing/event_header_utils_module.cc
@@ -117,7 +117,7 @@ void event_header_utils_module::reset() {
 void event_header_utils_module::_set_defaults() {
   _mode_ = MODE_INVALID;
 
-  _add_header_bank_label_ = snemo::datamodel::data_info::default_event_header_label();
+  _add_header_bank_label_ = snedm::labels::event_header();
   _add_header_gentype_ = snemo::datamodel::event_header::GENERATION_INVALID;
   _add_header_update_ = false;
   _add_header_run_number_ = 0;
@@ -216,7 +216,7 @@ void event_header_utils_module::_process_add_header(datatools::things& data_reco
   // Store GENBB event weight
   if (ah_is_simulated()) {
     if (_add_header_use_genbb_weight_ || _add_header_use_genbb_label_) {
-      const std::string sd_label = snemo::datamodel::data_info::default_simulated_data_label();
+      const std::string sd_label = snedm::labels::simulated_data();
       DT_THROW_IF(!data_record_.has(sd_label), std::logic_error,
                   "Event record has no '" << sd_label << "' bank!");
       const auto& the_simulated_data = data_record_.get<mctools::simulated_data>(sd_label);
@@ -282,7 +282,7 @@ DOCD_CLASS_IMPLEMENT_LOAD_BEGIN(snemo::processing::event_header_utils_module, oc
         .set_long_description(
             "This is the name of the bank to be used \n"
             "to store the event header informations. \n")
-        .set_default_value_string(snemo::datamodel::data_info::default_event_header_label())
+        .set_default_value_string(snedm::labels::event_header())
         .add_example(
             "Use an alternative name for the 'event_ header' bank:: \n"
             "                                                       \n"
@@ -313,7 +313,7 @@ DOCD_CLASS_IMPLEMENT_LOAD_BEGIN(snemo::processing::event_header_utils_module, oc
         .set_traits(datatools::TYPE_STRING)
         .set_mandatory(false)
         .set_long_description(R"(This is the type of generation ("real" or "simulated"))")
-        .set_default_value_string(snemo::datamodel::data_info::default_event_header_label())
+        .set_default_value_string(snedm::labels::event_header())
         .add_example(
             "Indicate simulated event:: \n"
             "                                                       \n"

--- a/source/falaise/snemo/processing/mock_calorimeter_s2c_module.cc
+++ b/source/falaise/snemo/processing/mock_calorimeter_s2c_module.cc
@@ -41,10 +41,8 @@ void mock_calorimeter_s2c_module::initialize(const datatools::properties& ps,
   this->base_module::_common_initialize(ps);
   falaise::property_set fps{ps};
 
-  sdInputTag =
-      fps.get<std::string>("SD_label", snedm::labels::simulated_data());
-  cdOutputTag = fps.get<std::string>("CD_label",
-                                     snedm::labels::calibrated_data());
+  sdInputTag = fps.get<std::string>("SD_label", snedm::labels::simulated_data());
+  cdOutputTag = fps.get<std::string>("CD_label", snedm::labels::calibrated_data());
 
   // Initialize the embedded random number generator:
   int random_seed = fps.get<int>("random.seed", 12345);
@@ -134,7 +132,7 @@ void mock_calorimeter_s2c_module::digitizeHits(
 
       // Extract the corresponding geom ID:
       auto& geomID = a_calo_mc_hit->get_geom_id();
-      using CCHitHdl = snemo::datamodel::calibrated_calorimeter_hit::collection_type::value_type;
+      using CCHitHdl = snemo::datamodel::CalorimeterHitHdlCollection::value_type;
 
       auto found = std::find_if(calohits.rbegin(), calohits.rend(), [&geomID](CCHitHdl const& x) {
         return x->get_geom_id() == geomID;

--- a/source/falaise/snemo/processing/mock_calorimeter_s2c_module.cc
+++ b/source/falaise/snemo/processing/mock_calorimeter_s2c_module.cc
@@ -104,7 +104,7 @@ dpp::base_module::process_status mock_calorimeter_s2c_module::process(datatools:
 // and build the final list of calibrated 'calorimeter' hits
 void mock_calorimeter_s2c_module::digitizeHits(
     const mctools::simulated_data& simdata,
-    snemo::datamodel::calibrated_data::calorimeter_hit_collection_type& calohits) {
+    snemo::datamodel::CalorimeterHitHdlCollection& calohits) {
   uint32_t calibrated_calorimeter_hit_id = 0;
 
   // Loop over all 'calorimeter hit' categories:
@@ -204,7 +204,7 @@ void mock_calorimeter_s2c_module::digitizeHits(
 
 // Calibrate calorimeter hits from digitization informations:
 void mock_calorimeter_s2c_module::calibrateHits(
-    snemo::datamodel::calibrated_data::calorimeter_hit_collection_type& calohits) {
+    snemo::datamodel::CalorimeterHitHdlCollection& calohits) {
   for (auto& theCaloHit : calohits) {
     // Setting category in order to get the correct energy resolution:
     // first recover the calorimeter category
@@ -231,7 +231,7 @@ void mock_calorimeter_s2c_module::calibrateHits(
 
 // Select calorimeter hit following trigger conditions
 void mock_calorimeter_s2c_module::triggerHits(
-    snemo::datamodel::calibrated_data::calorimeter_hit_collection_type& calohits) {
+    snemo::datamodel::CalorimeterHitHdlCollection& calohits) {
   bool high_threshold = false;
   for (auto& theCaloHit : calohits) {
     // Setting category in order to get the correct trigger parameters:
@@ -266,7 +266,7 @@ void mock_calorimeter_s2c_module::triggerHits(
 
 void mock_calorimeter_s2c_module::process_impl(
     const mctools::simulated_data& simdata,
-    snemo::datamodel::calibrated_data::calorimeter_hit_collection_type& calohits) {
+    snemo::datamodel::CalorimeterHitHdlCollection& calohits) {
   digitizeHits(simdata, calohits);
   calibrateHits(calohits);
   triggerHits(calohits);

--- a/source/falaise/snemo/processing/mock_calorimeter_s2c_module.cc
+++ b/source/falaise/snemo/processing/mock_calorimeter_s2c_module.cc
@@ -3,7 +3,7 @@
  */
 
 // Ourselves:
-#include <falaise/snemo/processing/mock_calorimeter_s2c_module.h>
+#include "mock_calorimeter_s2c_module.h"
 
 // Standard library:
 #include <sstream>

--- a/source/falaise/snemo/processing/mock_calorimeter_s2c_module.cc
+++ b/source/falaise/snemo/processing/mock_calorimeter_s2c_module.cc
@@ -92,10 +92,10 @@ dpp::base_module::process_status mock_calorimeter_s2c_module::process(datatools:
       snedm::getOrAddToEvent<snemo::datamodel::calibrated_data>(cdOutputTag, event);
 
   // Always rewrite hits....
-  calibratedData.calibrated_calorimeter_hits().clear();
+  calibratedData.calorimeter_hits().clear();
 
   // Main processing method :
-  process_impl(simulatedData, calibratedData.calibrated_calorimeter_hits());
+  process_impl(simulatedData, calibratedData.calorimeter_hits());
 
   return dpp::base_module::PROCESS_SUCCESS;
 }

--- a/source/falaise/snemo/processing/mock_calorimeter_s2c_module.cc
+++ b/source/falaise/snemo/processing/mock_calorimeter_s2c_module.cc
@@ -42,9 +42,9 @@ void mock_calorimeter_s2c_module::initialize(const datatools::properties& ps,
   falaise::property_set fps{ps};
 
   sdInputTag =
-      fps.get<std::string>("SD_label", snemo::datamodel::data_info::default_simulated_data_label());
+      fps.get<std::string>("SD_label", snedm::labels::simulated_data());
   cdOutputTag = fps.get<std::string>("CD_label",
-                                     snemo::datamodel::data_info::default_calibrated_data_label());
+                                     snedm::labels::calibrated_data());
 
   // Initialize the embedded random number generator:
   int random_seed = fps.get<int>("random.seed", 12345);
@@ -91,7 +91,7 @@ dpp::base_module::process_status mock_calorimeter_s2c_module::process(datatools:
   // May, or may not, have it depending on if we run before or after
   // other calibrators
   auto& calibratedData =
-      snemo::datamodel::getOrAddToEvent<snemo::datamodel::calibrated_data>(cdOutputTag, event);
+      snedm::getOrAddToEvent<snemo::datamodel::calibrated_data>(cdOutputTag, event);
 
   // Always rewrite hits....
   calibratedData.calibrated_calorimeter_hits().clear();
@@ -308,7 +308,7 @@ DOCD_CLASS_IMPLEMENT_LOAD_BEGIN(snemo::processing::mock_calorimeter_s2c_module, 
         .set_long_description(
             "This is the name of the bank to be used   \n"
             "as the input simulated calorimeter hits.  \n")
-        .set_default_value_string(snemo::datamodel::data_info::default_simulated_data_label())
+        .set_default_value_string(snedm::labels::simulated_data())
         .add_example(
             "Use an alternative name for the 'simulated data' bank:: \n"
             "                                \n"
@@ -326,7 +326,7 @@ DOCD_CLASS_IMPLEMENT_LOAD_BEGIN(snemo::processing::mock_calorimeter_s2c_module, 
         .set_long_description(
             "This is the name of the bank to be used    \n"
             "as the output calibrated calorimeter hits. \n")
-        .set_default_value_string(snemo::datamodel::data_info::default_calibrated_data_label())
+        .set_default_value_string(snedm::labels::calibrated_data())
         .add_example(
             "Use an alternative name for the 'calibrated data' bank:: \n"
             "                                \n"

--- a/source/falaise/snemo/processing/mock_calorimeter_s2c_module.h
+++ b/source/falaise/snemo/processing/mock_calorimeter_s2c_module.h
@@ -65,17 +65,17 @@ class mock_calorimeter_s2c_module : public dpp::base_module {
  private:
   /// Digitize calorimeter hits
   void digitizeHits(const mctools::simulated_data& simdata,
-                    snemo::datamodel::calibrated_data::calorimeter_hit_collection_type& calohits);
+                    snemo::datamodel::CalorimeterHitHdlCollection& calohits);
 
   /// Calibrate calorimeter hits (energy/time resolution spread)
-  void calibrateHits(snemo::datamodel::calibrated_data::calorimeter_hit_collection_type& calohits);
+  void calibrateHits(snemo::datamodel::CalorimeterHitHdlCollection& calohits);
 
   /// Apply basic trigger filter
-  void triggerHits(snemo::datamodel::calibrated_data::calorimeter_hit_collection_type& calohits);
+  void triggerHits(snemo::datamodel::CalorimeterHitHdlCollection& calohits);
 
   /// Main process function
   void process_impl(const mctools::simulated_data& simdata,
-                    snemo::datamodel::calibrated_data::calorimeter_hit_collection_type& calohits);
+                    snemo::datamodel::CalorimeterHitHdlCollection& calohits);
 
  private:
   mygsl::rng RNG_{};                     //!< PRN generator

--- a/source/falaise/snemo/processing/mock_tracker_s2c_module.cc
+++ b/source/falaise/snemo/processing/mock_tracker_s2c_module.cc
@@ -23,9 +23,9 @@
 #include <boost/range/adaptor/indexed.hpp>
 
 // This project :
-#include "detail/mock_raw_tracker_hit.h"
 #include <falaise/snemo/datamodels/data_model.h>
 #include <falaise/snemo/services/services.h>
+#include "detail/mock_raw_tracker_hit.h"
 #include "falaise/property_set.h"
 #include "falaise/quantity.h"
 
@@ -47,10 +47,8 @@ void mock_tracker_s2c_module::initialize(const datatools::properties& ps,
 
   falaise::property_set fps{ps};
 
-  sdInputTag =
-      fps.get<std::string>("SD_label", snemo::datamodel::data_info::default_simulated_data_label());
-  cdOutputTag = fps.get<std::string>("CD_label",
-                                     snemo::datamodel::data_info::default_calibrated_data_label());
+  sdInputTag = fps.get<std::string>("SD_label", snedm::labels::simulated_data());
+  cdOutputTag = fps.get<std::string>("CD_label", snedm::labels::calibrated_data());
 
   geoManager = snemo::service_handle<snemo::geometry_svc>{services};
 
@@ -111,7 +109,7 @@ dpp::base_module::process_status mock_tracker_s2c_module::process(datatools::thi
     sim_tracker_hit_col_t const& simTrackerHits = simulatedData.get_step_hits(_hit_category_);
 
     auto& currentCalData =
-        snemo::datamodel::getOrAddToEvent<snemo::datamodel::calibrated_data>(cdOutputTag, event);
+        snedm::getOrAddToEvent<snemo::datamodel::calibrated_data>(cdOutputTag, event);
     cal_tracker_hit_col_t& calTrackerHits = currentCalData.calibrated_tracker_hits();
 
     calTrackerHits = process_(simTrackerHits);
@@ -175,8 +173,7 @@ mock_tracker_s2c_module::raw_tracker_hit_col_t mock_tracker_s2c_module::digitize
 
     /*** Anode TDC ***/
     // randomize the expected Geiger drift time:
-    const double expected_drift_time =
-        _geiger_.getRandomTimeGivenRadius(RNG_, drift_distance);
+    const double expected_drift_time = _geiger_.getRandomTimeGivenRadius(RNG_, drift_distance);
     const double anode_time = ionization_time + expected_drift_time;
     const double sigma_anode_time = _geiger_.getAnodeTimeResolution(anode_time);
 
@@ -479,7 +476,7 @@ DOCD_CLASS_IMPLEMENT_LOAD_BEGIN(snemo::processing::mock_tracker_s2c_module, ocd_
         .set_long_description(
             "This is the name of the bank to be used    \n"
             "as the output calibrated calorimeter hits. \n")
-        .set_default_value_string(snemo::datamodel::data_info::default_simulated_data_label())
+        .set_default_value_string(snedm::labels::simulated_data())
         .add_example(
             "Use an alternative name for the 'simulated data' bank:: \n"
             "                                \n"
@@ -497,7 +494,7 @@ DOCD_CLASS_IMPLEMENT_LOAD_BEGIN(snemo::processing::mock_tracker_s2c_module, ocd_
         .set_long_description(
             "This is the name of the bank to be used  \n"
             "as the input simulated calorimeter hits. \n")
-        .set_default_value_string(snemo::datamodel::data_info::default_calibrated_data_label())
+        .set_default_value_string(snedm::labels::calibrated_data())
         .add_example(
             "Use an alternative name for the 'calibrated data' bank:: \n"
             "                                \n"

--- a/source/falaise/snemo/processing/mock_tracker_s2c_module.cc
+++ b/source/falaise/snemo/processing/mock_tracker_s2c_module.cc
@@ -3,7 +3,7 @@
  */
 
 // Ourselves:
-#include <falaise/snemo/processing/mock_tracker_s2c_module.h>
+#include "mock_tracker_s2c_module.h"
 
 // Standard library:
 #include <sstream>
@@ -23,6 +23,7 @@
 #include <boost/range/adaptor/indexed.hpp>
 
 // This project :
+#include "detail/mock_raw_tracker_hit.h"
 #include <falaise/snemo/datamodels/data_model.h>
 #include <falaise/snemo/services/services.h>
 #include "falaise/property_set.h"
@@ -213,8 +214,8 @@ mock_tracker_s2c_module::raw_tracker_hit_col_t mock_tracker_s2c_module::digitize
     auto found = std::find_if(rawTrackerDigits.begin(), rawTrackerDigits.end(), pred_has_gid);
     if (found == rawTrackerDigits.end()) {
       // This geom_id is not used by any previous tracker hit: we create a new tracker hit !
-      rawTrackerDigits.emplace_back(snemo::datamodel::mock_raw_tracker_hit{});
-      snemo::datamodel::mock_raw_tracker_hit& new_raw_tracker_hit = rawTrackerDigits.back();
+      rawTrackerDigits.emplace_back(snreco::detail::mock_raw_tracker_hit{});
+      snreco::detail::mock_raw_tracker_hit& new_raw_tracker_hit = rawTrackerDigits.back();
 
       // assign a hit ID and the geometry ID to the hit:
       new_raw_tracker_hit.set_hit_id(raw_tracker_hit_id);
@@ -250,7 +251,7 @@ mock_tracker_s2c_module::raw_tracker_hit_col_t mock_tracker_s2c_module::digitize
       }
     } else {
       // This geom_id is already used by some previous tracker hit: we update this hit !
-      snemo::datamodel::mock_raw_tracker_hit& some_raw_tracker_hit = *found;
+      snreco::detail::mock_raw_tracker_hit& some_raw_tracker_hit = *found;
 
       if (datatools::is_valid(anode_time)) {
         if (anode_time < some_raw_tracker_hit.get_drift_time()) {

--- a/source/falaise/snemo/processing/mock_tracker_s2c_module.cc
+++ b/source/falaise/snemo/processing/mock_tracker_s2c_module.cc
@@ -110,7 +110,7 @@ dpp::base_module::process_status mock_tracker_s2c_module::process(datatools::thi
 
     auto& currentCalData =
         snedm::getOrAddToEvent<snemo::datamodel::calibrated_data>(cdOutputTag, event);
-    cal_tracker_hit_col_t& calTrackerHits = currentCalData.calibrated_tracker_hits();
+    cal_tracker_hit_col_t& calTrackerHits = currentCalData.tracker_hits();
 
     calTrackerHits = process_(simTrackerHits);
   }

--- a/source/falaise/snemo/processing/mock_tracker_s2c_module.h
+++ b/source/falaise/snemo/processing/mock_tracker_s2c_module.h
@@ -68,7 +68,7 @@ class mock_tracker_s2c_module : public dpp::base_module {
   // Rationalized typenames
   using sim_tracker_hit_col_t = mctools::simulated_data::hit_handle_collection_type;
   using raw_tracker_hit_col_t = std::list<snreco::detail::mock_raw_tracker_hit>;
-  using cal_tracker_hit_col_t = snemo::datamodel::calibrated_data::tracker_hit_collection_type;
+  using cal_tracker_hit_col_t = snemo::datamodel::TrackerHitHdlCollection;
 
   /// Digitize tracker hits
   raw_tracker_hit_col_t digitizeHits_(const sim_tracker_hit_col_t& steps);

--- a/source/falaise/snemo/processing/mock_tracker_s2c_module.h
+++ b/source/falaise/snemo/processing/mock_tracker_s2c_module.h
@@ -29,15 +29,19 @@
 
 // This project :
 #include <falaise/snemo/datamodels/calibrated_data.h>
-#include <falaise/snemo/datamodels/mock_raw_tracker_hit.h>
 #include <falaise/snemo/processing/geiger_regime.h>
-#include <falaise/snemo/services/service_handle.h>
 #include <falaise/snemo/services/geometry.h>
-
+#include <falaise/snemo/services/service_handle.h>
 
 namespace geomtools {
 class manager;
 }
+
+namespace snreco {
+namespace detail {
+class mock_raw_tracker_hit;
+}
+}  // namespace snreco
 
 namespace snemo {
 
@@ -63,7 +67,7 @@ class mock_tracker_s2c_module : public dpp::base_module {
  private:
   // Rationalized typenames
   using sim_tracker_hit_col_t = mctools::simulated_data::hit_handle_collection_type;
-  using raw_tracker_hit_col_t = std::list<snemo::datamodel::mock_raw_tracker_hit>;
+  using raw_tracker_hit_col_t = std::list<snreco::detail::mock_raw_tracker_hit>;
   using cal_tracker_hit_col_t = snemo::datamodel::calibrated_data::tracker_hit_collection_type;
 
   /// Digitize tracker hits
@@ -76,10 +80,10 @@ class mock_tracker_s2c_module : public dpp::base_module {
   cal_tracker_hit_col_t process_(const sim_tracker_hit_col_t& hits);
 
   snemo::service_handle<snemo::geometry_svc> geoManager{};  //!< The geometry manager
-  std::string _module_category_{};                //!< The geometry category of the SuperNEMO module
-  std::string _hit_category_{};                   //!< The category of the input Geiger hits
-  geiger_regime _geiger_{};                       //!< Geiger regime tools
-  mygsl::rng RNG_{};                              //!< internal PRN generator
+  std::string _module_category_{};  //!< The geometry category of the SuperNEMO module
+  std::string _hit_category_{};     //!< The category of the input Geiger hits
+  geiger_regime _geiger_{};         //!< Geiger regime tools
+  mygsl::rng RNG_{};                //!< internal PRN generator
   double _peripheral_drift_time_threshold_{
       datatools::invalid_real_double()};  //!< Peripheral drift time threshold
   double _delayed_drift_time_threshold_{

--- a/source/falaise/snemo/test/test_snemo_datamodel_event.cxx
+++ b/source/falaise/snemo/test/test_snemo_datamodel_event.cxx
@@ -6,35 +6,35 @@
 
 TEST_CASE("Event construction works", "[falaise][datamodel]") {
   // Default
-  snemo::datamodel::event_record e{"foo", "bar"};
+  snedm::event_record e{"foo", "bar"};
 
   REQUIRE(e.has_name());
   REQUIRE(e.get_description() == "bar");
 }
 
 TEST_CASE("getOrAddToEvent free function works", "[falaise][datamodel]") {
-  snemo::datamodel::event_record e;
+  snedm::event_record e;
   using timestamp = snemo::datamodel::timestamp;
 
   SECTION("Get on an empty event creates 1 entry") {
-    REQUIRE_NOTHROW(auto& t0 = snemo::datamodel::getOrAddToEvent<timestamp>("first", e));
+    REQUIRE_NOTHROW(auto& t0 = snedm::getOrAddToEvent<timestamp>("first", e));
     REQUIRE(e.size() == 1);
     REQUIRE(e.has("first"));
     REQUIRE(e.is_a<timestamp>("first"));
   }
 
   SECTION("Get on a prefilled event gets the same object") {
-    auto& t0 = snemo::datamodel::getOrAddToEvent<timestamp>("first", e);
-    REQUIRE_NOTHROW(auto& t1 = snemo::datamodel::getOrAddToEvent<timestamp>("first", e));
+    auto& t0 = snedm::getOrAddToEvent<timestamp>("first", e);
+    REQUIRE_NOTHROW(auto& t1 = snedm::getOrAddToEvent<timestamp>("first", e));
     REQUIRE(e.size() == 1);
-    auto& t1 = snemo::datamodel::getOrAddToEvent<timestamp>("first", e);
+    auto& t1 = snedm::getOrAddToEvent<timestamp>("first", e);
     REQUIRE(&t0 == &t1);
   }
 
   SECTION("Getting on different type throws bad_things_cast") {
-    auto& t0 = snemo::datamodel::getOrAddToEvent<timestamp>("first", e);
+    auto& t0 = snedm::getOrAddToEvent<timestamp>("first", e);
 
-    REQUIRE_THROWS_AS(auto& t1 = snemo::datamodel::getOrAddToEvent<datatools::things>("first", e),
+    REQUIRE_THROWS_AS(auto& t1 = snedm::getOrAddToEvent<datatools::things>("first", e),
                       datatools::bad_things_cast);
   }
 }

--- a/source/falaise/snemo/test/test_snemo_datamodel_particle_track.cxx
+++ b/source/falaise/snemo/test/test_snemo_datamodel_particle_track.cxx
@@ -75,29 +75,6 @@ int main(/* int argc_, char ** argv_ */) {
     PT0.grab_auxiliaries().store_flag("fake_electron");
     PT0.tree_dump(std::clog, "Particle track : ");
 
-    // Retrieve a subset of vertices
-    sdm::particle_track::vertex_collection_type vertices;
-    {
-      const size_t nvtx = PT0.fetch_vertices(vertices, sdm::particle_track::VERTEX_ON_SOURCE_FOIL);
-      std::clog << "Number of vertices on the source foil = " << nvtx << std::endl;
-      std::clog << "Total number of vertices = " << vertices.size() << std::endl;
-    }
-    {
-      const size_t nvtx =
-          PT0.fetch_vertices(vertices, sdm::particle_track::VERTEX_ON_MAIN_CALORIMETER);
-      std::clog << "Number of vertices on the main calorimeter = " << nvtx << std::endl;
-      std::clog << "Total number of vertices = " << vertices.size() << std::endl;
-    }
-    {
-      const size_t nvtx = PT0.fetch_vertices(vertices,
-                                             sdm::particle_track::VERTEX_ON_MAIN_CALORIMETER |
-                                                 sdm::particle_track::VERTEX_ON_SOURCE_FOIL,
-                                             true);
-      std::clog << "Number of vertices on the source foil & the main calorimeter = " << nvtx
-                << std::endl;
-      std::clog << "Total number of vertices = " << vertices.size() << std::endl;
-    }
-
   } catch (std::exception& x) {
     std::cerr << "error: " << x.what() << std::endl;
     error_code = EXIT_FAILURE;

--- a/source/falaise/snemo/test/test_snemo_datamodel_particle_track.cxx
+++ b/source/falaise/snemo/test/test_snemo_datamodel_particle_track.cxx
@@ -30,11 +30,11 @@ int main(/* int argc_, char ** argv_ */) {
 
     datatools::handle<sdm::tracker_trajectory> hTJ0;
     hTJ0.reset(new sdm::tracker_trajectory);
-    hTJ0.grab().set_trajectory_id(0);
-    hTJ0.grab().set_pattern_handle(hLTP0);
-    hTJ0.grab().grab_auxiliaries().store_flag("test");
-    hTJ0.grab().grab_auxiliaries().store("chi2", 0.234);
-    hTJ0.get().tree_dump(std::clog, "Tracker trajectory : ");
+    hTJ0->set_id(0);
+    hTJ0->set_pattern_handle(hLTP0);
+    hTJ0->grab_auxiliaries().store_flag("test");
+    hTJ0->grab_auxiliaries().store("chi2", 0.234);
+    hTJ0->tree_dump(std::clog, "Tracker trajectory : ");
 
     // Create a handle of fake vertices :
     datatools::handle<geomtools::blur_spot> hV0;
@@ -69,7 +69,7 @@ int main(/* int argc_, char ** argv_ */) {
     sdm::particle_track PT0;
     PT0.set_track_id(0);
     PT0.set_trajectory_handle(hTJ0);
-    PT0.set_charge(sdm::particle_track::positive);
+    PT0.set_charge(sdm::particle_track::POSITIVE);
     PT0.get_vertices().push_back(hV0);
     PT0.get_vertices().push_back(hV1);
     PT0.grab_auxiliaries().store_flag("fake_electron");

--- a/source/falaise/snemo/test/test_snemo_datamodel_particle_track_data.cxx
+++ b/source/falaise/snemo/test/test_snemo_datamodel_particle_track_data.cxx
@@ -31,11 +31,11 @@ int main(/*int argc_, char ** argv_*/) {
 
     datatools::handle<sdm::tracker_trajectory> hTJ0;
     hTJ0.reset(new sdm::tracker_trajectory);
-    hTJ0.grab().set_trajectory_id(0);
-    hTJ0.grab().set_pattern_handle(hLTP0);
-    hTJ0.grab().grab_auxiliaries().store_flag("test");
-    hTJ0.grab().grab_auxiliaries().store("chi2", 0.234);
-    hTJ0.get().tree_dump(std::clog, "Tracker trajectory : ");
+    hTJ0->set_id(0);
+    hTJ0->set_pattern_handle(hLTP0);
+    hTJ0->grab_auxiliaries().store_flag("test");
+    hTJ0->grab_auxiliaries().store("chi2", 0.234);
+    hTJ0->tree_dump(std::clog, "Tracker trajectory : ");
 
     // Create a handle of fake vertices :
     datatools::handle<geomtools::blur_spot> hV0;
@@ -70,7 +70,7 @@ int main(/*int argc_, char ** argv_*/) {
     datatools::handle<sdm::particle_track> hPT0;
     hPT0.reset(new sdm::particle_track);
     hPT0.grab().set_track_id(0);
-    hPT0.grab().set_charge(sdm::particle_track::positive);
+    hPT0.grab().set_charge(sdm::particle_track::POSITIVE);
     hPT0.grab().set_trajectory_handle(hTJ0);
     hPT0.grab().get_vertices().push_back(hV0);
     hPT0.grab().get_vertices().push_back(hV1);
@@ -86,7 +86,7 @@ int main(/*int argc_, char ** argv_*/) {
     PTD.tree_dump(std::clog, "Particle track data :");
 
     // Retrieve electrons if any
-    sdm::ParticleHdlCollection electrons = PTD.getParticlesByCharge(sdm::particle_track::negative);
+    sdm::ParticleHdlCollection electrons = PTD.getParticlesByCharge(sdm::particle_track::NEGATIVE);
     std::clog << "Number of particles = " << PTD.numberOfParticles() << std::endl;
     std::clog << "Number of electrons = " << electrons.size() << std::endl;
 

--- a/source/falaise/snemo/test/test_snemo_datamodel_particle_track_data.cxx
+++ b/source/falaise/snemo/test/test_snemo_datamodel_particle_track_data.cxx
@@ -82,33 +82,21 @@ int main(/*int argc_, char ** argv_*/) {
 
     // Particle track data bank :
     auto& PTD = ER.add<sdm::particle_track_data>(snedm::labels::particle_track_data());
-    PTD.add_particle(hPT0);
+    PTD.insertParticle(hPT0);
     PTD.tree_dump(std::clog, "Particle track data :");
 
     // Retrieve electrons if any
-    sdm::particle_track_data::particle_collection_type electrons;
-    const size_t nelectrons = PTD.fetch_particles(electrons, sdm::particle_track::negative);
-    std::clog << "Number of particles = " << PTD.get_number_of_particles() << std::endl;
-    std::clog << "Number of electrons = " << nelectrons << std::endl;
+    sdm::ParticleHdlCollection electrons = PTD.getParticlesByCharge(sdm::particle_track::negative);
+    std::clog << "Number of particles = " << PTD.numberOfParticles() << std::endl;
+    std::clog << "Number of electrons = " << electrons.size() << std::endl;
 
     // Adding other particles
     for (size_t i = 0; i < 10; i++) {
       datatools::handle<sdm::particle_track> hPT;
       hPT.reset(new sdm::particle_track);
-      hPT.grab().set_track_id(i);
-      PTD.add_particle(hPT);
+      hPT->set_track_id(i);
+      PTD.insertParticle(hPT);
     }
-    std::clog << "Number of particles (before removing) = " << PTD.get_number_of_particles()
-              << std::endl;
-    // Create a list of particle index to remove
-    std::vector<size_t> indexes;
-    indexes.push_back(3);
-    indexes.push_back(5);
-    indexes.push_back(1);
-    PTD.remove_particles(indexes);
-    std::clog << "Number of particles (after removing) = " << PTD.get_number_of_particles()
-              << std::endl;
-    PTD.tree_dump(std::clog, "Particle track data after cleaning:");
   } catch (std::exception& x) {
     std::cerr << "error: " << x.what() << std::endl;
     error_code = EXIT_FAILURE;

--- a/source/falaise/snemo/test/test_snemo_datamodel_particle_track_data.cxx
+++ b/source/falaise/snemo/test/test_snemo_datamodel_particle_track_data.cxx
@@ -78,11 +78,10 @@ int main(/*int argc_, char ** argv_*/) {
     hPT0.get().tree_dump(std::clog, "Particle track : ");
 
     // Event record :
-    sdm::event_record ER;
+    snedm::event_record ER;
 
     // Particle track data bank :
-    auto& PTD =
-        ER.add<sdm::particle_track_data>(sdm::data_info::default_particle_track_data_label());
+    auto& PTD = ER.add<sdm::particle_track_data>(snedm::labels::particle_track_data());
     PTD.add_particle(hPT0);
     PTD.tree_dump(std::clog, "Particle track data :");
 

--- a/source/falaise/snemo/test/test_snemo_datamodel_particle_track_data.cxx
+++ b/source/falaise/snemo/test/test_snemo_datamodel_particle_track_data.cxx
@@ -86,7 +86,7 @@ int main(/*int argc_, char ** argv_*/) {
     PTD.tree_dump(std::clog, "Particle track data :");
 
     // Retrieve electrons if any
-    sdm::ParticleHdlCollection electrons = PTD.getParticlesByCharge(sdm::particle_track::NEGATIVE);
+    sdm::ParticleHdlCollection electrons = get_particles_by_charge(PTD, sdm::particle_track::NEGATIVE);
     std::clog << "Number of particles = " << PTD.numberOfParticles() << std::endl;
     std::clog << "Number of electrons = " << electrons.size() << std::endl;
 

--- a/source/falaise/snemo/test/test_snemo_datamodel_timestamp.cxx
+++ b/source/falaise/snemo/test/test_snemo_datamodel_timestamp.cxx
@@ -15,27 +15,6 @@ TEST_CASE("Timestamps are correctly constructed", "[falaise][datamodel]") {
   REQUIRE(t2.is_valid());
 }
 
-TEST_CASE("Timestamps can be validated/invalidated", "[falaise][datamodel]") {
-  snemo::datamodel::timestamp t1;
-  REQUIRE_FALSE(t1.is_valid());
-
-  SECTION("Invalidate does not change validity") {
-    t1.invalidate();
-    REQUIRE_FALSE(t1.is_valid());
-  }
-
-  SECTION("Setting invalid makes timestamp invalid") {
-    t1.invalidate();
-    REQUIRE_FALSE(t1.is_valid());
-  }
-
-  SECTION("Timestamps can be reset to valid") {
-    t1.invalidate();
-    t1.set_seconds(1);
-    t1.set_picoseconds(1);
-    REQUIRE(t1.is_valid());
-  }
-}
 
 TEST_CASE("Timestamps can be copied and compared", "[falaise][datamodel]") {
   snemo::datamodel::timestamp t1{12345, 678910};
@@ -45,7 +24,6 @@ TEST_CASE("Timestamps can be copied and compared", "[falaise][datamodel]") {
   snemo::datamodel::timestamp t2_pico{12345, 678911};
 
   snemo::datamodel::timestamp tInvalid;
-  tInvalid.invalidate();
 
   REQUIRE(t1 == t1_copy);
   REQUIRE(t1 < t2_sec);
@@ -62,7 +40,6 @@ TEST_CASE("Timestamps can be read from/written to strings", "[falaise][datamodel
   std::string t1String{"[12345:678910]"};
 
   snemo::datamodel::timestamp tInvalid;
-  tInvalid.invalidate();
   std::string tStringInvalid{"[?:?]"};
 
   std::string tStringValue{"[54321:987654321]"};

--- a/source/falaise/snemo/test/test_snemo_datamodel_tracker_cluster.cxx
+++ b/source/falaise/snemo/test/test_snemo_datamodel_tracker_cluster.cxx
@@ -23,9 +23,9 @@ int main(/* int argc_, char ** argv_ */) {
     srand48(314159);
 
     // Populate a collection of handles on Geiger hits :
-    sdm::calibrated_tracker_hit::collection_type hits;
+    sdm::TrackerHitHdlCollection hits;
     for (int i = 0; i < 10; ++i) {
-      sdm::calibrated_tracker_hit::handle_type h(new sdm::calibrated_tracker_hit);
+      sdm::TrackerHitHdl h(new sdm::calibrated_tracker_hit);
       sdm::calibrated_tracker_hit& gg_hit = h.grab();
       gg_hit.set_hit_id(i);
       geomtools::geom_id gid;
@@ -46,7 +46,7 @@ int main(/* int argc_, char ** argv_ */) {
     }
 
     // Create a handle on some tracker cluster :
-    sdm::tracker_cluster::handle_type hTC1(new sdm::tracker_cluster);
+    sdm::TrackerClusterHdl hTC1(new sdm::tracker_cluster);
     sdm::tracker_cluster& TC1 = hTC1.grab();
     TC1.set_cluster_id(0);
     TC1.make_prompt();
@@ -63,7 +63,7 @@ int main(/* int argc_, char ** argv_ */) {
     }
 
     // Create another handle on some othertracker cluster :
-    sdm::tracker_cluster::handle_type hTC2(new sdm::tracker_cluster);
+    sdm::TrackerClusterHdl hTC2(new sdm::tracker_cluster);
     sdm::tracker_cluster& TC2 = hTC2.grab();
     TC2.set_cluster_id(1);
     TC2.make_prompt();

--- a/source/falaise/snemo/test/test_snemo_datamodel_tracker_cluster.cxx
+++ b/source/falaise/snemo/test/test_snemo_datamodel_tracker_cluster.cxx
@@ -50,11 +50,11 @@ int main(/* int argc_, char ** argv_ */) {
     sdm::tracker_cluster& TC1 = hTC1.grab();
     TC1.set_cluster_id(0);
     TC1.make_prompt();
-    TC1.get_hits().push_back(hits[0]);
-    TC1.get_hits().push_back(hits[1]);
-    TC1.get_hits().push_back(hits[2]);
-    TC1.get_hits().push_back(hits[3]);
-    TC1.get_hits().push_back(hits[4]);
+    TC1.hits().push_back(hits[0]);
+    TC1.hits().push_back(hits[1]);
+    TC1.hits().push_back(hits[2]);
+    TC1.hits().push_back(hits[3]);
+    TC1.hits().push_back(hits[4]);
     TC1.grab_auxiliaries().store("display.color", "blue");
     {
       std::ostringstream title;
@@ -67,10 +67,10 @@ int main(/* int argc_, char ** argv_ */) {
     sdm::tracker_cluster& TC2 = hTC2.grab();
     TC2.set_cluster_id(1);
     TC2.make_prompt();
-    TC2.get_hits().push_back(hits[6]);
-    TC2.get_hits().push_back(hits[7]);
-    TC2.get_hits().push_back(hits[8]);
-    TC2.get_hits().push_back(hits[9]);
+    TC2.hits().push_back(hits[6]);
+    TC2.hits().push_back(hits[7]);
+    TC2.hits().push_back(hits[8]);
+    TC2.hits().push_back(hits[9]);
     TC2.grab_auxiliaries().store("display.color", "red");
     {
       std::ostringstream title;

--- a/source/falaise/snemo/test/test_snemo_datamodel_tracker_clustering_data.cxx
+++ b/source/falaise/snemo/test/test_snemo_datamodel_tracker_clustering_data.cxx
@@ -189,7 +189,7 @@ int main(int argc_, char** argv_) {
       if (draw) {
         draw_gg_hit(fvisu.grab(), gg_hit);
       }
-      CD.calibrated_tracker_hits().push_back(h);
+      CD.tracker_hits().push_back(h);
     }
     std::clog << std::endl;
     if (draw) {
@@ -202,7 +202,7 @@ int main(int argc_, char** argv_) {
     auto& TCD = ER.add<sdm::tracker_clustering_data>(snedm::labels::tracker_clustering_data());
 
     // Get a reference to the collection of calibrated Geiger hits from the 'CD' bank :
-    sdm::TrackerHitHdlCollection& gg_hits = CD.calibrated_tracker_hits();
+    sdm::TrackerHitHdlCollection& gg_hits = CD.tracker_hits();
 
     // Create a handle on some tracker cluster :
     sdm::TrackerClusterHdl hTC0(new sdm::tracker_cluster);

--- a/source/falaise/snemo/test/test_snemo_datamodel_tracker_clustering_data.cxx
+++ b/source/falaise/snemo/test/test_snemo_datamodel_tracker_clustering_data.cxx
@@ -85,7 +85,7 @@ void draw_gg_cluster_item(std::ostream& out_, const sdm::calibrated_tracker_hit&
 
 void draw_gg_cluster(std::ostream& out_, const sdm::tracker_cluster& gg_cluster_,
                      bool enlarged_ = false, bool sep_ = true) {
-  for (const auto& i : gg_cluster_.get_hits()) {
+  for (const auto& i : gg_cluster_.hits()) {
     draw_gg_cluster_item(out_, i.get(), enlarged_);
   }
   if (sep_) {
@@ -209,16 +209,16 @@ int main(int argc_, char** argv_) {
     sdm::tracker_cluster& TC0 = hTC0.grab();
     TC0.set_cluster_id(0);
     TC0.make_prompt();
-    TC0.get_hits().push_back(gg_hits[0]);
-    TC0.get_hits().push_back(gg_hits[1]);
-    TC0.get_hits().push_back(gg_hits[2]);
-    TC0.get_hits().push_back(gg_hits[3]);
-    TC0.get_hits().push_back(gg_hits[4]);
-    TC0.get_hits().push_back(gg_hits[5]);
-    TC0.get_hits().push_back(gg_hits[6]);
-    TC0.get_hits().push_back(gg_hits[7]);
-    TC0.get_hits().push_back(gg_hits[8]);
-    TC0.get_hits().push_back(gg_hits[9]);
+    TC0.hits().push_back(gg_hits[0]);
+    TC0.hits().push_back(gg_hits[1]);
+    TC0.hits().push_back(gg_hits[2]);
+    TC0.hits().push_back(gg_hits[3]);
+    TC0.hits().push_back(gg_hits[4]);
+    TC0.hits().push_back(gg_hits[5]);
+    TC0.hits().push_back(gg_hits[6]);
+    TC0.hits().push_back(gg_hits[7]);
+    TC0.hits().push_back(gg_hits[8]);
+    TC0.hits().push_back(gg_hits[9]);
     TC0.grab_auxiliaries().store("display.color", "blue");
     {
       std::ostringstream title;
@@ -232,12 +232,12 @@ int main(int argc_, char** argv_) {
     sdm::tracker_cluster& TC1 = hTC1.grab();
     TC1.set_cluster_id(1);
     TC1.make_prompt();
-    TC1.get_hits().push_back(gg_hits[10]);
-    TC1.get_hits().push_back(gg_hits[11]);
-    TC1.get_hits().push_back(gg_hits[12]);
-    TC1.get_hits().push_back(gg_hits[13]);
-    TC1.get_hits().push_back(gg_hits[14]);
-    TC1.get_hits().push_back(gg_hits[15]);
+    TC1.hits().push_back(gg_hits[10]);
+    TC1.hits().push_back(gg_hits[11]);
+    TC1.hits().push_back(gg_hits[12]);
+    TC1.hits().push_back(gg_hits[13]);
+    TC1.hits().push_back(gg_hits[14]);
+    TC1.hits().push_back(gg_hits[15]);
     TC1.grab_auxiliaries().store("display.color", "red");
     {
       std::ostringstream title;
@@ -270,7 +270,7 @@ int main(int argc_, char** argv_) {
       draw_gg_clustering_solution(fvisu.grab(), TCS0, "unclustered_hits");
     }
 
-    TCD.add_solution(hTCS0, true);
+    TCD.push_back(hTCS0, true);
     TCD.tree_dump(std::clog, "Tracker clustering data('TCD') : ");
     std::clog << std::endl;
 

--- a/source/falaise/snemo/test/test_snemo_datamodel_tracker_clustering_data.cxx
+++ b/source/falaise/snemo/test/test_snemo_datamodel_tracker_clustering_data.cxx
@@ -161,7 +161,7 @@ int main(int argc_, char** argv_) {
     auto& CD = ER.add<sdm::calibrated_data>(snedm::labels::calibrated_data());
     // Populate a collection of handles on Geiger hits :
     for (int i = 0; i < 18; ++i) {
-      sdm::calibrated_tracker_hit::handle_type h(new sdm::calibrated_tracker_hit);
+      sdm::TrackerHitHdl h(new sdm::calibrated_tracker_hit);
       sdm::calibrated_tracker_hit& gg_hit = h.grab();
       gg_hit.set_hit_id(i);
       geomtools::geom_id gid;
@@ -199,14 +199,13 @@ int main(int argc_, char** argv_) {
     std::clog << std::endl;
 
     // Tracker clustering data bank :
-    auto& TCD = ER.add<sdm::tracker_clustering_data>(
-        snedm::labels::tracker_clustering_data());
+    auto& TCD = ER.add<sdm::tracker_clustering_data>(snedm::labels::tracker_clustering_data());
 
     // Get a reference to the collection of calibrated Geiger hits from the 'CD' bank :
     sdm::calibrated_data::tracker_hit_collection_type& gg_hits = CD.calibrated_tracker_hits();
 
     // Create a handle on some tracker cluster :
-    sdm::tracker_cluster::handle_type hTC0(new sdm::tracker_cluster);
+    sdm::TrackerClusterHdl hTC0(new sdm::tracker_cluster);
     sdm::tracker_cluster& TC0 = hTC0.grab();
     TC0.set_cluster_id(0);
     TC0.make_prompt();
@@ -229,7 +228,7 @@ int main(int argc_, char** argv_) {
     }
 
     // Create another handle on some other tracker cluster :
-    sdm::tracker_cluster::handle_type hTC1(new sdm::tracker_cluster);
+    sdm::TrackerClusterHdl hTC1(new sdm::tracker_cluster);
     sdm::tracker_cluster& TC1 = hTC1.grab();
     TC1.set_cluster_id(1);
     TC1.make_prompt();
@@ -251,7 +250,7 @@ int main(int argc_, char** argv_) {
       draw_gg_cluster(fvisu.grab(), TC1);
     }
 
-    sdm::tracker_clustering_solution::handle_type hTCS0(new sdm::tracker_clustering_solution);
+    sdm::TrackerClusteringSolutionHdl hTCS0(new sdm::tracker_clustering_solution);
     sdm::tracker_clustering_solution& TCS0 = hTCS0.grab();
     TCS0.set_solution_id(0);
     TCS0.get_auxiliaries().store_real("weighting.chi2", 3.2546);

--- a/source/falaise/snemo/test/test_snemo_datamodel_tracker_clustering_data.cxx
+++ b/source/falaise/snemo/test/test_snemo_datamodel_tracker_clustering_data.cxx
@@ -202,7 +202,7 @@ int main(int argc_, char** argv_) {
     auto& TCD = ER.add<sdm::tracker_clustering_data>(snedm::labels::tracker_clustering_data());
 
     // Get a reference to the collection of calibrated Geiger hits from the 'CD' bank :
-    sdm::calibrated_data::tracker_hit_collection_type& gg_hits = CD.calibrated_tracker_hits();
+    sdm::TrackerHitHdlCollection& gg_hits = CD.calibrated_tracker_hits();
 
     // Create a handle on some tracker cluster :
     sdm::TrackerClusterHdl hTC0(new sdm::tracker_cluster);

--- a/source/falaise/snemo/test/test_snemo_datamodel_tracker_clustering_data.cxx
+++ b/source/falaise/snemo/test/test_snemo_datamodel_tracker_clustering_data.cxx
@@ -146,10 +146,10 @@ int main(int argc_, char** argv_) {
     }
 
     // Event record :
-    sdm::event_record ER;
+    snedm::event_record ER;
 
     // Event header bank :
-    auto& EH = ER.add<sdm::event_header>(sdm::data_info::default_event_header_label());
+    auto& EH = ER.add<sdm::event_header>(snedm::labels::event_header());
     EH.set_id(datatools::event_id(666, 345));
     EH.set_timestamp(sdm::timestamp(1268644034, 1204));
     EH.set_generation(sdm::event_header::GENERATION_SIMULATED);
@@ -158,7 +158,7 @@ int main(int argc_, char** argv_) {
     EH.tree_dump(std::clog, "Event header('EH'): ");
 
     // Calibrated data bank :
-    auto& CD = ER.add<sdm::calibrated_data>(sdm::data_info::default_calibrated_data_label());
+    auto& CD = ER.add<sdm::calibrated_data>(snedm::labels::calibrated_data());
     // Populate a collection of handles on Geiger hits :
     for (int i = 0; i < 18; ++i) {
       sdm::calibrated_tracker_hit::handle_type h(new sdm::calibrated_tracker_hit);
@@ -200,7 +200,7 @@ int main(int argc_, char** argv_) {
 
     // Tracker clustering data bank :
     auto& TCD = ER.add<sdm::tracker_clustering_data>(
-        sdm::data_info::default_tracker_clustering_data_label());
+        snedm::labels::tracker_clustering_data());
 
     // Get a reference to the collection of calibrated Geiger hits from the 'CD' bank :
     sdm::calibrated_data::tracker_hit_collection_type& gg_hits = CD.calibrated_tracker_hits();

--- a/source/falaise/snemo/test/test_snemo_datamodel_tracker_clustering_solution.cxx
+++ b/source/falaise/snemo/test/test_snemo_datamodel_tracker_clustering_solution.cxx
@@ -82,7 +82,7 @@ void draw_gg_cluster_item(std::ostream& out_, const sdm::calibrated_tracker_hit&
 
 void draw_gg_cluster(std::ostream& out_, const sdm::tracker_cluster& gg_cluster_,
                      bool enlarged_ = false, bool sep_ = true) {
-  for (const auto& i : gg_cluster_.get_hits()) {
+  for (const auto& i : gg_cluster_.hits()) {
     draw_gg_cluster_item(out_, i.get(), enlarged_);
   }
   if (sep_) {
@@ -184,16 +184,16 @@ int main(int argc_, char** argv_) {
     sdm::tracker_cluster& TC0 = hTC0.grab();
     TC0.set_cluster_id(0);
     TC0.make_prompt();
-    TC0.get_hits().push_back(hits[0]);
-    TC0.get_hits().push_back(hits[1]);
-    TC0.get_hits().push_back(hits[2]);
-    TC0.get_hits().push_back(hits[3]);
-    TC0.get_hits().push_back(hits[4]);
-    TC0.get_hits().push_back(hits[5]);
-    TC0.get_hits().push_back(hits[6]);
-    TC0.get_hits().push_back(hits[7]);
-    TC0.get_hits().push_back(hits[8]);
-    TC0.get_hits().push_back(hits[9]);
+    TC0.hits().push_back(hits[0]);
+    TC0.hits().push_back(hits[1]);
+    TC0.hits().push_back(hits[2]);
+    TC0.hits().push_back(hits[3]);
+    TC0.hits().push_back(hits[4]);
+    TC0.hits().push_back(hits[5]);
+    TC0.hits().push_back(hits[6]);
+    TC0.hits().push_back(hits[7]);
+    TC0.hits().push_back(hits[8]);
+    TC0.hits().push_back(hits[9]);
     TC0.grab_auxiliaries().store("display.color", "blue");
     {
       std::ostringstream title;
@@ -209,12 +209,12 @@ int main(int argc_, char** argv_) {
     sdm::tracker_cluster& TC1 = hTC1.grab();
     TC1.set_cluster_id(1);
     TC1.make_prompt();
-    TC1.get_hits().push_back(hits[10]);
-    TC1.get_hits().push_back(hits[11]);
-    TC1.get_hits().push_back(hits[12]);
-    TC1.get_hits().push_back(hits[13]);
-    TC1.get_hits().push_back(hits[14]);
-    TC1.get_hits().push_back(hits[15]);
+    TC1.hits().push_back(hits[10]);
+    TC1.hits().push_back(hits[11]);
+    TC1.hits().push_back(hits[12]);
+    TC1.hits().push_back(hits[13]);
+    TC1.hits().push_back(hits[14]);
+    TC1.hits().push_back(hits[15]);
     TC1.grab_auxiliaries().store("display.color", "red");
     {
       std::ostringstream title;

--- a/source/falaise/snemo/test/test_snemo_datamodel_tracker_clustering_solution.cxx
+++ b/source/falaise/snemo/test/test_snemo_datamodel_tracker_clustering_solution.cxx
@@ -143,9 +143,9 @@ int main(int argc_, char** argv_) {
     }
 
     // Populate a collection of handles on Geiger hits :
-    sdm::calibrated_tracker_hit::collection_type hits;
+    sdm::TrackerHitHdlCollection hits;
     for (int i = 0; i < 18; ++i) {
-      sdm::calibrated_tracker_hit::handle_type h(new sdm::calibrated_tracker_hit);
+      sdm::TrackerHitHdl h(new sdm::calibrated_tracker_hit);
       sdm::calibrated_tracker_hit& gg_hit = h.grab();
       gg_hit.set_hit_id(i);
       geomtools::geom_id gid;
@@ -180,7 +180,7 @@ int main(int argc_, char** argv_) {
     }
 
     // Create a handle on some tracker cluster :
-    sdm::tracker_cluster::handle_type hTC0(new sdm::tracker_cluster);
+    sdm::TrackerClusterHdl hTC0(new sdm::tracker_cluster);
     sdm::tracker_cluster& TC0 = hTC0.grab();
     TC0.set_cluster_id(0);
     TC0.make_prompt();
@@ -205,7 +205,7 @@ int main(int argc_, char** argv_) {
     }
 
     // Create another handle on some other tracker cluster :
-    sdm::tracker_cluster::handle_type hTC1(new sdm::tracker_cluster);
+    sdm::TrackerClusterHdl hTC1(new sdm::tracker_cluster);
     sdm::tracker_cluster& TC1 = hTC1.grab();
     TC1.set_cluster_id(1);
     TC1.make_prompt();
@@ -225,7 +225,7 @@ int main(int argc_, char** argv_) {
       draw_gg_cluster(fvisu.grab(), TC1);
     }
 
-    sdm::tracker_clustering_solution::handle_type hTCS0(new sdm::tracker_clustering_solution);
+    sdm::TrackerClusteringSolutionHdl hTCS0(new sdm::tracker_clustering_solution);
     sdm::tracker_clustering_solution& TCS0 = hTCS0.grab();
     TCS0.set_solution_id(0);
     TCS0.get_auxiliaries().store("weighting.chi2", 3.2546);

--- a/source/falaise/snemo/test/test_snemo_datamodel_tracker_trajectory.cxx
+++ b/source/falaise/snemo/test/test_snemo_datamodel_tracker_trajectory.cxx
@@ -54,11 +54,11 @@ int main(/* int argc_, char ** argv_ */) {
     sdm::tracker_cluster& TC0 = hTC0.grab();
     TC0.set_cluster_id(0);
     TC0.make_prompt();
-    TC0.get_hits().push_back(hits[0]);
-    TC0.get_hits().push_back(hits[1]);
-    TC0.get_hits().push_back(hits[2]);
-    TC0.get_hits().push_back(hits[3]);
-    TC0.get_hits().push_back(hits[4]);
+    TC0.hits().push_back(hits[0]);
+    TC0.hits().push_back(hits[1]);
+    TC0.hits().push_back(hits[2]);
+    TC0.hits().push_back(hits[3]);
+    TC0.hits().push_back(hits[4]);
     TC0.grab_auxiliaries().store("display.color", "blue");
     {
       std::ostringstream title;
@@ -77,7 +77,7 @@ int main(/* int argc_, char ** argv_ */) {
       hLTP0.reset(LTP);
 
       sdm::tracker_trajectory TJ0;
-      TJ0.set_trajectory_id(0);
+      TJ0.set_id(0);
       TJ0.set_cluster_handle(hTC0);
       TJ0.set_pattern_handle(hLTP0);
       TJ0.grab_auxiliaries().store_flag("test");

--- a/source/falaise/snemo/test/test_snemo_datamodel_tracker_trajectory.cxx
+++ b/source/falaise/snemo/test/test_snemo_datamodel_tracker_trajectory.cxx
@@ -27,9 +27,9 @@ int main(/* int argc_, char ** argv_ */) {
     srand48(314159);
 
     // Populate a collection of handles on Geiger hits :
-    sdm::calibrated_tracker_hit::collection_type hits;
+    sdm::TrackerHitHdlCollection hits;
     for (int i = 0; i < 10; ++i) {
-      sdm::calibrated_tracker_hit::handle_type h(new sdm::calibrated_tracker_hit);
+      sdm::TrackerHitHdl h(new sdm::calibrated_tracker_hit);
       sdm::calibrated_tracker_hit& gg_hit = h.grab();
       gg_hit.set_hit_id(i);
       geomtools::geom_id gid;
@@ -50,7 +50,7 @@ int main(/* int argc_, char ** argv_ */) {
     }
 
     // Create a handle on some tracker cluster :
-    sdm::tracker_cluster::handle_type hTC0(new sdm::tracker_cluster);
+    sdm::TrackerClusterHdl hTC0(new sdm::tracker_cluster);
     sdm::tracker_cluster& TC0 = hTC0.grab();
     TC0.set_cluster_id(0);
     TC0.make_prompt();

--- a/source/falaise/snemo/test/test_snemo_datamodel_tracker_trajectory_solution.cxx
+++ b/source/falaise/snemo/test/test_snemo_datamodel_tracker_trajectory_solution.cxx
@@ -39,7 +39,7 @@ int main(/* int argc_, char ** argv_ */) {
      *************************/
 
     // Populate a collection of handles on Geiger hits :
-    sdm::calibrated_tracker_hit::collection_type hits;
+    sdm::TrackerHitHdlCollection hits;
     for (int i = 0; i < 18; ++i) {
       DATATOOLS_HANDLE_DECLARE_NEW(hgg_hit, sdm::calibrated_tracker_hit);
       DATATOOLS_HANDLE_GRAB_REF(gg_hit, hgg_hit, sdm::calibrated_tracker_hit);

--- a/source/falaise/snemo/test/test_snemo_datamodel_tracker_trajectory_solution.cxx
+++ b/source/falaise/snemo/test/test_snemo_datamodel_tracker_trajectory_solution.cxx
@@ -79,11 +79,11 @@ int main(/* int argc_, char ** argv_ */) {
     // tracker_cluster & TC0 = hTC0.get();
     TC0.set_cluster_id(0);
     TC0.make_prompt();
-    TC0.get_hits().push_back(hits.at(0));
-    TC0.get_hits().push_back(hits.at(1));
-    TC0.get_hits().push_back(hits.at(2));
-    TC0.get_hits().push_back(hits.at(3));
-    TC0.get_hits().push_back(hits.at(4));
+    TC0.hits().push_back(hits.at(0));
+    TC0.hits().push_back(hits.at(1));
+    TC0.hits().push_back(hits.at(2));
+    TC0.hits().push_back(hits.at(3));
+    TC0.hits().push_back(hits.at(4));
     TC0.grab_auxiliaries().store("display.color", "blue");
     {
       std::ostringstream title;
@@ -98,12 +98,12 @@ int main(/* int argc_, char ** argv_ */) {
     // tracker_cluster & TC1 = hTC1.get();
     TC1.set_cluster_id(1);
     TC1.make_prompt();
-    TC1.get_hits().push_back(hits.at(10));
-    TC1.get_hits().push_back(hits.at(11));
-    TC1.get_hits().push_back(hits.at(12));
-    TC1.get_hits().push_back(hits.at(13));
-    TC1.get_hits().push_back(hits.at(14));
-    TC1.get_hits().push_back(hits.at(15));
+    TC1.hits().push_back(hits.at(10));
+    TC1.hits().push_back(hits.at(11));
+    TC1.hits().push_back(hits.at(12));
+    TC1.hits().push_back(hits.at(13));
+    TC1.hits().push_back(hits.at(14));
+    TC1.hits().push_back(hits.at(15));
     TC1.grab_auxiliaries().store("display.color", "red");
     {
       std::ostringstream title;
@@ -149,7 +149,7 @@ int main(/* int argc_, char ** argv_ */) {
     DATATOOLS_HANDLE_GRAB_REF(TJ0, hTJ0, sdm::tracker_trajectory);
     // datatools::utils::handle<sdm::tracker_trajectory> hTJ0(new sdm::tracker_trajectory);
     // tracker_trajectory & TJ0 = hTJ0.get();
-    TJ0.set_trajectory_id(0);
+    TJ0.set_id(0);
     TJ0.set_cluster_handle(hTC0);
     TJ0.set_pattern_handle(hLTP0);
     TJ0.grab_auxiliaries().store_flag("line");
@@ -173,7 +173,7 @@ int main(/* int argc_, char ** argv_ */) {
     DATATOOLS_HANDLE_GRAB_REF(TJ1, hTJ1, sdm::tracker_trajectory);
     // datatools::utils::handle<tracker_trajectory> hTJ1(new sdm::tracker_trajectory);
     // tracker_trajectory & TJ1 = hTJ1.get();
-    TJ1.set_trajectory_id(0);
+    TJ1.set_id(0);
     TJ1.set_cluster_handle(hTC1);
     TJ1.set_pattern_handle(hLTP1);
     TJ1.grab_auxiliaries().store_flag("helix");

--- a/source/flsimulate/flsimulatemain.cc
+++ b/source/flsimulate/flsimulatemain.cc
@@ -298,7 +298,7 @@ falaise::exit_code do_flsimulate(int argc, char *argv[]) {
     // Simulation module:
     mctools::g4::simulation_module flSimModule;
     flSimModule.set_name("G4SimulationModule");
-    std::string sd_label = snemo::datamodel::data_info::default_simulated_data_label();
+    std::string sd_label = snedm::labels::simulated_data();
     std::string geo_label = snemo::service_info::geometryServiceName();
     flSimModule.set_sd_label(sd_label);
     flSimModule.set_geo_label(geo_label);
@@ -354,7 +354,7 @@ falaise::exit_code do_flsimulate(int argc, char *argv[]) {
 
       // Add the event header bank
       auto &eventHeader = workItem.add<snemo::datamodel::event_header>(
-          snemo::datamodel::data_info::default_event_header_label(), "Event Header Bank");
+          snedm::labels::event_header(), "Event Header Bank");
       eventHeader.set_generation(snemo::datamodel::event_header::GENERATION_SIMULATED);
       datatools::event_id eventID{datatools::event_id::ANY_RUN_NUMBER, static_cast<int>(i)};
       eventHeader.set_id(eventID);


### PR DESCRIPTION
This begins work on modernizing the code under `source/falaise/snemo/datamodel`. Main tasks will be:

- Reverse typedefs so that "hit" type classes no longer declare their handle/collection types
- Bump known/identified properties to class attributes for clarity (likely needs a schema version bump, *and* interface change 😠 ....
- Try and move to composition rather than inheritance model where possible

Client modules will also be updated.
