### PR TITLE
Fix incorrect GVeto column ID validation (Issue #199)

### DIFF
--- a/source/falaise/snemo.cmake
+++ b/source/falaise/snemo.cmake
@@ -137,6 +137,7 @@ list(APPEND FalaiseLibrary_SOURCES
 list(APPEND FalaiseLibrary_TESTS_CATCH
   snemo/test/test_snemo_datamodel_event.cxx
   snemo/test/test_snemo_datamodel_timestamp.cxx
+  snemo/test/test_snemo_geometry_gveto_locator_2.cxx
   snemo/test/test_module.cxx
   snemo/test/test_service.cxx
   )

--- a/source/falaise/snemo/geometry/gveto_locator.cc
+++ b/source/falaise/snemo/geometry/gveto_locator.cc
@@ -454,13 +454,13 @@ double gveto_locator::getXCoordOfColumn(uint32_t side, uint32_t wall, uint32_t c
 
   if (side == (uint32_t)side_t::BACK) {
     DT_THROW_IF(
-        column >= backCaloBlock_X_[wall].size(), std::out_of_range,
-        "Invalid column number(" << column << ">" << backCaloBlock_X_[wall].size() - 1 << ")!");
+        column >= backCaloBlock_Y_[wall].size(), std::out_of_range,
+        "Invalid column number(" << column << ">" << backCaloBlock_Y_[wall].size() - 1 << ")!");
     return backCaloBlock_X_[wall][column];
   }
   DT_THROW_IF(
-      column >= frontCaloBlock_X_[wall].size(), std::out_of_range,
-      "Invalid column number(" << column << ">" << frontCaloBlock_X_[wall].size() - 1 << ")!");
+      column >= frontCaloBlock_Y_[wall].size(), std::out_of_range,
+      "Invalid column number(" << column << ">" << frontCaloBlock_Y_[wall].size() - 1 << ")!");
   return frontCaloBlock_X_[wall][column];
 }
 

--- a/source/falaise/snemo/test/test_snemo_geometry_gveto_locator_2.cxx
+++ b/source/falaise/snemo/test/test_snemo_geometry_gveto_locator_2.cxx
@@ -1,0 +1,59 @@
+// Catch
+#include "catch.hpp"
+
+#include "falaise/snemo/services/geometry.h"
+#include "falaise/snemo/services/service_handle.h"
+#include "falaise/snemo/geometry/gveto_locator.h"
+#include "falaise/snemo/geometry/locator_plugin.h"
+#include "falaise/snemo/geometry/locator_helpers.h"
+
+#include "bayeux/datatools/multi_properties.h"
+#include "bayeux/datatools/service_manager.h"
+
+
+TEST_CASE("Exercise Issue 199", "") {
+  datatools::service_manager dummyServices{};
+  datatools::multi_properties config;
+  config.add_section("geometry", "geomtools::geometry_service")
+      .store_path("manager.configuration_file",
+                  "@falaise:snemo/demonstrator/geometry/GeometryManager.conf");
+  dummyServices.load(config);
+  dummyServices.initialize();
+  snemo::service_handle<snemo::geometry_svc> gs{dummyServices};
+
+  // Get the gveto locator
+  const snemo::geometry::locator_plugin* lp = snemo::geometry::getSNemoLocator(*(gs.operator->()),"locators_driver");
+  const snemo::geometry::gveto_locator& gl = lp->gvetoLocator();
+
+  // Check sides/walls/columns
+  // Only one module
+  const uint32_t NModule = gl.getModuleNumber();
+  const uint32_t NSides = gl.numberOfSides();
+  const uint32_t NWalls = gl.numberOfWalls();
+
+  // These are pure sanity checks, albeit hardcoded
+  REQUIRE(NModule == 0);
+  REQUIRE(NSides == 2);
+  REQUIRE(NWalls == 2);
+
+  // We can count columns over side/wall - again expectation is hardcoded
+  for(uint32_t s=0; s < NSides; ++s) {
+    for(uint32_t w=0; w < NWalls; ++w) {
+      REQUIRE(gl.numberOfColumns(s,w) == 16);
+    }
+  }
+
+  // Expected GIDs are [category:module:side:wall:column]
+  // Category is "1253" (from resources/snemo/demonstrator/geometry/GeomIDMaps/tracker_categories.lis)
+  // Module is fixed here at "0"
+  // Then have 2x2x16 range of allowed GIDs (so 64 blocks)
+  for(uint32_t s=0; s < NSides; ++s) {
+    for(uint32_t w=0; w < NWalls; ++w) {
+      for(uint32_t c=0; c < 16; ++c) {
+        REQUIRE(gl.isValidAddress(s,w,c));
+        // This should exercise Issue 199
+        REQUIRE_NOTHROW(gl.getBlockPosition(s,w,c));
+      }
+    }
+  }
+}


### PR DESCRIPTION
As reported in Issue #199, the current tip of `develop` can fail with errors from CAT on incorrect indices for gamma veto blocks, e.g.

```console
[fatal:virtual base_module::process_status dpp::chain_module::process(::datatools::things &):185] Module 'CATTrackerClusterizer' failed to process event record; message is '[double snemo::geometry::gveto_locator::getXCoordOfColumn(uint32_t, uint32_t, uint32_t) const:463: Invalid column number(6>0)!]'
```

in case of file supplied to reproduce error. Traced to changes made in 42ed724, but cause not as yet pinpointed. 

This PR will address this, the first step of this is a test to reproduce the bug. It simply runs `flreconstruct` over a single-event `.brio` file which reproduces the error. Once bug is traced, a cleaner unit test should be added. Purely WIP until the fix is identified and made.

Fixes: #199 

