### PR TITLE
flvisualize update : event combo box removed

### DIFF
--- a/programs/flvisualize/EventBrowser/status_bar.cc
+++ b/programs/flvisualize/EventBrowser/status_bar.cc
@@ -79,22 +79,28 @@ void status_bar::_at_init_(TGCompositeFrame* main_) {
   main_->AddFrame(main_frame,
                   new TGLayoutHints(kLHintsTop | kLHintsLeft | kLHintsExpandX, 3, 3, 3, 3));
 
-  // A combo box for the events
-  _event_list_ = new TGComboBox(main_frame, STATUS_BAR);
-  _event_list_->Resize(int(0.5 * width), 20);
-  _event_list_->Associate(main_);
-  main_frame->AddFrame(_event_list_, new TGLayoutHints(kLHintsTop | kLHintsLeft, 1, 1, 1, 1));
-
   // Goto event number
-  main_frame->AddFrame(new TGLabel(main_frame, "Goto event"),
+  main_frame->AddFrame(new TGLabel(main_frame, "Event Number :"),
                        new TGLayoutHints(kLHintsTop | kLHintsLeft, 10, 10, 2, 2));
   _goto_event_ = new TGNumberEntryField(main_frame, GOTO_EVENT, 0, TGNumberFormat::kNESInteger,
                                         TGNumberFormat::kNEAPositive);
-  _goto_event_->Resize(int(0.05 * width), 20);
+  _goto_event_->Resize(int(0.1 * width), 20);
   _goto_event_->Associate(main_);
   _goto_event_->Connect("ReturnPressed()", "snemo::visualization::view::status_bar", this,
                         "process()");
   main_frame->AddFrame(_goto_event_, new TGLayoutHints(kLHintsTop | kLHintsLeft, 1, 5, 1, 1));
+
+  // Total event number
+  main_frame->AddFrame(new TGLabel(main_frame, " / "),
+                       new TGLayoutHints(kLHintsTop | kLHintsLeft, 10, 10, 2, 2));
+  _total_event_ = new TGNumberEntryField(main_frame, -1, 0, TGNumberFormat::kNESInteger,
+                                        TGNumberFormat::kNEAPositive);
+  _total_event_->Resize(int(0.1 * width), 20);
+  _total_event_->Associate(main_);
+	_total_event_->SetEnabled(false);
+  _total_event_->Connect("ReturnPressed()", "snemo::visualization::view::status_bar", this,
+                        "process()");
+  main_frame->AddFrame(_total_event_, new TGLayoutHints(kLHintsTop | kLHintsLeft, 1, 5, 1, 1));
 
   // Navigation buttons
   _button_first_ = new TGPictureButton(main_frame, gClient->GetPicture("first_t.xpm"), FIRST_EVENT);
@@ -119,17 +125,9 @@ void status_bar::_at_init_(TGCompositeFrame* main_) {
 }
 
 void status_bar::reset() {
-  io::event_server& server = *_server_;
 
-  // clear list
-  _event_list_->RemoveAll();
-  _event_list_->SetEnabled(true);
-
-  if (!server.is_opened()) {
-    _event_list_->AddEntry(" +++ NO EVENT LOADED +++ ", 0);
-    _event_list_->Select(0);
-    _event_list_->SetEnabled(false);
-  }
+	_goto_event_->SetNumber(0);
+	_total_event_->SetNumber(0);
 
   this->reset_buttons();
 }
@@ -148,10 +146,6 @@ void status_bar::update(const bool reset_, const bool disable_) {
     if (server.has_external_data()) {
       status << " +++ EXTERNAL PROCESSING +++ ";
     }
-    _event_list_->RemoveAll();
-    _event_list_->AddEntry(status.str().c_str(), 0);
-    _event_list_->Select(0);
-    _event_list_->SetEnabled(false);
     _goto_event_->SetEnabled(false);
     return;
   }
@@ -161,21 +155,11 @@ void status_bar::update(const bool reset_, const bool disable_) {
     const io::event_server::event_selection_list_type& event_selection_list =
         server.get_event_selection();
     if (event_selection_list.empty()) {
-      _event_list_->AddEntry(" +++ NO EVENT MATCHED SELECTION +++ ", 0);
-      _event_list_->Select(0);
     } else {
-      for (size_t ievent : event_selection_list) {
-        const size_t total = server.get_number_of_events() - 1;
-        std::ostringstream label;
-        label << "event #" << ievent << "/" << total << " ("
-              << (total > 0 ? int(double(ievent) / total * 100) : 100) << "% complete)";
-        _event_list_->AddEntry(label.str().c_str(), ievent);
-      }
+			_total_event_->SetNumber(server.get_number_of_events()-1);
     }
   }
-
-  _event_list_->SetEnabled(!disable_);
-  _event_list_->Select(server.get_current_event_number());
+	_goto_event_->SetNumber(server.get_current_event_number());
   _goto_event_->SetEnabled(!disable_);
 }
 
@@ -250,7 +234,6 @@ void status_bar::process() {
     DT_LOG_WARNING(options_manager::get_instance().get_logging_priority(),
                    "Event number (#" << a_nbr << ") larger than the total number of events !");
   } else {
-    _event_list_->Select(a_nbr);
     _server_->set_current_event_number(a_nbr);
   }
 }

--- a/programs/flvisualize/EventBrowser/view/status_bar.h
+++ b/programs/flvisualize/EventBrowser/view/status_bar.h
@@ -100,8 +100,8 @@ class status_bar {
 
   io::event_server* _server_;  //!< Event server reference
 
-  TGComboBox* _event_list_;            //!< Event list combo box
   TGNumberEntryField* _goto_event_;    //!< Goto event number box
+  TGNumberEntryField* _total_event_;   //!< Total event number box
   TGPictureButton* _button_first_;     //!< First event button
   TGPictureButton* _button_previous_;  //!< Previous event button
   TGPictureButton* _button_next_;      //!< Next event button


### PR DESCRIPTION
i have deleted the event combo box. when opening a large data file, the generation of all entries in the combo box and browsing through it is slowing down the GUI. Goto event functionnalities is kept. I added the total number of event in read only mode.

status bar **before** :
![flvisualize-before](https://user-images.githubusercontent.com/28624059/67234944-63288a00-f446-11e9-9b36-d2fc70d7b254.png)

status bar **after** :
![flvisualize-after](https://user-images.githubusercontent.com/28624059/67234973-74719680-f446-11e9-8f4a-39942fcf4913.png)
