### PR TITLE
Fix error in setting up mapped magnetic field

### DIFF
--- a/programs/flsimulate/tests/CMakeLists.txt
+++ b/programs/flsimulate/tests/CMakeLists.txt
@@ -211,3 +211,10 @@ add_test(NAME flsimulate-script-xwall_gveto_pmt_glass-run
           -c "${CMAKE_CURRENT_SOURCE_DIR}/flsimulate-script-xwall_gveto_pmt_glass.conf" -o "${CMAKE_CURRENT_BINARY_DIR}/flsimulate-script-xwall_gveto_pmt_glass.brio"
   )
 set_falaise_test_environment(flsimulate-script-Bi207_source_calibration-run)
+
+# - Flsimulate issue #198, and tests that mapped magnetic field can be used
+add_test(NAME flsimulate-issue198-run
+  COMMAND flsimulate
+          -c "${CMAKE_CURRENT_SOURCE_DIR}/flsimulate-issue198.conf" -o "${CMAKE_CURRENT_BINARY_DIR}/issue198.brio"
+  )
+set_falaise_test_environment(flsimulate-issue198-run)

--- a/programs/flsimulate/tests/flsimulate-issue198.conf
+++ b/programs/flsimulate/tests/flsimulate-issue198.conf
@@ -1,0 +1,15 @@
+#@key_label  "name"
+#@meta_label "type"
+[name="flsimulate" type="flsimulate::section"]
+numberOfEvents : integer = 1
+
+[name="flsimulate.variantService" type="flsimulate::section"]
+# Issue was that on startup of flsimulate, an exception would be thrown
+#
+# flsimulate : Setup/run of simulation threw exception
+# value at 'map_file' is not of requested type
+#
+settings : string[2] = \
+  "geometry:layout/if_basic/magnetic_field/is_active/type=Mapped" \
+  "geometry:layout/if_basic/magnetic_field/is_active/type/if_mapped/map=Map0" 
+

--- a/source/falaise/snemo/geometry/mapped_magnetic_field.cc
+++ b/source/falaise/snemo/geometry/mapped_magnetic_field.cc
@@ -351,7 +351,7 @@ void mapped_magnetic_field::initialize(const datatools::properties& config_,
     DT_THROW(std::logic_error, "Invalid mapping mode '" << modeStr << "'!");
   }
 
-  mapFile_ = ps.get<std::string>("map_file", mapFile_);
+  mapFile_ = ps.get<falaise::path>("map_file", mapFile_);
   // if (mapMode_ == map_mode_t::IMPORT_CSV_MAP_0) { // Useless as this is the only mode
   fieldMap_.reset(new MapImpl{mapFile_});
   //}


### PR DESCRIPTION
As reported in #198, the mapped magnetic field setup cannot be used using the current `develop` branch. Tags 4.0.2 and 4.0.3 have been confirmed not to be affected. The error was traced to commit 42ed724 and the lines

https://github.com/SuperNEMO-DBD/Falaise/blob/42ed724b61737122fd161e2f2b180547827f07aa/source/falaise/snemo/geometry/mapped_magnetic_field.cc#L353-L357

The `map_file` parameter is strictly a `falaise::path`, so should be retrieved from the properties as such.

This PR is split into two commits - the first to provide a simple test that exercises the bug, the second to fix.

Fixes: #198 
