### PR TITLE
Resolve issue with present but empty PTD bank after standard pipeline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,20 +71,21 @@ endif()
 # Configure testing if required
 #
 option(FALAISE_ENABLE_TESTING "Build unit testing system for Falaise" OFF)
-if(FALAISE_ENABLE_TESTING)
-  enable_testing()
 
-  # Common testing environment
-  set(_falaise_TEST_ENVIRONMENT
+# Common testing environment
+set(_falaise_TEST_ENVIRONMENT
   "FALAISE_RESOURCE_DIR=${PROJECT_SOURCE_DIR}/resources"
   "PATH=${PROJECT_BUILD_BINDIR}:$ENV{PATH}"
   )
 
-  macro(set_falaise_test_environment _tname)
-    set_property(TEST ${_tname}
-      APPEND PROPERTY ENVIRONMENT ${_falaise_TEST_ENVIRONMENT}
-    )
-  endmacro()
+macro(set_falaise_test_environment _tname)
+  set_property(TEST ${_tname}
+    APPEND PROPERTY ENVIRONMENT ${_falaise_TEST_ENVIRONMENT}
+  )
+endmacro()
+
+if(FALAISE_ENABLE_TESTING)
+  enable_testing()
 endif()
 
 #-----------------------------------------------------------------------

--- a/modules/ChargedParticleTracking/ChargedParticleTracking/charged_particle_tracking_module.cc
+++ b/modules/ChargedParticleTracking/ChargedParticleTracking/charged_particle_tracking_module.cc
@@ -131,7 +131,7 @@ dpp::base_module::process_status charged_particle_tracking_module::process(
   const auto& the_tracker_trajectory_data = event.get<snedm::tracker_trajectory_data>(TTDTag_);
 
   // Create or reset output bank
-  auto the_particle_track_data =
+  auto& the_particle_track_data =
       ::snedm::getOrAddToEvent<snedm::particle_track_data>(PTDTag_, event);
   the_particle_track_data.clear();
 

--- a/programs/flreconstruct/FLReconstructPipeline.cc
+++ b/programs/flreconstruct/FLReconstructPipeline.cc
@@ -197,6 +197,7 @@ falaise::exit_code do_pipeline(const FLReconstructParams& flRecParameters) {
       }
       if (recInput->process(workItem) != dpp::base_module::PROCESS_OK) {
         DT_LOG_FATAL(flRecParameters.logLevel, "Failed to read data record from input source");
+        code = falaise::EXIT_UNAVAILABLE;
         break;
       }
 
@@ -212,12 +213,15 @@ falaise::exit_code do_pipeline(const FLReconstructParams& flRecParameters) {
       // This is a very conservative approach, but it is compatible with the default behaviour of
       // the bxdpp_processing executable.
       if (pStatus == dpp::base_module::PROCESS_FATAL) {
+        code = falaise::EXIT_UNAVAILABLE;
         break;
       }
       if (pStatus == dpp::base_module::PROCESS_ERROR) {
+        code = falaise::EXIT_UNAVAILABLE;
         break;
       }
       if (pStatus == dpp::base_module::PROCESS_ERROR_STOP) {
+        code = falaise::EXIT_UNAVAILABLE;
         break;
       }
 
@@ -234,6 +238,7 @@ falaise::exit_code do_pipeline(const FLReconstructParams& flRecParameters) {
         pStatus = recOutputHandle->process(workItem);
         if (pStatus != dpp::base_module::PROCESS_OK) {
           DT_LOG_FATAL(flRecParameters.logLevel, "Failed to write data record to output sink");
+          code = falaise::EXIT_UNAVAILABLE;
           break;
         }
       }

--- a/programs/flreconstruct/tests/CMakeLists.txt
+++ b/programs/flreconstruct/tests/CMakeLists.txt
@@ -113,3 +113,14 @@ add_test(NAME flreconstruct-fix-issue8-validation
   )
 set_falaise_test_environment(flreconstruct-fix-issue8-validation)
 
+# - Validation of Issue #201 fix
+# 1. Need a module to test contents of PTD bank
+add_library(TestIssue201 SHARED issue201/TestIssue201.cc)
+target_link_libraries(TestIssue201 Falaise)
+set_target_properties(TestIssue201 PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BUILD_PREFIX}/${CMAKE_INSTALL_PLUGINDIR}")
+# 2. Run test as script to generate deterministic sim/reco file
+add_test(NAME flreconstruct-fix-issue-201
+  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/issue201/run.sh ${CMAKE_CURRENT_SOURCE_DIR}/issue201
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  )
+set_falaise_test_environment(flreconstruct-fix-issue-201)

--- a/programs/flreconstruct/tests/issue201/TestIssue201.cc
+++ b/programs/flreconstruct/tests/issue201/TestIssue201.cc
@@ -1,0 +1,34 @@
+#include "falaise/snemo/datamodels/event_header.h"
+#include "falaise/snemo/datamodels/particle_track_data.h"
+#include "falaise/snemo/processing/module.h"
+namespace flp = falaise::processing;
+
+// A trivial wrapped module
+class TestIssue201 {
+ public:
+  TestIssue201() = default;
+  TestIssue201(falaise::property_set const& /*unused*/, datatools::service_manager& /*unused*/)
+      : TestIssue201() {}
+
+  flp::status process(datatools::things& e) {
+    // Need event header and PTD to check
+    const auto& eh = e.get<snemo::datamodel::event_header>("EH");
+    const auto& ptd = e.get<snemo::datamodel::particle_track_data>("PTD");
+
+    // Use event id and particle count to compare
+    int id = eh.get_id().get_event_number();
+    size_t expectedParticles = ptdCounts_.at(id);
+    size_t actualParticles = ptd.numberOfParticles();
+
+    // Assert that we have the expected number of particles
+    std::cout << id << ", " << expectedParticles << ", " << actualParticles << std::endl;
+    DT_THROW_IF(expectedParticles != actualParticles, std::logic_error,
+                "Event " << id << " has " << actualParticles << " particles, expected " << expectedParticles);
+
+    return flp::status::PROCESS_OK;
+  }
+
+ private:
+  std::vector<size_t> ptdCounts_ = {1, 5, 1, 4, 3, 2, 1, 1, 1, 0};
+};
+FALAISE_REGISTER_MODULE(TestIssue201)

--- a/programs/flreconstruct/tests/issue201/issue201_reco.conf
+++ b/programs/flreconstruct/tests/issue201/issue201_reco.conf
@@ -1,0 +1,9 @@
+#@key_label   "name"
+#@meta_label  "type"
+[name="flreconstruct.plugins" type="flreconstruct::section"]
+plugins : string[1] = "TestIssue201"
+
+[name="pipeline" type="dpp::chain_module"]
+modules : string[1] = "TestIssue201"
+
+[name="TestIssue201" type="TestIssue201"]

--- a/programs/flreconstruct/tests/issue201/issue201_sim.conf
+++ b/programs/flreconstruct/tests/issue201/issue201_sim.conf
@@ -1,0 +1,10 @@
+#@key_label  "name"
+#@meta_label "type"
+[name="flsimulate" type="flsimulate::section"]
+numberOfEvents : integer = 10
+
+[name="flsimulate.simulation" type="flsimulate::section"]
+rngEventGeneratorSeed         : integer = 314159
+rngVertexGeneratorSeed        : integer = 765432
+rngGeant4GeneratorSeed        : integer = 123456
+rngHitProcessingGeneratorSeed : integer = 987654

--- a/programs/flreconstruct/tests/issue201/run.sh
+++ b/programs/flreconstruct/tests/issue201/run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -ex
+flsimulate -c $1/issue201_sim.conf -o issue201_sim.brio
+flreconstruct -i issue201_sim.brio -p "@falaise:snemo/demonstrator/reconstruction/official-2.0.0.conf" -o issue201_reco.brio
+flreconstruct -i issue201_reco.brio -p $1/issue201_reco.conf -o issue201_reco_2.brio


### PR DESCRIPTION
As reported in Issue #201, the PTD bank is present but always empty in the current `develop` branch. Triaging with `git bisect` and the known good tag v4.0.3 revealed that commit 9aee9ec16a9244d25d8d1df27fb7407b05e59926 introduced the bug.

A test is now implemented to reproduce the bug via:

- Creates 10 events with flsimulate using fixed seeds
- Processes these events with the current official pipeline
- Processes the output of the flreconstruct run, checking the expected
  number of particles in PTD with the actual.

I think I can see the cause of the bug, but want to test the above first to confirm it identifies the problem.

A minor bug fix was needed in `flreconstruct` to ensure a good error code is returned on the pipeline processing failing.

Fixes: #201
