### PR TITLE
Include <stdexcept> for custom exceptions

### DIFF
--- a/source/falaise/path.h
+++ b/source/falaise/path.h
@@ -1,7 +1,7 @@
 #ifndef FALAISE_PATH_H
 #define FALAISE_PATH_H
 
-#include <exception>
+#include <stdexcept>
 #include <ostream>
 #include <string>
 
@@ -27,7 +27,7 @@ class invalid_path_error : public std::logic_error {
  * explicit paths allowing users to validate that a @ref property_set value
  * is a true path. It is nothing more than a simple holder of the std::string for
  * the absolute path and may be used as:
- * 
+ *
  * ```cpp
  * void configure_me(property_set const& ps) {
  *   auto p = ps.get<falaise::path>("mypath"); // throws if "mypath" is not a path value

--- a/source/falaise/property_set.h
+++ b/source/falaise/property_set.h
@@ -1,7 +1,7 @@
 #ifndef FALAISE_PROPERTY_SET_H
 #define FALAISE_PROPERTY_SET_H
 
-#include <exception>
+#include <stdexcept>
 #include <string>
 #include <vector>
 #include "bayeux/datatools/properties.h"

--- a/source/falaise/quantity.h
+++ b/source/falaise/quantity.h
@@ -3,7 +3,7 @@
 #ifndef FALAISE_QUANTITY_H
 #define FALAISE_QUANTITY_H
 
-#include <exception>
+#include <stdexcept>
 #include "CLHEP/Units/PhysicalConstants.h"
 #include "CLHEP/Units/SystemOfUnits.h"
 #include "bayeux/datatools/units.h"

--- a/source/falaise/snemo/processing/module.h
+++ b/source/falaise/snemo/processing/module.h
@@ -2,7 +2,7 @@
 #ifndef FALAISE_SNEMO_PROCESSING_MODULE_H
 #define FALAISE_SNEMO_PROCESSING_MODULE_H
 
-#include <exception>
+#include <stdexcept>
 #include <type_traits>
 
 #include <bayeux/datatools/properties.h>

--- a/source/falaise/snemo/services/service_handle.h
+++ b/source/falaise/snemo/services/service_handle.h
@@ -3,7 +3,7 @@
 #ifndef SERVICE_HANDLE_HH
 #define SERVICE_HANDLE_HH
 
-#include <exception>
+#include <stdexcept>
 
 #include "bayeux/datatools/service_manager.h"
 #include "falaise/snemo/services/service_traits.h"


### PR DESCRIPTION
Several classes in Falaise implement custom exceptions for their specific failure cases. These exceptions generally inherit from the standard C++ exceptions declared/defined in the `<stdexcept>` header, but the code included the lower level <exception> header. Lack of compiler errors is likely due to transitive inclusion of `<stdexcept>` by other standard headers in more modern compilers.

Include appropriate `<stdexcept>` header directly to ensure correct classes are declared without incorrectly relying on transitive inclusion.