### PR TITLE
Update interfaces for event/configuration handling in Falaise modules

### DIFF
--- a/documentation/falaise_doxygen.conf.in
+++ b/documentation/falaise_doxygen.conf.in
@@ -705,7 +705,8 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = @PROJECT_SOURCE_DIR@/documentation/data_models \
+EXCLUDE                = @PROJECT_SOURCE_DIR@/source/falaise/snemo/processing/detail/testing \
+                         @PROJECT_SOURCE_DIR@/documentation/data_models \
                          @PROJECT_SOURCE_DIR@/documentation/data_processing_modules \
                          @PROJECT_SOURCE_DIR@/documentation/flreconstruct/MyModule \
                          @PROJECT_SOURCE_DIR@/documentation/flreconstruct/MyModuleConfigurable \

--- a/source/falaise/CMakeLists.txt
+++ b/source/falaise/CMakeLists.txt
@@ -39,6 +39,7 @@ configure_file(falaise_binreloc.h.in falaise_binreloc.h @ONLY)
 #
 set(FalaiseLibrary_HEADERS
   ${CMAKE_CURRENT_BINARY_DIR}/version.h
+  bounded_int.h
   exitcodes.h
   falaise.h
   resource.h
@@ -148,6 +149,7 @@ if(FALAISE_ENABLE_TESTING)
    )
   list(APPEND FalaiseLibrary_TESTS_CATCH
     test/test_falaise_version.cxx
+    test/test_bounded_int.cxx
     test/test_path.cxx
     test/test_property_set.cxx
     test/test_quantity.cxx

--- a/source/falaise/bounded_int.h
+++ b/source/falaise/bounded_int.h
@@ -26,6 +26,8 @@ namespace falaise {
 
 template <int32_t lower_bound, int32_t upper_bound>
 class bounded_int {
+  static_assert(lower_bound != upper_bound, "bounds cannot be equal, use a named constant instead");
+  static_assert(lower_bound < upper_bound, "lower_bound must be less than upper_bound");
  public:
   bounded_int() = default;
   bounded_int(int32_t x) : value_{x} {

--- a/source/falaise/bounded_int.h
+++ b/source/falaise/bounded_int.h
@@ -1,0 +1,56 @@
+// Copyright (c) 2020 by Ben Morgan <Ben.Morgan@warwick.ac.uk>
+// Copyright (c) 2020 by The University of Warwick
+//
+// This file is part of Falaise.
+//
+// Falaise is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Falaise is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Falaise.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef FALAISE_BOUNDED_INT_H
+#define FALAISE_BOUNDED_INT_H
+
+#include <cstdint>
+#include <exception>
+
+namespace falaise {
+
+template <int32_t lower_bound, int32_t upper_bound>
+class bounded_int {
+ public:
+  bounded_int() = default;
+  bounded_int(int32_t x) : value_{x} {
+    if (x < lower_bound || x > upper_bound) {
+      throw std::out_of_range("supplied value is out of range");
+    }
+  }
+
+  ~bounded_int() = default;
+
+  bounded_int(const bounded_int&) = default;
+  bounded_int(bounded_int&& rhs) = default;
+
+  bounded_int& operator=(const bounded_int&) = default;
+  bounded_int& operator=(bounded_int&&) = default;
+
+  operator int32_t() const { return value_; }
+
+  constexpr int32_t min() const { return lower_bound; }
+
+  constexpr int32_t max() const { return upper_bound; }
+
+ private:
+  int32_t value_ = lower_bound;
+};
+}  // namespace falaise
+
+#endif  // FALAISE_BOUNDED_INT_H

--- a/source/falaise/bounded_int.h
+++ b/source/falaise/bounded_int.h
@@ -1,3 +1,4 @@
+//! \file falaise/bounded_int.h
 // Copyright (c) 2020 by Ben Morgan <Ben.Morgan@warwick.ac.uk>
 // Copyright (c) 2020 by The University of Warwick
 //
@@ -23,13 +24,89 @@
 #include <exception>
 
 namespace falaise {
-
+//! \brief Class representing an integral value with strict bounds
+/*!
+ * \tparam lower_bound Inclusive lower bound on value
+ * \tparam upper_bound Inclusive upper bound on value
+ *
+ * Provides a convenience class for integral values with strict bounds that
+ * cannot overflow. The canonical use case in Falaise is indices for tracker
+ * layers and columns, [0,8] and [0,111] respectively. These bounds do not line
+ * up with the range of any builtin integral type, and builtin types are
+ * vunerable to overflow/underflow. Instead of having to write code that checks
+ * bounds explicitly everytime we use an builtin integral :
+ *
+ * ```cpp
+ * const int32_t NLAYER = 8;
+ *
+ * void example(int32_t layerIndex) {
+ *   if (layer < 0 || layer > NLAYER) {
+ *     throw std::out_of_range;
+ *   }
+ *   ... do something ...
+ * }
+ * ```
+ *
+ * bounded_int allows us to do
+ *
+ * ```cpp
+ * using layer_index_t = bounded_int<0,8>;
+ *
+ * void example(layer_index_t i) {
+ *   ... do something ...
+ * }
+ *
+ * layer_index_t good{1}; // fine
+ * layer_index_t bad{9};  // throws std::out_of_range
+ *
+ * int32_t works{2};
+ * int32_t fails{-1};
+ *
+ * // Implicit conversion fron int32_t to layer_index_t
+ * example(works); // fine
+ * example(fails); // throws std::out_of_range
+ * ```
+ *
+ * bounded_int only holds an int32_t value, so its maximum bounds are equivalent
+ * to int32_t's numeric limits. Compile time assertions will be raised in the cases:
+ *
+ * - lower_bound is greater than upper_bound
+ * - lower_bound is equal to upper_bound
+ *
+ * The first is enforced for consistency, the second is equivalent to a more useful
+ * named constant.
+ *
+ * bounded_int can be converted back to int32_t and any integral type that's implicitly
+ * convertible form int32_t:
+ *
+ * ```cpp
+ * bounded_int<0,8> x{2};
+ * int32_t y = x; // y = 2
+ * ```
+ *
+ * However, there is no checking for over/uinderflow in these cases.
+ */
 template <int32_t lower_bound, int32_t upper_bound>
 class bounded_int {
   static_assert(lower_bound != upper_bound, "bounds cannot be equal, use a named constant instead");
   static_assert(lower_bound < upper_bound, "lower_bound must be less than upper_bound");
  public:
+  //! Default constructor
+  /*!
+   * Initializes value to lower_bound
+   *
+   * \tparam lower_bound Inclusive lower bound on value
+   * \tparam upper_bound Inclusive upper bound on value
+   */
   bounded_int() = default;
+
+  //! Construct from a int32_t value
+  /*!
+   * \tparam lower_bound Inclusive lower bound on value
+   * \tparam upper_bound Inclusive upper bound on value
+   * \param[in] x value
+   * \throw out_of_range if value is outside [lower_bound,upper_bound]
+   */
   bounded_int(int32_t x) : value_{x} {
     if (x < lower_bound || x > upper_bound) {
       throw std::out_of_range("supplied value is out of range");
@@ -37,21 +114,22 @@ class bounded_int {
   }
 
   ~bounded_int() = default;
-
   bounded_int(const bounded_int&) = default;
   bounded_int(bounded_int&& rhs) = default;
-
   bounded_int& operator=(const bounded_int&) = default;
   bounded_int& operator=(bounded_int&&) = default;
 
+  //! Convert back to int32_t
   operator int32_t() const { return value_; }
 
+  //! Return lower bound
   constexpr int32_t min() const { return lower_bound; }
 
+  //! Return upper bound
   constexpr int32_t max() const { return upper_bound; }
 
  private:
-  int32_t value_ = lower_bound;
+  int32_t value_ = lower_bound; //< underlying value
 };
 }  // namespace falaise
 

--- a/source/falaise/bounded_int.h
+++ b/source/falaise/bounded_int.h
@@ -24,16 +24,16 @@
 #include <exception>
 
 namespace falaise {
-//! \brief Class representing an integral value with strict bounds
+//! \brief Class representing an integer value with strict bounds
 /*!
  * \tparam lower_bound Inclusive lower bound on value
  * \tparam upper_bound Inclusive upper bound on value
  *
  * Provides a convenience class for integral values with strict bounds that
  * cannot overflow. The canonical use case in Falaise is indices for tracker
- * layers and columns, [0,8] and [0,111] respectively. These bounds do not line
+ * layers and columns, [0,8] and [0,112] respectively. These bounds do not line
  * up with the range of any builtin integral type, and builtin types are
- * vunerable to overflow/underflow. Instead of having to write code that checks
+ * vulnerable to overflow/underflow. Instead of having to write code that checks
  * bounds explicitly everytime we use an builtin integral :
  *
  * ```cpp
@@ -59,10 +59,13 @@ namespace falaise {
  * layer_index_t good{1}; // fine
  * layer_index_t bad{9};  // throws std::out_of_range
  *
+ * // Implicit conversion fron int32_t to layer_index_t
+ * // If you pass a regular integer to a function that takes
+ * // a bounded_int it will check the bounds for you an throw
+ * // an exception if the value is out of bounds
  * int32_t works{2};
  * int32_t fails{-1};
  *
- * // Implicit conversion fron int32_t to layer_index_t
  * example(works); // fine
  * example(fails); // throws std::out_of_range
  * ```
@@ -77,14 +80,14 @@ namespace falaise {
  * named constant.
  *
  * bounded_int can be converted back to int32_t and any integral type that's implicitly
- * convertible form int32_t:
+ * convertible from int32_t:
  *
  * ```cpp
  * bounded_int<0,8> x{2};
  * int32_t y = x; // y = 2
  * ```
  *
- * However, there is no checking for over/uinderflow in these cases.
+ * However, there is no checking for over/underflow in these cases.
  */
 template <int32_t lower_bound, int32_t upper_bound>
 class bounded_int {

--- a/source/falaise/metadata_utils.h
+++ b/source/falaise/metadata_utils.h
@@ -1,4 +1,4 @@
-//! \file  falaise/app/metadata_utils.h
+//! \file  falaise/metadata_utils.h
 //! \brief Utilities for accessing metadata
 //
 // Copyright (c) 2017 by François Mauger <mauger@lpccaen.in2p3.fr>

--- a/source/falaise/path.h
+++ b/source/falaise/path.h
@@ -1,3 +1,21 @@
+//! \file falaise/path.h
+// Copyright (c) 2020 by Ben Morgan <Ben.Morgan@warwick.ac.uk>
+// Copyright (c) 2020 by The University of Warwick
+//
+// This file is part of Falaise.
+//
+// Falaise is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Falaise is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Falaise.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef FALAISE_PATH_H
 #define FALAISE_PATH_H
 
@@ -11,7 +29,7 @@ class invalid_path_error : public std::logic_error {
   using std::logic_error::logic_error;
 };
 
-//! Class representing a filesystem path as held by a @ref property_set
+//! Class representing a filesystem path as held by a falaise::property_set
 /*!
  * Filesystem paths can be defined in datatools::properties syntax as:
  *
@@ -24,7 +42,7 @@ class invalid_path_error : public std::logic_error {
  * the resolved absolute path.
  *
  * @ref path provides a simple type to distinguish raw `std::string` from
- * explicit paths allowing users to validate that a @ref property_set value
+ * explicit paths allowing users to validate that a falaise::property_set value
  * is a true path. It is nothing more than a simple holder of the std::string for
  * the absolute path and may be used as:
  *

--- a/source/falaise/property_set.cpp
+++ b/source/falaise/property_set.cpp
@@ -1,5 +1,7 @@
 #include "property_set.h"
 
+#include <fstream>
+
 namespace falaise {
 property_set::property_set(datatools::properties const& ps) : ps_(ps) {}
 
@@ -67,8 +69,7 @@ bool property_set::is_type_impl_(std::string const& key, const std::string& /*un
   return ps_.is_string(key) && (!ps_.is_explicit_path(key)) && ps_.is_scalar(key);
 }
 
-bool property_set::is_type_impl_(std::string const& key,
-                                 const falaise::path& /*unused*/) const {
+bool property_set::is_type_impl_(std::string const& key, const falaise::path& /*unused*/) const {
   return ps_.is_explicit_path(key) && ps_.is_scalar(key);
 }
 
@@ -101,8 +102,14 @@ bool property_set::is_type_impl_(std::string const& key,
 }
 
 void make_property_set(const std::string& filename, property_set& ps) {
+  std::ifstream fs{filename.c_str()};
+  make_property_set(fs, ps);
+}
+
+void make_property_set(std::istream& is, property_set& ps) {
   datatools::properties tmp{};
-  datatools::properties::read_config(filename, tmp);
+  datatools::properties::config reader{};
+  reader.read(is, tmp);
   ps = tmp;
 }
 }  // namespace falaise

--- a/source/falaise/property_set.h
+++ b/source/falaise/property_set.h
@@ -1,3 +1,21 @@
+//! \file falaise/property_set.h
+// Copyright (c) 2020 by Ben Morgan <Ben.Morgan@warwick.ac.uk>
+// Copyright (c) 2020 by The University of Warwick
+//
+// This file is part of Falaise.
+//
+// Falaise is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Falaise is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Falaise.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef FALAISE_PROPERTY_SET_H
 #define FALAISE_PROPERTY_SET_H
 
@@ -29,7 +47,7 @@ class wrong_type_error : public std::logic_error {
   using std::logic_error::logic_error;
 };
 
-//! \brief Class holding a set of key-value properties
+//! Class holding a set of key-value properties
 /*!
  * Provides a convenient adaptor interface over datatools::properties,
  * targeted at developers of modules for Falaise needing key-value storage
@@ -75,12 +93,13 @@ class wrong_type_error : public std::logic_error {
  *
  * or from any input stream, e.g
  *
- * ```
+ * ```cpp
  * void example(std::istream& is) {
  *   falaise::property_set ps{};
  *   falaise::make_property_set(is, ps);
  *   // ... use ps ...
  * }
+ * ```
  *
  * Storage and retrieval of parameters is typesafe in the sense that:
  *

--- a/source/falaise/property_set.h
+++ b/source/falaise/property_set.h
@@ -1,6 +1,7 @@
 #ifndef FALAISE_PROPERTY_SET_H
 #define FALAISE_PROPERTY_SET_H
 
+#include <ios>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -71,6 +72,15 @@ class wrong_type_error : public std::logic_error {
  *   // ... use ps ...
  * }
  * ```
+ *
+ * or from any input stream, e.g
+ *
+ * ```
+ * void example(std::istream& is) {
+ *   falaise::property_set ps{};
+ *   falaise::make_property_set(is, ps);
+ *   // ... use ps ...
+ * }
  *
  * Storage and retrieval of parameters is typesafe in the sense that:
  *
@@ -570,6 +580,13 @@ void property_set::get_impl_(std::string const& key, falaise::quantity_t<T>& res
  * \param ps property_set to fill with data
  */
 void make_property_set(const std::string& filename, property_set& ps);
+
+//! Construct a property_set from a std::istream
+/*!
+ * \param is stream from which to read data
+ * \param ps  property_set to fill with data
+ */
+void make_property_set(std::istream& is, property_set& ps);
 
 }  // namespace falaise
 

--- a/source/falaise/snemo.cmake
+++ b/source/falaise/snemo.cmake
@@ -140,6 +140,7 @@ list(APPEND FalaiseLibrary_TESTS_CATCH
   snemo/test/test_snemo_geometry_gveto_locator_2.cxx
   snemo/test/test_module.cxx
   snemo/test/test_service.cxx
+  snemo/test/test_event_record.cxx
   )
 list(APPEND FalaiseLibrary_TESTS
   snemo/test/test_snemo_datamodel_event_header.cxx

--- a/source/falaise/snemo/datamodels/event.h
+++ b/source/falaise/snemo/datamodels/event.h
@@ -4,9 +4,11 @@
 #ifndef FALAISE_SNEMO_DATAMODELS_EVENT_H
 #define FALAISE_SNEMO_DATAMODELS_EVENT_H
 
-#include <string>
-#include <stdexcept>
 #include <bayeux/datatools/things.h>
+
+#include <stdexcept>
+#include <string>
+#include <type_traits>
 
 namespace snedm {
 //! Event record type definition
@@ -26,6 +28,8 @@ class existing_product_key : public std::logic_error {
  */
 template <typename T>
 T& getOrAddToEvent(std::string const& key, event_record& event) {
+  static_assert(std::is_base_of<datatools::i_serializable, T>::value,
+                "snedm::event_record can only store types derived from datatools::i_serializable");
   if (event.has(key)) {
     return event.grab<T>(key);
   }
@@ -36,15 +40,20 @@ T& getOrAddToEvent(std::string const& key, event_record& event) {
 /*!
  * \tparam T type of value to be added
  * \param[in] key key for value
- * \param[in] event event record to add the value to
+ * \param[in] event snedm::event_record to add the value to
  * \returns reference to created value held at key
  * \throws snedm::existing_product_key if key already exists
  */
 template <typename T>
 T& addToEvent(std::string const& key, event_record& event) {
+  static_assert(std::is_base_of<datatools::i_serializable, T>::value,
+                "snedm::event_record can only store types derived from datatools::i_serializable");
   if (event.has(key)) {
-    throw existing_product_key{"snedm:event_record '" + event.get_name() + "' already holds product '" + key + "'"};
+    throw existing_product_key{"snedm:event_record '" + event.get_name() +
+                               "' already holds product '" + key + "'"};
   }
+  // add will throw if the product exists, but check
+  // explicitly to raise a clearer exception
   return event.add<T>(key);
 }
 

--- a/source/falaise/snemo/datamodels/event.h
+++ b/source/falaise/snemo/datamodels/event.h
@@ -11,18 +11,54 @@
 #include <type_traits>
 
 namespace snedm {
-//! Event record type definition
+//! Class modelling Falaise's top level event data model
+/*!
+ * A key-value store with keys being `std::string` and values being
+ * any type inheriting from Bayeux's datatools:i_serializable base class.
+ *
+ * It is just a clarity typedef to Bayeux's underlying datatools::things class,
+ * which should be consulted for the full interface.
+ * \sa datatools::things
+ */
 using event_record = datatools::things;
 
 class existing_product_key : public std::logic_error {
   using std::logic_error::logic_error;
 };
 
-//! Get or add instance of T at supplied key in event record
+//! Get or add instance of T at supplied key in input event_record
 /*!
+ * A simple convenience wrapper around a typical use case in Falaise
+ * modules: retrieve a non-const reference to the value of type T stored
+ * at "key" in the event_record, inserting a new value of that type at "key"
+ * if "key is not present. In code this results in the boilerplate:
+ *
+ * ```cpp
+ * // Usually in the "process" member function of a Falaise module
+ * SomeDataType* x{nullptr};
+ *
+ * if(event.has(key)) {
+ *   x = event.grab<SomeDataType>(key); // throws if key does not hold a value of type T
+ * }
+ * else {
+ *   x = event.add<SomeDataType>(key);
+ * }
+ *
+ * // do something with x
+ * ```
+ *
+ * This wrapper function reduces the above to:
+ *
+ * ```
+ * auto x = getOrAddToEvent<SomeDataType>(key, event);
+ * ```
+ *
+ * It additionally checks at compile time that the supplied type (`SomeDataType` here)
+ * meets the requirements to be stored in the event.
+ *
  * \tparam T type of value to be retrieved or added
  * \param[in] key key for value to find
- * \param[in] event event record to search in
+ * \param[in] event event_record to search in
  * \returns reference to value held at key
  * \throws datatools::bad_things_cast if value at key is not of type T
  */
@@ -36,8 +72,25 @@ T& getOrAddToEvent(std::string const& key, event_record& event) {
   return event.add<T>(key);
 }
 
-//! Add instance of T at supplied key in event record unless key exists
+//! Add instance of T at supplied key in event_record unless key exists
 /*!
+ * A simple convenience wrapper around a typical use case in Falaise modules:
+ * add a new value to the event at "key" only if the "key" is not already in use
+ *
+ * ```cpp
+ * // Usually in the "process" member function of a Falaise module
+ * auto x = addToEvent<SomeDataType>("mydata",event);
+ *
+ * // use x
+ * ```
+ *
+ * Whilst the event_record type has an `add` member function of its own, it is wrapped
+ * here to allow:
+ *
+ * - A clearer existing_product_key exception to be thrown if the key already exists
+ * - A compile time check that the type of data being stored meets the requirements to
+ *   be stored in the event
+ *
  * \tparam T type of value to be added
  * \param[in] key key for value
  * \param[in] event snedm::event_record to add the value to

--- a/source/falaise/snemo/datamodels/event.h
+++ b/source/falaise/snemo/datamodels/event.h
@@ -5,12 +5,16 @@
 #define FALAISE_SNEMO_DATAMODELS_EVENT_H
 
 #include <string>
-
+#include <stdexcept>
 #include <bayeux/datatools/things.h>
 
 namespace snedm {
 //! Event record type definition
 using event_record = datatools::things;
+
+class existing_product_key : public std::logic_error {
+  using std::logic_error::logic_error;
+};
 
 //! Get or add instance of T at supplied key in event record
 /*!
@@ -24,6 +28,22 @@ template <typename T>
 T& getOrAddToEvent(std::string const& key, event_record& event) {
   if (event.has(key)) {
     return event.grab<T>(key);
+  }
+  return event.add<T>(key);
+}
+
+//! Add instance of T at supplied key in event record unless key exists
+/*!
+ * \tparam T type of value to be added
+ * \param[in] key key for value
+ * \param[in] event event record to add the value to
+ * \returns reference to created value held at key
+ * \throws snedm::existing_product_key if key already exists
+ */
+template <typename T>
+T& addToEvent(std::string const& key, event_record& event) {
+  if (event.has(key)) {
+    throw existing_product_key{"snedm:event_record '" + event.get_name() + "' already holds product '" + key + "'"};
   }
   return event.add<T>(key);
 }

--- a/source/falaise/snemo/datamodels/event.h
+++ b/source/falaise/snemo/datamodels/event.h
@@ -1,4 +1,4 @@
-/// \file falaise/snemo/datatmodels/event.h
+/// \file falaise/snemo/datamodels/event.h
 /// \brief Event type and free functions
 
 #ifndef FALAISE_SNEMO_DATAMODELS_EVENT_H

--- a/source/falaise/snemo/geometry/xcalo_locator.h
+++ b/source/falaise/snemo/geometry/xcalo_locator.h
@@ -184,7 +184,7 @@ class xcalo_locator : public geomtools::base_locator, public datatools::i_tree_d
    */
   double getXCoordOfColumn(uint32_t side, uint32_t wall, uint32_t column) const;
 
-  /**! @RETURN THE Z-POSITION OF A BLOCK FOR SPECIFIC SIDE, WALL AND ROW (IN MODULE COORDINATE
+  /**! @return the S-position of a block for specific side, wall and row (in module coordinate
    * system).
    */
   double getZCoordOfRow(uint32_t side, uint32_t wall, uint32_t row) const;

--- a/source/falaise/snemo/processing/detail/mock_raw_tracker_hit.h
+++ b/source/falaise/snemo/processing/detail/mock_raw_tracker_hit.h
@@ -1,5 +1,5 @@
 // -*- mode: c++ ; -*-
-/// \file falaise/snemo/datamodels/mock_raw_tracker_hit.h
+/// \file falaise/snemo/processing/detail/mock_raw_tracker_hit.h
 /* Author(s) :    Francois Mauger <mauger@lpccaen.in2p3.fr>
  * Creation date: 2010-03-15
  * Last modified: 2014-01-30

--- a/source/falaise/snemo/test/test_event_record.cxx
+++ b/source/falaise/snemo/test/test_event_record.cxx
@@ -1,0 +1,8 @@
+// Catch
+#include "catch.hpp"
+
+#include "falaise/snemo/datamodels/event.h"
+
+TEST_CASE("Default construction works", "") {
+  REQUIRE(false);
+}

--- a/source/falaise/snemo/test/test_event_record.cxx
+++ b/source/falaise/snemo/test/test_event_record.cxx
@@ -3,6 +3,10 @@
 
 #include "falaise/snemo/datamodels/event.h"
 
-TEST_CASE("Default construction works", "") {
-  REQUIRE(false);
+TEST_CASE("Adding product at existing key throws", "") {
+  snedm::event_record e;
+
+  REQUIRE_NOTHROW(snedm::addToEvent<snedm::event_record>("first", e));
+  REQUIRE_THROWS_AS(snedm::addToEvent<snedm::event_record>("first", e),
+                    snedm::existing_product_key);
 }

--- a/source/falaise/test/test_bounded_int.cxx
+++ b/source/falaise/test/test_bounded_int.cxx
@@ -1,0 +1,40 @@
+#include "catch.hpp"
+
+#include "falaise/bounded_int.h"
+
+TEST_CASE("Raw bounded construction", "") {
+  falaise::bounded_int<-1,42> x{};
+  REQUIRE(x == -1);
+  REQUIRE(x.min() == -1);
+  REQUIRE(x.max() == 42);
+}
+
+TEST_CASE("Out of bounds construction", "") {
+  using address = falaise::bounded_int<0,119>;
+
+  // Must be able to construct at bounds
+  REQUIRE_NOTHROW(address good{0});
+  REQUIRE_NOTHROW(address good{119});
+
+  // Out of bounds must throw
+  REQUIRE_THROWS_AS(address bad{-1}, std::out_of_range);
+  REQUIRE_THROWS_AS(address bad{120}, std::out_of_range);
+}
+
+TEST_CASE("Assignment operators work", "") {
+  using address = falaise::bounded_int<-42,119>;
+
+  address x;
+
+  // Assignment must work
+  x = 3;
+  REQUIRE(x == 3);
+
+  // Assignment on bounds must work
+  REQUIRE_NOTHROW(x = -42);
+  REQUIRE_NOTHROW(x = 119);
+
+  // Out of bounds assignment must throw
+  REQUIRE_THROWS_AS(x = -43, std::out_of_range);
+  REQUIRE_THROWS_AS(x = -120, std::out_of_range);
+}

--- a/source/falaise/test/test_bounded_int.cxx
+++ b/source/falaise/test/test_bounded_int.cxx
@@ -9,6 +9,14 @@ TEST_CASE("Raw bounded construction", "") {
   REQUIRE(x.max() == 42);
 }
 
+// To be refactored once we find a good method for
+// testing compile time constraints
+//TEST_CASE("Compile time bounds checking", "") {
+//  // Should not be able to compile these!
+//  falaise::bounded_int<2,1> x{};
+//  falaise::bounded_int<5,5> y{};
+//}
+
 TEST_CASE("Out of bounds construction", "") {
   using address = falaise::bounded_int<0,119>;
 

--- a/source/falaise/test/test_bounded_int.cxx
+++ b/source/falaise/test/test_bounded_int.cxx
@@ -3,7 +3,7 @@
 #include "falaise/bounded_int.h"
 
 TEST_CASE("Raw bounded construction", "") {
-  falaise::bounded_int<-1,42> x{};
+  falaise::bounded_int<-1, 42> x{};
   REQUIRE(x == -1);
   REQUIRE(x.min() == -1);
   REQUIRE(x.max() == 42);
@@ -11,14 +11,14 @@ TEST_CASE("Raw bounded construction", "") {
 
 // To be refactored once we find a good method for
 // testing compile time constraints
-//TEST_CASE("Compile time bounds checking", "") {
+// TEST_CASE("Compile time bounds checking", "") {
 //  // Should not be able to compile these!
 //  falaise::bounded_int<2,1> x{};
 //  falaise::bounded_int<5,5> y{};
 //}
 
 TEST_CASE("Out of bounds construction", "") {
-  using address = falaise::bounded_int<0,119>;
+  using address = falaise::bounded_int<0, 119>;
 
   // Must be able to construct at bounds
   REQUIRE_NOTHROW(address good{0});
@@ -30,7 +30,7 @@ TEST_CASE("Out of bounds construction", "") {
 }
 
 TEST_CASE("Assignment operators work", "") {
-  using address = falaise::bounded_int<-42,119>;
+  using address = falaise::bounded_int<-42, 119>;
 
   address x;
 
@@ -45,4 +45,18 @@ TEST_CASE("Assignment operators work", "") {
   // Out of bounds assignment must throw
   REQUIRE_THROWS_AS(x = -43, std::out_of_range);
   REQUIRE_THROWS_AS(x = -120, std::out_of_range);
+}
+
+TEST_CASE("Assignments from/to other builtin integrals", "") {
+  // NB: Relies on implicit conversions, which clang-tidy and
+  // so on may warn about. In that case, likely just need
+  // non-explicit constructors. Conversion to (operator T())
+  // other integrals would need to check that bounds fit inside
+  // limits
+  falaise::bounded_int<4,10> x;
+  size_t y = 5;
+  uint8_t z = 2;
+
+  REQUIRE_NOTHROW(x = y);
+  REQUIRE_THROWS_AS(x = z, std::out_of_range);
 }

--- a/source/falaise/test/test_property_set.cxx
+++ b/source/falaise/test/test_property_set.cxx
@@ -252,6 +252,12 @@ TEST_CASE("property_set type put/get specialization works", "") {
   }
 }
 
+TEST_CASE("Integer put/get specializations work", "") {
+  // Properties only stores int, but allow put/get to supply
+  // other int types provided value is within numeric_limits.
+  REQUIRE(false);
+}
+
 TEST_CASE("Creation from file works", "") {
   std::string fname{"kakhjbfdkb.conf"};
   datatools::properties tmp{makeSampleProperties()};
@@ -269,6 +275,11 @@ TEST_CASE("Creation from file works", "") {
   }
 
   remove(fname.c_str());
+}
+
+TEST_CASE("Creation from istream works", "") {
+  // So we're not constrained by filesystem
+  REQUIRE(false);
 }
 
 // Use the below as examples of how datatools::properties

--- a/source/falaise/test/test_property_set.cxx
+++ b/source/falaise/test/test_property_set.cxx
@@ -122,7 +122,20 @@ TEST_CASE("Retriever interfaces work", "") {
   // - x = 2 if "key" not in pset
   // - x = value of key if key exists and of right type
   // - throws wrong_type if key exists and not type of x
-  REQUIRE(false);
+  const int kMyDefault = 415627;
+  int myDefault = kMyDefault;
+  SECTION("No assignment when key does not exist") {
+    REQUIRE_NOTHROW(ps.assign_if("thiskeydoesnotexists", myDefault));
+    REQUIRE(myDefault == kMyDefault);
+  }
+  SECTION("Attempted assignment with mismatched types throws") {
+    REQUIRE_THROWS_AS(ps.assign_if("baz", myDefault), falaise::wrong_type_error);
+    REQUIRE(myDefault == kMyDefault);
+  }
+  SECTION("Assignment succeeds on matching key and type") {
+    REQUIRE_NOTHROW(ps.assign_if("foo", myDefault));
+    REQUIRE(myDefault == ps.get<int>("foo"));
+  }
 }
 
 TEST_CASE("Insertion/Erase interfaces work", "") {

--- a/source/falaise/test/test_property_set.cxx
+++ b/source/falaise/test/test_property_set.cxx
@@ -3,6 +3,7 @@
 #include "falaise/property_set.h"
 
 #include <cstdio>
+#include <sstream>
 #include "bayeux/datatools/clhep_units.h"
 #include "bayeux/datatools/units.h"
 
@@ -287,8 +288,21 @@ TEST_CASE("Creation from file works", "") {
 }
 
 TEST_CASE("Creation from istream works", "") {
-  // So we're not constrained by filesystem
-  REQUIRE(false);
+  // Creation from file exercises ifstream case
+  // Use stringstream here
+  const char* psRaw = R"ps(
+    x : integer = 2
+    y : string = "hello"
+  )ps";
+  std::istringstream iss{psRaw};
+
+  falaise::property_set ps;
+  REQUIRE_NOTHROW(make_property_set(iss, ps));
+
+  auto names = ps.get_names();
+  REQUIRE(names.size() == 2);
+  REQUIRE(ps.get<int>("x") == 2);
+  REQUIRE(ps.get<std::string>("y") == "hello");
 }
 
 // Use the below as examples of how datatools::properties

--- a/source/falaise/test/test_property_set.cxx
+++ b/source/falaise/test/test_property_set.cxx
@@ -71,6 +71,11 @@ TEST_CASE("Observer interfaces work", "") {
   SECTION("properties are correctly identified") {
     REQUIRE(ps.has_key("myprop"));
     REQUIRE(ps.is_key_to_property("myprop"));
+
+    REQUIRE(ps.is_key_to<std::string>("myprop"));
+    REQUIRE_FALSE(ps.is_key_to<int>("myprop"));
+    REQUIRE_FALSE(ps.is_key_to<std::string>("notpresent"));
+
     REQUIRE_FALSE(ps.is_key_to_property("notpresent"));
     REQUIRE_FALSE(ps.is_key_to_sequence("myprop"));
   }

--- a/source/falaise/test/test_property_set.cxx
+++ b/source/falaise/test/test_property_set.cxx
@@ -113,6 +113,15 @@ TEST_CASE("Retriever interfaces work", "") {
 
   REQUIRE_THROWS_AS(ps.get<falaise::path>("flatstring"), falaise::wrong_type_error);
   REQUIRE_NOTHROW(ps.get<falaise::path>("apath"));
+
+  // Provide easy defaulting interfaces to handle the self default case
+  // x = 2;
+  // x = ps.get<T>("key", x);
+  // Post-conditions are:
+  // - x = 2 if "key" not in pset
+  // - x = value of key if key exists and of right type
+  // - throws wrong_type if key exists and not type of x
+  REQUIRE(false);
 }
 
 TEST_CASE("Insertion/Erase interfaces work", "") {

--- a/source/falaise/user_level.h
+++ b/source/falaise/user_level.h
@@ -1,4 +1,4 @@
-//! \file falaise/common/user_profile.h - User profile
+//! \file falaise/user_level.h - User profile
 //
 // Copyright (c) 2017 by François Mauger <mauger@lpccaen.in2p3.fr>
 // Copyright (c) 2017 by Université de Caen Normandie


### PR DESCRIPTION
This updates the following existing and new interfaces related to handling `datatools::properties` in Falaise modules:

- `falaise::property_set`
  - Convenience functions for parameter assignment
  - Add ability to validate of incoming values from scripts
- `falaise::bounded_int`
  - Very simple type to model an integral value that is required to be within a limited range of values
  - Intended for use in reconstruction for automatic and safe indexing of tracker/calorimeter blocks rather than the current bare integers with boilerplate error checking everywhere.
- `snemo::datamodels`
  - A couple of free functions to make adding data products to the event record easier and with clearer errors than provided by `datatools::things`

Whilst there's a reasonable amount of code here, I hope it's relatively clear. The primary thing to look at is the documentation in:

- source/falaise/bounded_int.h
- source/falaise/property_set.h
- source/falaise/snemo/datamodels/event.h

As these are intended for simulation/reconstruction/analysis users, this needs to be clear, so questions, feedback etc very welcome!