### PR TITLE
Document release stability and development setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,11 @@ Falaise are described in the main [README](README.md)
 - [Catch](https://github.com/philsquared/Catch) for C++ unit testing
 - [Doxygen](http://www.doxygen.org) plus [Markdown](https://www.stack.nl/~dimitri/doxygen/manual/markdown.html) for API and Reference Documentation
 
+## Core Dependencies of Falaise
+Falaise uses several external packages to provide physics and data structure functionality.
+To build and test Falaise, you will require an install of these on the machine you intend
+to develop on. There are several ways to do this, and these are fully documented in the main
+[README.md](README.md) document.
 
 # Falaise Git Workflow
 ## Basic Git Configuration

--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ We recommend installing Falaise and its requirements as documented on our
 [fork of Homebrew](https://github.com/SuperNEMO-DBD/brew). By default this will
 install the latest stable release of Falaise. All releases with details of the changes
 introduced are listed on the [GitHub Releases page](https://github.com/SuperNEMO-DBD/Falaise/releases).
-For production and general work, you should only use a **stable release** (i.e. a git tag). These are _not_
-guaranteed to be bug free, but have passed all known/implemented tests at the time of their
-release (i.e. no known bugs at that time), with physics related features validated to the same level. If you wish to develop
+For production and general work, you should only use a **stable release** (i.e. a git tag using a version
+number such as `v4.0.3`). These are _not_ guaranteed to be bug free, but have passed all
+known/implemented tests at the time of their release (i.e. no known bugs at that time), with physics
+related features validated to the same level. If you wish to develop
 Falaise, e.g. find and fix a bug, or add new functionality, then you should start this work
 from the `develop` branch and build Falaise from source as detailed later in this document.
 The `develop` branch is used to integrate fixes and new functionality, and whilst it is tested

--- a/README.md
+++ b/README.md
@@ -24,7 +24,20 @@ can be used too.
 
 # Getting and Using Falaise
 ## Quickstart
-We recommend installing Falaise and its requirements as documented on our [fork of Homebrew](https://github.com/SuperNEMO-DBD/brew).
+We recommend installing Falaise and its requirements as documented on our
+[fork of Homebrew](https://github.com/SuperNEMO-DBD/brew). By default this will
+install the latest stable release of Falaise. All releases with details of the changes
+introduced are listed on the [GitHub Releases page](https://github.com/SuperNEMO-DBD/Falaise/releases).
+For production and general work, you should only use a **stable release** (i.e. a git tag). These are _not_
+guaranteed to be bug free, but have passed all known/implemented tests at the time of their
+release (i.e. no known bugs at that time), with physics related features validated to the same level. If you wish to develop
+Falaise, e.g. find and fix a bug, or add new functionality, then you should start this work
+from the `develop` branch and build Falaise from source as detailed later in this document.
+The `develop` branch is used to integrate fixes and new functionality, and whilst it is tested
+to the same level as releases, it should not be used for production work as this development cycle
+may introduce new and as-yet unidentified bugs. Please see the [CONTRIBUTING.md](CONTRIBUTING.md) document
+for further details on using the `develop` branch and contributing to the development of Falaise.
+
 Build-from-source and [Docker](https://www.docker.com)/[Singularity](https://www.sylabs.io/singularity/)
 Image installs are available, both providing a complete suite of software and tools for using and developing Falaise and extension modules.
 


### PR DESCRIPTION
As requested by Analysis Board, document expected stability of releases and develop branch.

Add short guide to setting up for development in contribution guide, linking back to existing documentation in README.


