### PR TITLE
Make ninja build on Travis verbose

### DIFF
--- a/.travis/ciscript.sh
+++ b/.travis/ciscript.sh
@@ -31,8 +31,8 @@ cmake -DCMAKE_PREFIX_PATH="$(brew --prefix);$(brew --prefix qt5-base)" \
       -DCMAKE_INSTALL_LIBDIR=lib \
       -GNinja \
       $PROJECTDIR
-# Build using Ninja to auto-parallelize
-ninja
+# Build using Ninja to auto-parallelize with verbosity
+ninja -v
 # Run tests - rerunning any that fail in verbose mode
 ctest || ctest -VV --rerun-failed
 


### PR DESCRIPTION
We're seeing some genuine errors and warnings on local builds which *should* have been picked up by the testing. Make the testing build verbose to check flags and any missed warnings.