### PR TITLE
Reduce recompilation from copying headers and use of git hash in version.h

### DIFF
--- a/documentation/falaise_doxygen.conf.in
+++ b/documentation/falaise_doxygen.conf.in
@@ -128,7 +128,8 @@ FULL_PATH_NAMES        = YES
 # If left blank the directory from which doxygen is run is used as the
 # path to strip.
 
-STRIP_FROM_PATH        = @PROJECT_BUILD_INCLUDEDIR@ \
+STRIP_FROM_PATH        = @PROJECT_SOURCE_DIR@/source \
+                         @PROJECT_BINARY_DIR@/source \
                          @PROJECT_SOURCE_DIR@
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of
@@ -138,7 +139,8 @@ STRIP_FROM_PATH        = @PROJECT_BUILD_INCLUDEDIR@ \
 # definition is used. Otherwise one should specify the include paths that
 # are normally passed to the compiler using the -I flag.
 
-STRIP_FROM_INC_PATH    = @PROJECT_BUILD_INCLUDEDIR@ \
+STRIP_FROM_INC_PATH    = @PROJECT_SOURCE_DIR@/source \
+                         @PROJECT_BINARY_DIR@/source \
                          @PROJECT_SOURCE_DIR@
 
 # If the SHORT_NAMES tag is set to YES, doxygen will generate much shorter
@@ -661,7 +663,8 @@ WARN_LOGFILE           =
 
 INPUT                  =  @FALAISE_ABSOLUTE_MARKDOWN_DOCS@ \
                           @FALAISE_DOCEXPORT_DIR@ \
-                          @PROJECT_BUILD_INCLUDEDIR@/falaise
+                          @PROJECT_SOURCE_DIR@/source/falaise \
+                          @PROJECT_BINARY_DIR@/source/falaise
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding, which is
@@ -722,7 +725,7 @@ EXCLUDE_SYMLINKS       = NO
 # against the file with absolute path, so to exclude all test directories
 # for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       = */.svn/* */*.ipp
+EXCLUDE_PATTERNS       = */.svn/* */*.ipp */*.cc */*.cpp */*.cxx */*.c
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the

--- a/source/falaise/CMakeLists.txt
+++ b/source/falaise/CMakeLists.txt
@@ -23,12 +23,24 @@
 #-----------------------------------------------------------------------
 # Configure library
 #
+configure_file(version.h.in version.h @ONLY)
+configure_file(resource.cc.in resource.cc @ONLY)
 
+# - Generate binreloc header/source with mangled names, ensuring first
+# character(s) are a valid for a C identifier
+string(RANDOM LENGTH 18 MANGLE_BINRELOC_MAIN)
+set(MANGLE_BINRELOC "MB${MANGLE_BINRELOC_MAIN}")
+configure_file(falaise_binreloc.h.in falaise_binreloc.h @ONLY)
+
+
+#-----------------------------------------------------------------------
+# Declare sources
+#
 set(FalaiseLibrary_HEADERS
+  ${CMAKE_CURRENT_BINARY_DIR}/version.h
   exitcodes.h
   falaise.h
   resource.h
-  version.h.in
   path.h
   property_set.h
   quantity.h
@@ -37,17 +49,6 @@ set(FalaiseLibrary_HEADERS
   detail/falaise_sys.h
   metadata_utils.h
 )
-
-#-----------------------------------------------------------------------
-# Declare sources
-#
-configure_file(resource.cc.in resource.cc @ONLY)
-
-# - Generate binreloc header/source with mangled names, ensuring first
-# character(s) are a valid for a C identifier
-string(RANDOM LENGTH 18 MANGLE_BINRELOC_MAIN)
-set(MANGLE_BINRELOC "MB${MANGLE_BINRELOC_MAIN}")
-configure_file(falaise_binreloc.h.in falaise_binreloc.h @ONLY)
 
 set(FalaiseLibrary_SOURCES
   version.cc
@@ -72,10 +73,10 @@ set(FalaiseLibrary_TESTS_CATCH)
 include(snemo.cmake)
 
 # - Publish headers
-foreach(_hdrin ${FalaiseLibrary_HEADERS})
-  string(REGEX REPLACE "\\.in$" "" _hdrout "${_hdrin}")
-  configure_file(${_hdrin} ${PROJECT_BUILD_INCLUDEDIR}/falaise/${_hdrout} @ONLY)
-endforeach()
+#foreach(_hdrin ${FalaiseLibrary_HEADERS})
+#  string(REGEX REPLACE "\\.in$" "" _hdrout "${_hdrin}")
+#  configure_file(${_hdrin} ${PROJECT_BUILD_INCLUDEDIR}/falaise/${_hdrout} @ONLY)
+#endforeach()
 
 
 #-----------------------------------------------------------------------
@@ -85,11 +86,10 @@ add_library(Falaise SHARED ${FalaiseLibrary_HEADERS} ${FalaiseLibrary_SOURCES})
 target_compile_features(Falaise PUBLIC ${FALAISE_CXX_COMPILE_FEATURES})
 target_compile_definitions(Falaise PRIVATE ENABLE_BINRELOC)
 target_include_directories(Falaise PUBLIC
-  $<BUILD_INTERFACE:${FALAISE_BUILD_INCLUDEDIR}>
-  $<BUILD_INTERFACE:${PROJECT_BUILD_INCLUDEDIR}/falaise>
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/source>
+  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/source>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/falaise>
   )
 target_link_libraries(Falaise PUBLIC Bayeux::Bayeux)
 target_clang_format(Falaise)
@@ -139,8 +139,11 @@ install(TARGETS Falaise FalaiseModule
   )
 
 # - Install public headers (preliminary)
-install(DIRECTORY ${FALAISE_BUILD_INCLUDEDIR}/
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/ ${CMAKE_CURRENT_BINARY_DIR}/
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/falaise
+  FILES_MATCHING PATTERN "*.h" PATTERN "*.ipp"
+  PATTERN "CMakeFiles" EXCLUDE
+  PATTERN "test" EXCLUDE
   )
 
 if(FALAISE_ENABLE_TESTING)

--- a/source/falaise/CMakeLists.txt
+++ b/source/falaise/CMakeLists.txt
@@ -24,6 +24,7 @@
 # Configure library
 #
 configure_file(version.h.in version.h @ONLY)
+configure_file(version.cc.in version.cc @ONLY)
 configure_file(resource.cc.in resource.cc @ONLY)
 
 # - Generate binreloc header/source with mangled names, ensuring first
@@ -51,7 +52,7 @@ set(FalaiseLibrary_HEADERS
 )
 
 set(FalaiseLibrary_SOURCES
-  version.cc
+  ${CMAKE_CURRENT_BINARY_DIR}/version.cc
   ${CMAKE_CURRENT_BINARY_DIR}/resource.cc
   ${CMAKE_CURRENT_BINARY_DIR}/falaise_binreloc.h
   falaise_binreloc.c
@@ -71,13 +72,6 @@ set(FalaiseLibrary_TESTS_CATCH)
 # - Declare headers, sources and test programs specific
 #   to various setups
 include(snemo.cmake)
-
-# - Publish headers
-#foreach(_hdrin ${FalaiseLibrary_HEADERS})
-#  string(REGEX REPLACE "\\.in$" "" _hdrout "${_hdrin}")
-#  configure_file(${_hdrin} ${PROJECT_BUILD_INCLUDEDIR}/falaise/${_hdrout} @ONLY)
-#endforeach()
-
 
 #-----------------------------------------------------------------------
 # Build/Link Library
@@ -158,6 +152,11 @@ if(FALAISE_ENABLE_TESTING)
     test/test_property_set.cxx
     test/test_quantity.cxx
     )
+  # Testing version is sensitive to compile definitions, so match them
+  set_property(SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/test/test_falaise_version.cxx
+    APPEND PROPERTY COMPILE_DEFINITIONS
+      FALAISE_VERSION_COMMIT=${Falaise_GIT_HASH_SHORT}
+      $<$<BOOL:${FALAISE_VERSION_IS_DIRTY}>:FALAISE_VERSION_IS_DIRTY>)
 endif()
 
 #-----------------------------------------------------------------------

--- a/source/falaise/test/test_falaise_version.cxx
+++ b/source/falaise/test/test_falaise_version.cxx
@@ -10,7 +10,9 @@ TEST_CASE("compile/run time versions match", "") {
 }
 
 TEST_CASE("compile/run time git state matches", "") {
-  REQUIRE(falaise::version::get_commit() == FALAISE_VERSION_COMMIT);
+  #define TFV_AS_STR(var) #var
+  #define XTFV_AS_STR(val) TFV_AS_STR(val)
+  REQUIRE(falaise::version::get_commit() == XTFV_AS_STR(FALAISE_VERSION_COMMIT));
 
 #ifdef FALAISE_VERSION_IS_DIRTY
   bool expectedDirty{true};

--- a/source/falaise/version.cc
+++ b/source/falaise/version.cc
@@ -24,19 +24,12 @@
 // Standard Library
 #include <sstream>
 
-// Third Party
-// - A
-
-// This Project
-
 namespace falaise {
 int version::get_major() { return static_cast<int>(FALAISE_VERSION_MAJOR); }
 
 int version::get_minor() { return static_cast<int>(FALAISE_VERSION_MINOR); }
 
 int version::get_patch() { return static_cast<int>(FALAISE_VERSION_PATCH); }
-
-int version::get_revision() { return static_cast<int>(FALAISE_VERSION_REVISION); }
 
 std::string version::get_commit() {
   static std::string revision{FALAISE_VERSION_COMMIT};

--- a/source/falaise/version.cc.in
+++ b/source/falaise/version.cc.in
@@ -24,6 +24,13 @@
 // Standard Library
 #include <sstream>
 
+//! First 8 characters of the current Git HEAD hash, empty outside a working
+//  copy.
+#define FALAISE_VERSION_COMMIT "@Falaise_GIT_HASH_SHORT@"
+
+//! Defined if this build has uncommited changes
+#cmakedefine FALAISE_VERSION_IS_DIRTY
+
 namespace falaise {
 int version::get_major() { return static_cast<int>(FALAISE_VERSION_MAJOR); }
 

--- a/source/falaise/version.h.in
+++ b/source/falaise/version.h.in
@@ -46,18 +46,6 @@
 //! Patch version number of falaise
 #define FALAISE_VERSION_PATCH @Falaise_VERSION_PATCH@
 
-//! Current revision/build number of falaise, 0 for a release
-//! \deprecated Since 3.1
-//! \see FALAISE_VERSION_COMMIT
-#define FALAISE_VERSION_REVISION -1
-
-//! First 8 characters of the current Git HEAD hash, empty outside a working
-//  copy.
-#define FALAISE_VERSION_COMMIT "@Falaise_GIT_HASH_SHORT@"
-
-//! Defined if this build has uncommited changes
-#cmakedefine01 FALAISE_VERSION_IS_DIRTY
-
 //! Encode falaise to ordered integer available at compile time
 #define FALAISE_ENCODE_VERSION(major, minor, patch) ( \
         ((major) * 10000) \

--- a/source/falaise/version.h.in
+++ b/source/falaise/version.h.in
@@ -93,11 +93,6 @@ static int get_minor();
 //! Return the patch version number of falaise, e.g., 3 for '1.2.3'
 static int get_patch();
 
-//! Return the current revision number
-//! \deprecated since 3.1
-//! \see get_commit()
-static int get_revision() __attribute__((deprecated));
-
 //! Return the first eight characters of the current Git HEAD hash
 static std::string get_commit();
 


### PR DESCRIPTION
This is a very simple PR that helps to speed up incremental and general builds, with no code changes and minimal reorganisation.

Headers are no longer copied to the build area as this was found to lead to significant recompilation. That functionality was originally implemented to help Doxygen generation, but this is no longer needed with the standardised header layout. Doxygen generation and header installs are updated to reflect these changes. There's no change to build/install behaviour.

Falaise's `version.h` file stores two preprocessor symbols for the Git hash and state (if the build is from a Git checkout), plus C++ class functions to get these at runtime. Because the hash/state frequently changes in development (and hence the interface of `version.h`, I was seeing significant recompilation of files that otherwise shouldn't be. Because the hash/state are really runtime metadata (there's no use case that we have to check them at compile time), their declaration is moved to `version.cc`, which is now generated. The class functions to retrieve that info are still present of course.