### PR TITLE
Set install RPATH of EventBrowser plugin to link path

### DIFF
--- a/.travis/ciscript.sh
+++ b/.travis/ciscript.sh
@@ -26,9 +26,22 @@ rm -Rf build && mkdir build
 cd build
 
 # Configure, assuming presence of Ninja tool
-cmake -DCMAKE_PREFIX_PATH="$(brew --prefix);$(brew --prefix qt5-base)" -DFALAISE_ENABLE_TESTING=ON -GNinja $PROJECTDIR
+cmake -DCMAKE_PREFIX_PATH="$(brew --prefix);$(brew --prefix qt5-base)" \
+      -DFALAISE_ENABLE_TESTING=ON \
+      -DCMAKE_INSTALL_LIBDIR=lib \
+      -GNinja \
+      $PROJECTDIR
 # Build using Ninja to auto-parallelize
 ninja
 # Run tests - rerunning any that fail in verbose mode
 ctest || ctest -VV --rerun-failed
+
+# On Linux, check install time behaviour of programs
+if [ `uname` == "Linux" ] ; then
+  DESTDIR=$PWD/test-install ninja install
+  # Print rpaths
+  readelf -d $PWD/test-install/usr/local/lib/Falaise/modules/libFalaise_EventBrowser.so
+  # Execute flvisualize help to be sure...
+  $PWD/test-install/usr/local/bin/flvisualize --help
+fi
 

--- a/programs/flvisualize/EventBrowser/CMakeLists.txt
+++ b/programs/flvisualize/EventBrowser/CMakeLists.txt
@@ -219,6 +219,8 @@ target_link_libraries(Falaise_EventBrowser
   ${Boost_LIBRARIES}
   ${ROOT_LIBRARIES}
   )
+# Because it's loaded, make sure its RPATH can find dependencies
+set_target_properties(Falaise_EventBrowser PROPERTIES INSTALL_RPATH_USE_LINK_PATH 1)
 
 if(APPLE)
   set_target_properties(Falaise_EventBrowser
@@ -228,7 +230,6 @@ endif()
 
 # Install it:
 install(TARGETS Falaise_EventBrowser DESTINATION ${CMAKE_INSTALL_LIBDIR}/Falaise/modules)
-
 # Also have to install the headers for the dictionary so that Cling can use them
 # at Runtime.
 install(FILES ${FalaiseEventBrowserPlugin_DICT_HEADERS}


### PR DESCRIPTION
Transient dependencies may not otherwise be found. Add an install test to Travis to check running and RPATH post-install.

Fixes #166


