### PR TITLE
Simplify flsimulate metadata handling

### DIFF
--- a/documentation/flsimulate/FLSimulate.md
+++ b/documentation/flsimulate/FLSimulate.md
@@ -94,12 +94,6 @@ Options:
                                        Examples:
                                          -c "simu.conf"
                                          -c "${WORKER_DIR}/config/simu1.conf"
-  -m [ --output-metadata-file ] file   file in which to store metadata
-                                       Example:
-                                         -m "simu.meta"
-  -E [ --embedded-metadata ] flag (=1) flag to (de)activate recording of
-                                       metadata in the simulation results
-                                       output file
   -o [ --output-file ] file            file in which to store simulation
                                        results
                                        Examples:
@@ -1160,18 +1154,13 @@ Note also that FLSimulate automatically computes some metadata besides
 the simulated events.  These metadata are stored by default within the
 output data file itself.  These metadata  can be reused in the context
 of  the  data reconstruction  or  other  analysis  tools. It  is  also
-possible  to  save the  metadata  container  within a  human  readable
-companion file  (using the `datatools::multi_properties` format) using
-the `--output-metadata-file` switch. Example:
+possible to dump the metadata stored in a Falaise `.brio` file using
+the `brio_file_dumper` program, e.g.
 
 ~~~~~
-$ flsimulate -c simu.conf -o example.brio --output-metadata-file example.meta
+$ brio_file_dumper -f example.brio
 ...
 ~~~~~
-
-In case the user  does not choose to store the  metadata in the output
-data  file and  no  explicit  external metadata  file  is selected,  a
-default one is generated with name `__flsimulate-metadata.log`.
 
 Output metadata {#usingflsimulate_outputmetadata}
 ===============
@@ -1184,12 +1173,8 @@ simulation, digitization,  variants, services...) in the  same way the
 configuration script is organized. This  enables the off line check of
 the simulation parameters.
 
-As mentionned above,  metadata is saved by default in  the output data
-file, through some kind of header (XML) or parallel branch (BRIO).  If
-asked on  the command line (`-m`  or `--output-metadata-file` switch),
-FLSimulate also saves metadata using the `datatools::multi_properties`
-format   in   an   external   companion   file   (default   name   is:
-`__flsimulate-metadata.log`).
+As mentionned above,  metadata is saved by in  the output data
+file, through some kind of header (XML) or parallel branch (BRIO).
 
 User profiles {#usingflsimulate_userprofiles}
 =============

--- a/programs/CMakeLists.txt
+++ b/programs/CMakeLists.txt
@@ -4,6 +4,8 @@ add_subdirectory(flsimulate)
 add_subdirectory(flreconstruct)
 add_subdirectory(fltags)
 
+add_subdirectory(brio_file_dumper)
+
 # - To allow modules to be developed independently, point
 # them to the current Bayeux/Falaise
 # To be replaced with the "Falaise::Falaise + overidden find_package" trick

--- a/programs/brio_file_dumper/CMakeLists.txt
+++ b/programs/brio_file_dumper/CMakeLists.txt
@@ -1,0 +1,29 @@
+add_executable(brio_file_dumper brio_file_dumper.cc)
+
+target_link_libraries(brio_file_dumper PRIVATE
+  Falaise
+  Bayeux::Bayeux
+  Boost::program_options)
+
+target_clang_format(brio_file_dumper)
+
+ # - Ensure link to internal and external deps
+set_target_properties(brio_file_dumper PROPERTIES INSTALL_RPATH_USE_LINK_PATH 1)
+
+if(UNIX AND NOT APPLE)
+  set_target_properties(brio_file_dumper
+    PROPERTIES INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
+    )
+elseif(APPLE)
+  # Temporary setting - needs testing
+  set_target_properties(brio_file_dumper
+    PROPERTIES
+      INSTALL_RPATH "@loader_path/../${CMAKE_INSTALL_LIBDIR}"
+    )
+endif()
+
+# - Install
+install(TARGETS brio_file_dumper
+  EXPORT FalaiseTargets
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  )

--- a/programs/brio_file_dumper/brio_file_dumper.cc
+++ b/programs/brio_file_dumper/brio_file_dumper.cc
@@ -1,0 +1,83 @@
+#include <iostream>
+
+// Third Party
+// - Bayeux
+#include "bayeux/brio/reader.h"
+#include "bayeux/datatools/multi_properties.h"
+#include "bayeux/datatools/properties.h"
+
+// - Boost
+#include "boost/program_options.hpp"
+
+// To be refactored
+// This is essentially the "schema" for Falaise BRIO files, so should
+// be an interface/defined in the core library
+namespace {
+std::string const GI_STORE{"GI"};
+std::string const ER_STORE{"ER"};
+}  // namespace
+
+void do_dump_metadata(const std::string& path, std::ostream& os) {
+  brio::reader brioFile;
+  brioFile.open(path);
+  datatools::properties p;
+  datatools::multi_properties inputMP;
+  std::size_t entry{0};
+
+  // The basic loop to extract the full metadata record into a multi_propertie object
+  while (brioFile.has_next(GI_STORE)) {
+    brioFile.load(p, GI_STORE, entry);
+    std::string key{p.fetch_string("__dpp.io.metadata.key")};
+    std::string meta{p.fetch_string("__dpp.io.metadata.meta")};
+    p.clean("__dpp.io.metadata.key");
+    p.clean("__dpp.io.metadata.meta");
+    p.clean("__dpp.io.metadata.rank");
+    inputMP.add(key, meta, p);
+    ++entry;
+  }
+
+  datatools::multi_properties::config w;
+  w.write(os, inputMP);
+}
+
+int main(int argc, char* argv[]) {
+  std::string inputFile{};
+
+  namespace bpo = boost::program_options;
+  bpo::options_description optDesc("Options");
+  // clang-format off
+  optDesc.add_options()
+    ("help,h", "print this help message")
+    ("input-file,f", bpo::value<std::string>(&inputFile)->value_name("file"),
+      "BRIO file from which to read information");
+  // clang-format on
+
+  // - Parse...
+  bpo::variables_map vMap;
+  try {
+    bpo::store(bpo::parse_command_line(argc, argv, optDesc), vMap);
+    bpo::notify(vMap);
+  } catch (const std::exception& e) {
+    std::cerr << "[OptionsException] " << e.what() << std::endl;
+    return 1;
+  }
+
+  // Handle any non-bound options
+  if (vMap.count("help") != 0u) {
+    std::cout << "Usage:\n"
+              << "  brio_file_dumper [options]\n\n"
+              << optDesc << "\n";
+  }
+
+  // Actions (only one for now)
+  if (!inputFile.empty()) {
+    try {
+      do_dump_metadata(inputFile, std::cout);
+    } catch (const std::exception& e) {
+      std::cerr << e.what() << std::endl;
+      return 1;
+    }
+  }
+
+  return 0;
+}

--- a/programs/flsimulate/FLSimulateArgs.cc
+++ b/programs/flsimulate/FLSimulateArgs.cc
@@ -113,13 +113,7 @@ void do_configure(int argc, char* argv[], FLSimulateArgs& flSimParameters) {
                   "Cannot parse directory mount directive '" << mountDirective << "' : " << errMsg);
       if (theTopic.empty()) {
         theTopic = datatools::library_info::default_topic_label();
-        DT_LOG_DEBUG(flSimParameters.logLevel,
-                     "Using default path registration topic: " << theTopic);
       }
-      DT_LOG_DEBUG(flSimParameters.logLevel, "Path registration: " << mountDirective);
-      DT_LOG_DEBUG(flSimParameters.logLevel, "  Library name : " << theLibname);
-      DT_LOG_DEBUG(flSimParameters.logLevel, "  Topic        : " << theTopic);
-      DT_LOG_DEBUG(flSimParameters.logLevel, "  Path         : " << thePath);
       try {
         dtklLibInfo.path_registration(theLibname, theTopic, thePath, false);
       } catch (std::exception& error) {
@@ -135,10 +129,6 @@ void do_configure(int argc, char* argv[], FLSimulateArgs& flSimParameters) {
     std::string configScript = args.configScript;
     datatools::fetch_path_with_env(configScript);
     flSimConfig.read(configScript);
-    DT_LOG_DEBUG(flSimParameters.logLevel, "Simulation Configuration:");
-    if (datatools::logger::is_debug(flSimParameters.logLevel)) {
-      flSimConfig.tree_dump(std::cerr, "", "[debug] ");
-    }
 
     // Now extract and bind values as needed
     // Caution: some parameters are only available for specific user profile
@@ -164,9 +154,6 @@ void do_configure(int argc, char* argv[], FLSimulateArgs& flSimParameters) {
       // Simulation setup URN:
       flSimParameters.simulationSetupUrn =
           simSubsystem.get<std::string>("simulationSetupUrn", flSimParameters.simulationSetupUrn);
-
-      DT_LOG_DEBUG(flSimParameters.logLevel,
-                   "flSimParameters.simulationSetupUrn=" << flSimParameters.simulationSetupUrn);
 
       // Simulation manager main configuration file:
       if (flSimParameters.userProfile == "production" &&
@@ -318,7 +305,6 @@ void do_configure(int argc, char* argv[], FLSimulateArgs& flSimParameters) {
 }
 
 void do_postprocess(FLSimulateArgs& flSimParameters) {
-  DT_LOG_TRACE_ENTERING(flSimParameters.logLevel);
   datatools::kernel& dtk = datatools::kernel::instance();
   const datatools::urn_query_service& dtkUrnQuery = dtk.get_urn_query();
 
@@ -452,22 +438,14 @@ void do_postprocess(FLSimulateArgs& flSimParameters) {
                                         << flSimParameters.variantSubsystemParams.profile_load
                                         << "'!");
   } else {
-    DT_LOG_DEBUG(flSimParameters.logLevel, "No variant profile is set.");
     if (flSimParameters.variantProfileUrn.empty()) {
-      DT_LOG_DEBUG(flSimParameters.logLevel, "No variant profile URN is set.");
       // No variant profile URN is set:
       if (simSetupUrnInfo.is_valid()) {
-        DT_LOG_DEBUG(flSimParameters.logLevel,
-                     "Trying to find a default one from the current simulation setup...");
         // Try to find a default one from the current variant setup:
         if (simSetupUrnInfo.has_topic("defvarprofile") &&
             simSetupUrnInfo.get_components_by_topic("defvarprofile").size() == 1) {
           // If the simulation setup URN implies a "services" component, fetch it!
           flSimParameters.variantProfileUrn = simSetupUrnInfo.get_component("defvarprofile");
-          DT_LOG_DEBUG(flSimParameters.logLevel, "Using the default variant profile '"
-                                                     << flSimParameters.variantProfileUrn << "'"
-                                                     << " associated to simulation setup '"
-                                                     << simSetupUrnInfo.get_urn() << "'.");
         }
       }
     }

--- a/programs/flsimulate/FLSimulateArgs.cc
+++ b/programs/flsimulate/FLSimulateArgs.cc
@@ -44,7 +44,6 @@ FLSimulateArgs FLSimulateArgs::makeDefault() {
   params.userProfile = "normal";
   params.numberOfEvents = 1;
   params.doSimulation = true;
-  params.doDigitization = false;
   // Identification of the experimental setup:
   params.experimentalSetupUrn = "";
 
@@ -178,10 +177,6 @@ void do_configure(int argc, char* argv[], FLSimulateArgs& flSimParameters) {
       // Do simulation:
       flSimParameters.doSimulation =
           baseSystem.get<bool>("doSimulation", flSimParameters.doSimulation);
-
-      // Do digitization:
-      flSimParameters.doDigitization =
-          baseSystem.get<bool>("doDigitization", flSimParameters.doDigitization);
     }
 
     // Simulation subsystem:
@@ -280,12 +275,6 @@ void do_configure(int argc, char* argv[], FLSimulateArgs& flSimParameters) {
       flSimParameters.simulationManagerParams.prng_states_save_modulo = simSubsystem.get<int>(
           "rngStateModuloEvents", flSimParameters.simulationManagerParams.prng_states_save_modulo);
     }
-
-    // Digitization subsystem:
-    // if (flSimConfig.has_key_with_meta("flsimulate.digitization", "flsimulate::section")) {
-    //  datatools::properties digiSubsystem = flSimConfig.get_section("flsimulate.digitization");
-    // Bind properties in this section to the relevant ones in params:
-    //}
 
     // Variants subsystem:
     if (flSimConfig.has_key_with_meta("flsimulate.variantService", "flsimulate::section")) {
@@ -569,15 +558,12 @@ void FLSimulateArgs::print(std::ostream& out_) const {
   out_ << tag << "userProfile                = " << userProfile << std::endl;
   out_ << tag << "numberOfEvents             = " << numberOfEvents << std::endl;
   out_ << tag << "doSimulation               = " << std::boolalpha << doSimulation << std::endl;
-  out_ << tag << "doDigitization             = " << std::boolalpha << doDigitization << std::endl;
   out_ << tag << "experimentalSetupUrn       = " << experimentalSetupUrn << std::endl;
   out_ << tag << "simulationSetupUrn         = " << simulationSetupUrn << std::endl;
   out_ << tag << "simulationSetupConfig      = " << simulationManagerParams.manager_config_filename
        << std::endl;
   out_ << tag << "saveRngSeeding             = " << std::boolalpha << saveRngSeeding << std::endl;
   out_ << tag << "rngSeeding                 = " << rngSeeding << std::endl;
-  out_ << tag << "digitizationSetupUrn       = "
-       << (digitizationSetupUrn.empty() ? "<not used>" : digitizationSetupUrn) << std::endl;
   out_ << tag << "variantConfigUrn           = " << variantConfigUrn << std::endl;
   out_ << tag << "variantProfileUrn          = " << variantProfileUrn << std::endl;
   out_ << tag << "variantSubsystemParams     = " << variantSubsystemParams.config_filename

--- a/programs/flsimulate/FLSimulateArgs.cc
+++ b/programs/flsimulate/FLSimulateArgs.cc
@@ -37,7 +37,6 @@ FLSimulateArgs FLSimulateArgs::makeDefault() {
   params.logLevel = datatools::logger::PRIO_ERROR;
   params.userProfile = "normal";
   params.numberOfEvents = 1;
-  params.doSimulation = true;
   // Identification of the experimental setup:
   params.experimentalSetupUrn = "";
 
@@ -155,10 +154,6 @@ void do_configure(int argc, char* argv[], FLSimulateArgs& flSimParameters) {
       // Printing rate for events:
       flSimParameters.simulationManagerParams.number_of_events_modulo = baseSystem.get<int>(
           "moduloEvents", flSimParameters.simulationManagerParams.number_of_events_modulo);
-
-      // Do simulation:
-      flSimParameters.doSimulation =
-          baseSystem.get<bool>("doSimulation", flSimParameters.doSimulation);
     }
 
     // Simulation subsystem:
@@ -521,7 +516,6 @@ void FLSimulateArgs::print(std::ostream& out_) const {
        << std::endl;
   out_ << tag << "userProfile                = " << userProfile << std::endl;
   out_ << tag << "numberOfEvents             = " << numberOfEvents << std::endl;
-  out_ << tag << "doSimulation               = " << std::boolalpha << doSimulation << std::endl;
   out_ << tag << "experimentalSetupUrn       = " << experimentalSetupUrn << std::endl;
   out_ << tag << "simulationSetupUrn         = " << simulationSetupUrn << std::endl;
   out_ << tag << "simulationSetupConfig      = " << simulationManagerParams.manager_config_filename

--- a/programs/flsimulate/FLSimulateArgs.cc
+++ b/programs/flsimulate/FLSimulateArgs.cc
@@ -65,7 +65,6 @@ FLSimulateArgs FLSimulateArgs::makeDefault() {
   params.variantConfigUrn = "";
   params.variantProfileUrn = "";
   params.variantSubsystemParams.config_filename = "";
-  params.saveVariantSettings = true;
 
   // Service support:
   params.servicesSubsystemConfigUrn = "";
@@ -314,20 +313,7 @@ void do_postprocess(FLSimulateArgs& flSimParameters) {
 
   if (flSimParameters.simulationSetupUrn.empty()) {
     // Check for hardcoded path to the main simulation setup configuration file:
-    if (!flSimParameters.simulationManagerParams.manager_config_filename.empty()) {
-      // Only for 'expert' of 'normal' user profiles.
-
-      // Variant configuration:
-      if (flSimParameters.variantSubsystemParams.config_filename.empty()) {
-        DT_LOG_WARNING(flSimParameters.logLevel, "No variant configuration file is provided!");
-      }
-
-      // Services configuration:
-      if (flSimParameters.servicesSubsystemConfig.empty()) {
-        DT_LOG_WARNING(flSimParameters.logLevel, "No services configuration file is provided!");
-      }
-
-    } else {
+    if (flSimParameters.simulationManagerParams.manager_config_filename.empty()) {
       DT_THROW(std::logic_error, "Missing simulation setup configuration file!");
     }
   }
@@ -464,21 +450,6 @@ void do_postprocess(FLSimulateArgs& flSimParameters) {
     }
   }
 
-  if (flSimParameters.variantSubsystemParams.config_filename.empty()) {
-    DT_LOG_WARNING(flSimParameters.logLevel, "No variant configuration is provided.");
-  } else {
-    if (flSimParameters.variantSubsystemParams.profile_load.empty()) {
-      DT_LOG_WARNING(flSimParameters.logLevel, "No variant profile is provided.");
-    } else {
-      // Additional variants settings may be allowed but *must* be compatible
-      // with selected variants config and optional variants profile.
-    }
-  }
-
-  if (flSimParameters.servicesSubsystemConfig.empty()) {
-    DT_LOG_WARNING(flSimParameters.logLevel, "No services configuration is provided.");
-  }
-
   // Print:
   if (datatools::logger::is_debug(flSimParameters.logLevel)) {
     flSimParameters.print(std::cerr);
@@ -502,8 +473,6 @@ void FLSimulateArgs::print(std::ostream& out_) const {
   out_ << tag << "variantConfigUrn           = " << variantConfigUrn << std::endl;
   out_ << tag << "variantProfileUrn          = " << variantProfileUrn << std::endl;
   out_ << tag << "variantSubsystemParams     = " << variantSubsystemParams.config_filename
-       << std::endl;
-  out_ << tag << "saveVariantSettings        = " << std::boolalpha << saveVariantSettings
        << std::endl;
   out_ << tag << "servicesSubsystemConfigUrn = " << servicesSubsystemConfigUrn << std::endl;
   out_ << tag << "servicesSubsystemConfig    = " << servicesSubsystemConfig << std::endl;

--- a/programs/flsimulate/FLSimulateArgs.h
+++ b/programs/flsimulate/FLSimulateArgs.h
@@ -34,8 +34,6 @@ struct FLSimulateArgs {
   std::vector<std::string> mountPoints;  //!< Directory mount directives
   unsigned int numberOfEvents;           //!< Number of events to be processed in the pipeline
 
-  bool doSimulation;                 //!< Simulation flag
-  bool doDigitization;               //!< Digitization flag
   std::string experimentalSetupUrn;  //!< The URN of the experimental setup (possibly extracted from
                                      //!< the simulation setup)
 

--- a/programs/flsimulate/FLSimulateArgs.h
+++ b/programs/flsimulate/FLSimulateArgs.h
@@ -56,9 +56,6 @@ struct FLSimulateArgs {
   std::string servicesSubsystemConfig;     //!< The main configuration file for the service manager
 
   // Simulation control:
-  std::string outputMetadataFile;  //!< Output metadata file
-  bool embeddedMetadata;           //!< Flag to embed metadata in the output data file
-  bool saveRngSeeding;             //!< Flag to save PRNG seeds in metadata
   std::string rngSeeding;          //!< PRNG seed initialization
   std::string outputFile;          //!< Output data file for the output module
 
@@ -69,9 +66,6 @@ struct FLSimulateArgs {
 
   // Print:
   void print(std::ostream &) const;
-
-  // Return the default file for output metadata
-  static const std::string &default_file_for_output_metadata();
 
   // Return the default file output metadata file
   static const std::string &default_file_for_seeds();

--- a/programs/flsimulate/FLSimulateArgs.h
+++ b/programs/flsimulate/FLSimulateArgs.h
@@ -44,9 +44,6 @@ struct FLSimulateArgs {
   mctools::g4::manager_parameters
       simulationManagerParams;  //!< Parameters for the Geant4 simulation manager
 
-  // Digitization module setup:
-  std::string digitizationSetupUrn;  //!< The URN of the digitization module setup
-
   // Variants support:
   std::string variantConfigUrn;   //!< Variants configuration URN
   std::string variantProfileUrn;  //!< Variants profile URN

--- a/programs/flsimulate/FLSimulateArgs.h
+++ b/programs/flsimulate/FLSimulateArgs.h
@@ -45,7 +45,6 @@ struct FLSimulateArgs {
   // Variants support:
   std::string variantConfigUrn;   //!< Variants configuration URN
   std::string variantProfileUrn;  //!< Variants profile URN
-  bool saveVariantSettings;       //!< Flag to save effective variant settings in metadata
   datatools::configuration::variant_service::config
       variantSubsystemParams;  //!< Variants configuration parameters
 

--- a/programs/flsimulate/FLSimulateCommandLine.cc
+++ b/programs/flsimulate/FLSimulateCommandLine.cc
@@ -24,8 +24,6 @@ FLSimulateCommandLine FLSimulateCommandLine::makeDefault() {
   FLSimulateCommandLine flClarg;
   flClarg.logLevel = datatools::logger::PRIO_ERROR;
   flClarg.configScript = "";
-  flClarg.outputMetadataFile = "";
-  flClarg.embeddedMetadata = true;
   flClarg.outputFile = "";
   flClarg.userProfile = "normal";
   return flClarg;
@@ -139,21 +137,12 @@ void do_cldialog(int argc, char* argv[], FLSimulateCommandLine& clArgs) {
       "Example: \n"
       "  -d \"nemoprod@/etc/nemoprod/config\" \n"
       "  -d \"nemoprod.data@/data/nemoprod/runs\"")
-    
+
     ("config,c", bpo::value<std::string>(&clArgs.configScript)->value_name("file"),
       "configuration script for simulation\n"
       "Examples: \n"
       "  -c \"simu.conf\" \n"
       "  -c \"${WORKER_DIR}/config/simu1.conf\"")
-
-    ("output-metadata-file,m", bpo::value<std::string>(&clArgs.outputMetadataFile)->value_name("file"),
-      "file in which to store metadata\n"
-      "Example:\n"
-      "  -m \"simu.meta\"")
-
-    ("embedded-metadata,E", bpo::value<bool>(&clArgs.embeddedMetadata)->value_name("flag")->default_value(true),
-      "flag to (de)activate recording of metadata in the "
-      "simulation results output file")
 
     ("output-file,o", bpo::value<std::string>(&clArgs.outputFile)->required()->value_name("file"),
       "file in which to store simulation results\n"

--- a/programs/flsimulate/FLSimulateCommandLine.h
+++ b/programs/flsimulate/FLSimulateCommandLine.h
@@ -34,8 +34,6 @@ struct FLSimulateCommandLine {
   std::string userProfile;               //!< User profile
   std::vector<std::string> mountPoints;  //!< Directory mount directives
   std::string configScript;              //!< Path to configuration script
-  std::string outputMetadataFile;        //!< Path for saving metadata
-  bool embeddedMetadata;                 //!< Flag to embed metadata in the output data file
   std::string outputFile;                //!< Path for the output module
   static FLSimulateCommandLine makeDefault();
 };

--- a/programs/flsimulate/flsimulatecfgmain.cc
+++ b/programs/flsimulate/flsimulatecfgmain.cc
@@ -375,20 +375,13 @@ void do_configure(int argc, char* argv[], FLSimulateConfigureParams& params) {
   // No variant profile is set:
   if (params.variantServiceConfig.profile_load.empty()) {
     if (params.inputVariantProfileUrn.empty()) {
-      DT_LOG_DEBUG(params.logLevel, "No input variant profile URN is set.");
       // No variant profile URN is set:
       if (simSetupUrnInfo.is_valid()) {
-        DT_LOG_DEBUG(params.logLevel,
-                     "Trying to find a default one from the current simulation setup...");
         // Try to find a default one from the current variant setup:
         if (simSetupUrnInfo.has_topic("defvarprofile") &&
             simSetupUrnInfo.get_components_by_topic("defvarprofile").size() == 1) {
           // If the simulation setup URN implies a "services" component, fetch it!
           params.inputVariantProfileUrn = simSetupUrnInfo.get_component("defvarprofile");
-          DT_LOG_DEBUG(params.logLevel, "Using the default variant profile '"
-                                            << params.inputVariantProfileUrn << "'"
-                                            << " associated to simulation setup '"
-                                            << simSetupUrnInfo.get_urn() << "'.");
         }
       }
     }
@@ -405,20 +398,6 @@ void do_configure(int argc, char* argv[], FLSimulateConfigureParams& params) {
       params.variantServiceConfig.profile_load = conf_variantsProfile_path;
     }
   }
-
-  DT_THROW_IF(params.variantServiceConfig.profile_load.empty(), std::logic_error,
-              "No variant service input profile path is set!");
-
-  DT_LOG_DEBUG(params.logLevel,
-               "Simulation setup tag      : [" << params.simulationSetupUrn << ']');
-  DT_LOG_DEBUG(params.logLevel,
-               "Variant configuration tag : [" << variantConfigUrnInfo.get_urn() << ']');
-  DT_LOG_DEBUG(params.logLevel, "Variant configuration     : '"
-                                    << params.variantServiceConfig.config_filename << "'");
-  DT_LOG_DEBUG(params.logLevel,
-               "Input variant profile tag : [" << params.inputVariantProfileUrn << ']');
-  DT_LOG_DEBUG(params.logLevel,
-               "Input variant profile     : '" << params.variantServiceConfig.profile_load << "'");
 }
 
 falaise::exit_code do_flsimulate_config(int argc, char* argv[]) {
@@ -469,9 +448,7 @@ falaise::exit_code do_flsimulate_config(int argc, char* argv[]) {
   }
 
   // Terminate the variant service:
-  if (variantService.is_started()) {
-    variantService.stop();
-  }
+  variantService.stop();
 
   return ret;
 }

--- a/programs/flsimulate/flsimulatemain.cc
+++ b/programs/flsimulate/flsimulatemain.cc
@@ -177,8 +177,7 @@ falaise::exit_code do_metadata(const FLSimulateArgs &flSimParameters,
                               "Variants profile path");
   }
 
-  if (flSimParameters.saveVariantSettings &&
-      !flSimParameters.variantSubsystemParams.settings.empty()) {
+  if (flSimParameters.variantSubsystemParams.settings.empty()) {
     // Saving effective list of variant settings:
     variants_props.store("settings", flSimParameters.variantSubsystemParams.settings,
                          "Effective variants settings");

--- a/programs/flsimulate/flsimulatemain.cc
+++ b/programs/flsimulate/flsimulatemain.cc
@@ -135,9 +135,6 @@ falaise::exit_code do_metadata(const FLSimulateArgs &flSimParameters,
 
   system_props.store_boolean("doSimulation", flSimParameters.doSimulation, "Activate simulation");
 
-  system_props.store_boolean("doDigitization", flSimParameters.doDigitization,
-                             "Activate digitization");
-
   if (!flSimParameters.experimentalSetupUrn.empty()) {
     system_props.store_string("experimentalSetupUrn", flSimParameters.experimentalSetupUrn,
                               "Experimental setup URN");
@@ -145,12 +142,6 @@ falaise::exit_code do_metadata(const FLSimulateArgs &flSimParameters,
 
   system_props.store_boolean("embeddedMetadata", flSimParameters.embeddedMetadata,
                              "Metadata embedding flag");
-
-  // Remove timestamp from metadata:
-  // boost::posix_time::ptime start_run_timestamp =
-  // boost::posix_time::second_clock::universal_time(); system_props.store_string("timestamp",
-  //                           boost::posix_time::to_iso_string(start_run_timestamp),
-  //                           "Run start timestamp");
 
   if (flSimParameters.doSimulation) {
     // Simulation section:
@@ -170,25 +161,6 @@ falaise::exit_code do_metadata(const FLSimulateArgs &flSimParameters,
       // Saving effective initial seeds for PRNGs:
       simulation_props.store_string("rngSeeding", flSimParameters.rngSeeding, "PRNG initial seeds");
     }
-  }
-
-  if (flSimParameters.doDigitization) {
-    // Digitization section:
-    datatools::properties &digitization_props =
-        flSimMetadata.add_section("flsimulate.digitization", "flsimulate::section");
-    digitization_props.set_description("Digitization setup parameters");
-
-    // Not implemented yet.
-
-    // if (!flSimParameters.digitizationSetupUrn.empty()) {
-    //   digitization_props.store_string("digitizationSetupUrn",
-    //                                        flSimParameters.digitizationSetupUrn,
-    //                                        "Digitization setup URN");
-    // } else if (!flSimParameters.digitizationSetupConfig.empty()) {
-    //   digitization_props.store_path("digitizationSetupConfig",
-    //                                      flSimParameters.digitizationSetupConfig,
-    //                                      "Digitization manager configuration file");
-    // }
   }
 
   // Variants section:
@@ -313,11 +285,6 @@ falaise::exit_code do_flsimulate(int argc, char *argv[]) {
       DT_LOG_DEBUG(flSimParameters.logLevel, "PRNG seeding = " << flSimParameters.rngSeeding);
     }
 
-    // Digitization module:
-    if (flSimParameters.doDigitization) {
-      DT_THROW(std::logic_error, "Digitization is not supported yet!");
-    }
-
     // Output metadata management:
     datatools::multi_properties flSimMetadata("name", "type",
                                               "Metadata associated to a flsimulate run");
@@ -369,8 +336,6 @@ falaise::exit_code do_flsimulate(int argc, char *argv[]) {
         std::cerr << "flsimulate : Output module failed" << std::endl;
         code = falaise::EXIT_UNAVAILABLE;
       }
-
-      // Here we will process optional ASB+Digitization+terminal output modules
 
       if (code != falaise::EXIT_OK) {
         break;

--- a/programs/flsimulate/flsimulatemain.cc
+++ b/programs/flsimulate/flsimulatemain.cc
@@ -133,31 +133,27 @@ falaise::exit_code do_metadata(const FLSimulateArgs &flSimParameters,
   system_props.store_integer("numberOfEvents", flSimParameters.numberOfEvents,
                              "Number of simulated events");
 
-  system_props.store_boolean("doSimulation", flSimParameters.doSimulation, "Activate simulation");
-
   if (!flSimParameters.experimentalSetupUrn.empty()) {
     system_props.store_string("experimentalSetupUrn", flSimParameters.experimentalSetupUrn,
                               "Experimental setup URN");
   }
 
-  if (flSimParameters.doSimulation) {
-    // Simulation section:
-    datatools::properties &simulation_props =
-        flSimMetadata.add_section("flsimulate.simulation", "flsimulate::section");
-    simulation_props.set_description("Simulation setup parameters");
+  // Simulation section:
+  datatools::properties &simulation_props =
+      flSimMetadata.add_section("flsimulate.simulation", "flsimulate::section");
+  simulation_props.set_description("Simulation setup parameters");
 
-    if (!flSimParameters.simulationSetupUrn.empty()) {
-      simulation_props.store_string("simulationSetupUrn", flSimParameters.simulationSetupUrn,
-                                    "Simulation setup URN");
-    } else if (!flSimParameters.simulationManagerParams.manager_config_filename.empty()) {
-      simulation_props.store_path("simulationSetupConfig",
-                                  flSimParameters.simulationManagerParams.manager_config_filename,
-                                  "Simulation manager configuration file");
-    }
-    if (!flSimParameters.rngSeeding.empty()) {
-      // Saving effective initial seeds for PRNGs:
-      simulation_props.store_string("rngSeeding", flSimParameters.rngSeeding, "PRNG initial seeds");
-    }
+  if (!flSimParameters.simulationSetupUrn.empty()) {
+    simulation_props.store_string("simulationSetupUrn", flSimParameters.simulationSetupUrn,
+                                  "Simulation setup URN");
+  } else if (!flSimParameters.simulationManagerParams.manager_config_filename.empty()) {
+    simulation_props.store_path("simulationSetupConfig",
+                                flSimParameters.simulationManagerParams.manager_config_filename,
+                                "Simulation manager configuration file");
+  }
+  if (!flSimParameters.rngSeeding.empty()) {
+    // Saving effective initial seeds for PRNGs:
+    simulation_props.store_string("rngSeeding", flSimParameters.rngSeeding, "PRNG initial seeds");
   }
 
   // Variants section:

--- a/programs/flsimulate/flsimulatemain.cc
+++ b/programs/flsimulate/flsimulatemain.cc
@@ -140,9 +140,6 @@ falaise::exit_code do_metadata(const FLSimulateArgs &flSimParameters,
                               "Experimental setup URN");
   }
 
-  system_props.store_boolean("embeddedMetadata", flSimParameters.embeddedMetadata,
-                             "Metadata embedding flag");
-
   if (flSimParameters.doSimulation) {
     // Simulation section:
     datatools::properties &simulation_props =
@@ -157,7 +154,7 @@ falaise::exit_code do_metadata(const FLSimulateArgs &flSimParameters,
                                   flSimParameters.simulationManagerParams.manager_config_filename,
                                   "Simulation manager configuration file");
     }
-    if (flSimParameters.saveRngSeeding && !flSimParameters.rngSeeding.empty()) {
+    if (!flSimParameters.rngSeeding.empty()) {
       // Saving effective initial seeds for PRNGs:
       simulation_props.store_string("rngSeeding", flSimParameters.rngSeeding, "PRNG initial seeds");
     }
@@ -293,22 +290,13 @@ falaise::exit_code do_flsimulate(int argc, char *argv[]) {
       flSimMetadata.tree_dump(std::cerr, "Simulation metadata: ", "[debug]: ");
     }
 
-    if (!flSimParameters.outputMetadataFile.empty()) {
-      std::string fMetadata = flSimParameters.outputMetadataFile;
-      datatools::fetch_path_with_env(fMetadata);
-      flSimMetadata.write(fMetadata);
-    }
-
     // Simulation output module:
     dpp::output_module simOutput;
     simOutput.set_name("FLSimulateOutput");
     simOutput.set_single_output_file(flSimParameters.outputFile);
-    // Metadata management:
-    if (flSimParameters.embeddedMetadata) {
-      // Push the metadata in the metadata store:
-      datatools::multi_properties &metadataStore = simOutput.grab_metadata_store();
-      metadataStore = flSimMetadata;
-    }
+    // Push the metadata in the metadata store:
+    datatools::multi_properties &metadataStore = simOutput.grab_metadata_store();
+    metadataStore = flSimMetadata;
     simOutput.initialize_simple();
 
     // Manual Event loop....


### PR DESCRIPTION
To work towards the requests in #176, #178 this PR addresses some basic simplification of `flsimulate`'s metadata organisation and output, of which random number seeds/state are a part.

The core change being implemented is to ensure that _all_ metadata relating to an `flsimulate` run can _only_ be stored in the output `.brio` file. In particular, the provision to output metadata to a separate file by `flsimulate` is removed, with a separate `brio_file_dumper` (name to be argued over!) program supplied that takes a `.brio` file as input and can spit out as much/little info about the file contents (including metadata as needed). At present it simply dumps the metadata to `stdout` in raw `datatools::multi_properties`, so a production job can obtain the metadata via:

```
$ flsimulate <args> -o output.brio
...
$ brio_file_dumper -f output.brio > output.meta.conf
```

This ensures that:

1. We never have the chance to generate a file _without_ metadata stored
2. The handling/treatment of the metadata in MC production or similar is dealt with outside of `flsimulate` (which is purely responsible for generating that data)
3. There's an easy interface for examining any raw `.brio` file, or extracting info in any form suitable for database/cataloguing. This can easily be extended to raw/reconstructed data as well.

This is still a "Draft" PR because not everything is implemented yet, and wanted early eyes/feedback from all of you (as it impacts production/database/reco/analysis). The main thing to work out is what your different areas need from the `brio_file_dumper` program, i.e. what interface/printed info is most useful to you?
