### PR TITLE
WIP: Modernize Event Data Model documentation

### DIFF
--- a/documentation/flreconstruct/PipelineOutput.md
+++ b/documentation/flreconstruct/PipelineOutput.md
@@ -7,6 +7,8 @@ FLReconstruct Pipeline Output {#flreconstructpipelineoutput}
 Introduction {#flreconstructpipelineoutput_introduction}
 ============
 
+Simplify and clarify, probably split into general and specific parts.
+
 The  current  official  reconstruction pipeline  consists  in  several
 steps, each responsible of  the elaboration of additional informations
 stored  in dedicated  banks  in  the event  record.   We  saw in


### PR DESCRIPTION
As discussed in the Analysis Board meeting of the 16th September, the documentation for the Event Data Model should be updated to cover:

1. Basic description, intent, and contents of each type under `snemo::datamodel`
2. Outline the data flow and transforms (e.g. "SD" is transformed to "CD" by the "mock_s2c" module(s)).

Should cover both the page currently at https://supernemo.org/Falaise/flreconstructpipelineoutput.html and the Doxygen markup for the individual classes. The pages relating to writing modules that read/write this data should also be cross-referenced.

This is a WIP PR, so @emchauve, @cherylepatrick please comment anything else you'd like to see (and add any other relevant reviewers!).