### PR TITLE
Refactor common locator code into common location

### DIFF
--- a/source/falaise/snemo.cmake
+++ b/source/falaise/snemo.cmake
@@ -101,6 +101,7 @@ list(APPEND FalaiseLibrary_SOURCES
   snemo/geometry/locator_plugin.cc
   snemo/geometry/utils.cc
   snemo/geometry/mapped_magnetic_field.cc
+  snemo/geometry/private/categories.h
 
   snemo/processing/event_header_utils_module.cc
   snemo/processing/event_header_utils_module.h

--- a/source/falaise/snemo/geometry/gg_locator.cc
+++ b/source/falaise/snemo/geometry/gg_locator.cc
@@ -21,6 +21,8 @@
 // Ourselves:
 #include <falaise/snemo/geometry/gg_locator.h>
 
+#include "private/categories.h"
+
 // Standard library:
 #include <stdexcept>
 
@@ -33,16 +35,6 @@
 #include <geomtools/box.h>
 #include <geomtools/cylinder.h>
 #include <geomtools/manager.h>
-
-namespace {
-// NB: These must be matched to the entries appearing in the relevant
-// geometry mapping resource files!
-// At present, no clear direction on who has priority here: code or resources
-const char kModuleGIDCategory[] = "module";
-const char kTrackerVolumeGIDCategory[] = "tracker_volume";
-// const char kTrackerLayerGIDCategory[] = "tracker_layer";
-const char kDriftCellGIDCategory[] = "drift_cell_core";
-}  // namespace
 
 namespace snemo {
 
@@ -705,16 +697,16 @@ void gg_locator::construct_() {
   const geomtools::id_mgr &idManager = get_geo_manager().get_id_mgr();
 
   const geomtools::id_mgr::category_info &cellCatInfo =
-      idManager.get_category_info(kDriftCellGIDCategory);
+      idManager.get_category_info(detail::kDriftCellGIDCategory);
   cellGIDType_ = cellCatInfo.get_type();
 
   // The get_subaddress_index member function returns an invalid index
   // rather than throwing an exception. We therefore check the subaddress
   // categories we need upfront...
   for (const std::string &subaddress : {"module", "side", "layer", "row"}) {
-    DT_THROW_IF(
-        !cellCatInfo.has_subaddress(subaddress), std::logic_error,
-        "Category '" << kDriftCellGIDCategory << "' has no subaddress '" << subaddress << "'");
+    DT_THROW_IF(!cellCatInfo.has_subaddress(subaddress), std::logic_error,
+                "Category '" << detail::kDriftCellGIDCategory << "' has no subaddress '"
+                             << subaddress << "'");
   }
 
   moduleAddressIndex_ = cellCatInfo.get_subaddress_index("module");
@@ -724,7 +716,7 @@ void gg_locator::construct_() {
 
   geomMapping_ = &get_geo_manager().get_mapping();
 
-  uint32_t moduleGIDType = idManager.get_category_type(kModuleGIDCategory);
+  uint32_t moduleGIDType = idManager.get_category_type(detail::kModuleGIDCategory);
   const geomtools::geom_id moduleGID(moduleGIDType, moduleNumber_);
   const geomtools::geom_info &moduleGeomInfo = geomMapping_->get_geom_info(moduleGID);
   const geomtools::i_shape_3d *moduleShape = &moduleGeomInfo.get_logical().get_shape();
@@ -734,7 +726,7 @@ void gg_locator::construct_() {
   moduleWorldPlacement_ = &moduleGeomInfo.get_world_placement();
 
   // Search for tracker submodules :
-  uint32_t trackerVolumeGIDType = idManager.get_category_type(kTrackerVolumeGIDCategory);
+  uint32_t trackerVolumeGIDType = idManager.get_category_type(detail::kTrackerVolumeGIDCategory);
   geomtools::geom_id side_gid;
   side_gid.set_type(trackerVolumeGIDType);
   uint32_t ref_side = geomtools::geom_id::INVALID_ADDRESS;

--- a/source/falaise/snemo/geometry/gveto_locator.cc
+++ b/source/falaise/snemo/geometry/gveto_locator.cc
@@ -23,6 +23,8 @@
 // Ourselves:
 #include <falaise/snemo/geometry/gveto_locator.h>
 
+#include "private/categories.h"
+
 // Standard library:
 #include <stdexcept>
 
@@ -36,55 +38,6 @@
 #include <geomtools/intersection_3d.h>
 #include <geomtools/manager.h>
 #include <geomtools/subtraction_3d.h>
-
-namespace {
-// NB: These must be matched to the entries appearing in the relevant
-// geometry mapping resource files!
-// At present, no clear direction on who has priority here: code or resources
-const char kModuleGIDCategory[] = "module";
-const char kTrackerSubmoduleGIDCategory[] = "calorimeter_submodule";
-const char kGammaVetoBlockGIDCategory[] = "gveto_block";
-const char kGammaVetoWrapperGIDCategory[] = "gveto_wrapper";
-
-//! Given the geom_info for a calorimeter block, return the underlying box object
-//  Not entirely clear why this is needed: review what's in resource files...
-const geomtools::box *getBlockBox(const geomtools::geom_info &blockGI) {
-  const geomtools::i_shape_3d *caloBlockShape = &blockGI.get_logical().get_shape();
-  if (caloBlockShape->get_shape_name() == "subtraction_3d") {
-    const auto &ref_s3d = dynamic_cast<const geomtools::subtraction_3d &>(*caloBlockShape);
-    // Example : 'calo_scin_box_model' case :
-    const geomtools::i_composite_shape_3d::shape_type &sht1 = ref_s3d.get_shape1();
-    const geomtools::i_shape_3d &sh1 = sht1.get_shape();
-    DT_THROW_IF(sh1.get_shape_name() != "box", std::logic_error,
-                "Do not support non-box shaped block with ID = " << blockGI.get_geom_id() << " !");
-    return dynamic_cast<const geomtools::box *>(&sh1);
-  }
-
-  if (caloBlockShape->get_shape_name() == "intersection_3d") {
-    // Example : 'calo_tapered_scin_box_model' case :
-    const auto &ref_i3d = dynamic_cast<const geomtools::intersection_3d &>(*caloBlockShape);
-    const geomtools::i_composite_shape_3d::shape_type &sht1 = ref_i3d.get_shape1();
-    const geomtools::i_shape_3d &sh1 = sht1.get_shape();
-    DT_THROW_IF(sh1.get_shape_name() != "subtraction_3d", std::logic_error,
-                "Do not support non-subtraction_3d shaped block with ID = " << blockGI.get_geom_id()
-                                                                            << " !");
-    const auto &ref_s3d = dynamic_cast<const geomtools::subtraction_3d &>(sh1);
-    const geomtools::i_composite_shape_3d::shape_type &sht11 = ref_s3d.get_shape1();
-    const geomtools::i_shape_3d &sh11 = sht11.get_shape();
-    DT_THROW_IF(sh11.get_shape_name() != "box", std::logic_error,
-                "Do not support non-box shaped block with ID = " << blockGI.get_geom_id() << " !");
-    return dynamic_cast<const geomtools::box *>(&sh11);
-  }
-
-  if (caloBlockShape->get_shape_name() == "box") {
-    // Simple box case :
-    return dynamic_cast<const geomtools::box *>(caloBlockShape);
-  }
-
-  return nullptr;
-}
-
-}  // namespace
 
 namespace snemo {
 
@@ -831,22 +784,23 @@ void gveto_locator::construct_() {
   geomMapping_ = &get_geo_manager().get_mapping();
   const geomtools::id_mgr &idManager = get_geo_manager().get_id_mgr();
 
-  const uint32_t moduleGIDType = idManager.get_category_type(kModuleGIDCategory);
+  const uint32_t moduleGIDType = idManager.get_category_type(detail::kModuleGIDCategory);
   const uint32_t trackerSubmoduleGIDType =
-      idManager.get_category_type(kTrackerSubmoduleGIDCategory);
-  const uint32_t gvetoWrapperGIDType = idManager.get_category_type(kGammaVetoWrapperGIDCategory);
+      idManager.get_category_type(detail::kTrackerSubmoduleGIDCategory);
+  const uint32_t gvetoWrapperGIDType =
+      idManager.get_category_type(detail::kGammaVetoWrapperGIDCategory);
 
-  caloBlockGIDType_ = idManager.get_category_type(kGammaVetoBlockGIDCategory);
+  caloBlockGIDType_ = idManager.get_category_type(detail::kGammaVetoBlockGIDCategory);
   const geomtools::id_mgr::category_info &block_ci =
-      idManager.get_category_info(kGammaVetoBlockGIDCategory);
+      idManager.get_category_info(detail::kGammaVetoBlockGIDCategory);
 
   // The get_subaddress_index member function returns an invalid index
   // rather than throwing an exception. We therefore check the subaddress
   // categories we need upfront...
   for (const std::string &subaddress : {"module", "side", "wall", "column"}) {
-    DT_THROW_IF(
-        !block_ci.has_subaddress(subaddress), std::logic_error,
-        "Category '" << kGammaVetoBlockGIDCategory << "' has no subaddress '" << subaddress << "'");
+    DT_THROW_IF(!block_ci.has_subaddress(subaddress), std::logic_error,
+                "Category '" << detail::kGammaVetoBlockGIDCategory << "' has no subaddress '"
+                             << subaddress << "'");
   }
 
   moduleAddressIndex_ = block_ci.get_subaddress_index("module");
@@ -902,7 +856,7 @@ void gveto_locator::construct_() {
     }
 
     const geomtools::geom_info &blockBoxGeomInfo = geomMapping_->get_geom_info(caloBlockBoxGID);
-    caloBlockBox_ = getBlockBox(blockBoxGeomInfo);
+    caloBlockBox_ = detail::getBlockBox(blockBoxGeomInfo);
     DT_THROW_IF(caloBlockBox_ == nullptr, std::logic_error,
                 "Cannot extract the shape from block with ID = " << caloBlockBoxGID << " !");
   }

--- a/source/falaise/snemo/geometry/private/categories.h
+++ b/source/falaise/snemo/geometry/private/categories.h
@@ -1,0 +1,79 @@
+#ifndef FALAISE_SNEMO_GEOMETRY_DETAIL_CATEGORIES_H
+#define FALAISE_SNEMO_GEOMETRY_DETAIL_CATEGORIES_H
+
+#include <geomtools/box.h>
+#include <geomtools/geom_info.h>
+#include <geomtools/i_composite_shape_3d.h>
+#include <geomtools/intersection_3d.h>
+#include <geomtools/subtraction_3d.h>
+
+namespace snemo {
+namespace geometry {
+namespace detail {
+
+// NB: These must be matched to the entries appearing in the relevant
+// geometry mapping resource files!
+// At present, no clear direction on who has priority here: code or resources
+const char kModuleGIDCategory[] = "module";
+
+// Veto Calorimeters
+const char kTrackerSubmoduleGIDCategory[] = "calorimeter_submodule";
+const char kGammaVetoBlockGIDCategory[] = "gveto_block";
+const char kGammaVetoWrapperGIDCategory[] = "gveto_wrapper";
+
+// Calorimeter
+const char kCaloSubmoduleGIDCategory[] = "calorimeter_submodule";
+const char kCaloBlockGIDCategory[] = "calorimeter_block";
+const char kCaloWrapperGIDCategory[] = "calorimeter_wrapper";
+
+// XWall Calorimter
+// const char kTrackerSubmoduleGIDCategory[] = "calorimeter_submodule";
+const char kXCaloBlockGIDCategory[] = "xcalo_block";
+const char kXCaloWrapperGIDCategory[] = "xcalo_wrapper";
+
+// Tracker
+const char kTrackerVolumeGIDCategory[] = "tracker_volume";
+// const char kTrackerLayerGIDCategory[] = "tracker_layer";
+const char kDriftCellGIDCategory[] = "drift_cell_core";
+
+//! Given the geom_info for a calorimeter block, return the underlying box object
+//  Not entirely clear why this is needed: review what's in resource files...
+inline const geomtools::box *getBlockBox(const geomtools::geom_info &blockGI) {
+  const geomtools::i_shape_3d *caloBlockShape = &blockGI.get_logical().get_shape();
+  if (caloBlockShape->get_shape_name() == "subtraction_3d") {
+    const auto &ref_s3d = dynamic_cast<const geomtools::subtraction_3d &>(*caloBlockShape);
+    // Example : 'calo_scin_box_model' case :
+    const geomtools::i_composite_shape_3d::shape_type &sht1 = ref_s3d.get_shape1();
+    const geomtools::i_shape_3d &sh1 = sht1.get_shape();
+    DT_THROW_IF(sh1.get_shape_name() != "box", std::logic_error,
+                "Do not support non-box shaped block with ID = " << blockGI.get_geom_id() << " !");
+    return dynamic_cast<const geomtools::box *>(&sh1);
+  }
+
+  if (caloBlockShape->get_shape_name() == "intersection_3d") {
+    // Example : 'calo_tapered_scin_box_model' case :
+    const auto &ref_i3d = dynamic_cast<const geomtools::intersection_3d &>(*caloBlockShape);
+    const geomtools::i_composite_shape_3d::shape_type &sht1 = ref_i3d.get_shape1();
+    const geomtools::i_shape_3d &sh1 = sht1.get_shape();
+    DT_THROW_IF(sh1.get_shape_name() != "subtraction_3d", std::logic_error,
+                "Do not support non-subtraction_3d shaped block with ID = " << blockGI.get_geom_id()
+                                                                            << " !");
+    const auto &ref_s3d = dynamic_cast<const geomtools::subtraction_3d &>(sh1);
+    const geomtools::i_composite_shape_3d::shape_type &sht11 = ref_s3d.get_shape1();
+    const geomtools::i_shape_3d &sh11 = sht11.get_shape();
+    DT_THROW_IF(sh11.get_shape_name() != "box", std::logic_error,
+                "Do not support non-box shaped block with ID = " << blockGI.get_geom_id() << " !");
+    return dynamic_cast<const geomtools::box *>(&sh11);
+  }
+
+  if (caloBlockShape->get_shape_name() == "box") {
+    // Simple box case :
+    return dynamic_cast<const geomtools::box *>(caloBlockShape);
+  }
+  return nullptr;
+}
+}  // namespace detail
+}  // namespace geometry
+}  // namespace snemo
+
+#endif


### PR DESCRIPTION
This completes the initial simplification of geometry locators in Falaise. Constants and a function common across those for the tracker and calorimeter(s) have been pulled out into a private header (i.e. not installed) under a `detail` namespace.

This is a pure restructure and there should be no changes in functionality.