### PR TITLE
fix datatools::kernel::stuff into datatools::stuff to sync with bxcppdev/bayeux 32f2144 commit

### DIFF
--- a/programs/flvisualize/programs/FLVisualizeCommandLine.cc
+++ b/programs/flvisualize/programs/FLVisualizeCommandLine.cc
@@ -21,15 +21,15 @@ namespace bpo = boost::program_options;
 // Initialization flags for kernel setup
 uint32_t app_kernel_init_flags() {
   uint32_t kernel_init_flags = 0;
-  kernel_init_flags |= datatools::kernel::init_no_help;
-  kernel_init_flags |= datatools::kernel::init_no_splash;
-  kernel_init_flags |= datatools::kernel::init_no_inhibit_libinfo;
-  kernel_init_flags |= datatools::kernel::init_no_libinfo_logging;
-  kernel_init_flags |= datatools::kernel::init_no_variant;
-  kernel_init_flags |= datatools::kernel::init_no_inhibit_variant;
-  kernel_init_flags |= datatools::kernel::init_no_locale_category;
-  kernel_init_flags |= datatools::kernel::init_no_inhibit_qt_gui;
-  kernel_init_flags |= datatools::kernel::init_no_inhibit_urnquery;
+  kernel_init_flags |= datatools::init_no_help;
+  kernel_init_flags |= datatools::init_no_splash;
+  kernel_init_flags |= datatools::init_no_inhibit_libinfo;
+  kernel_init_flags |= datatools::init_no_libinfo_logging;
+  kernel_init_flags |= datatools::init_no_variant;
+  kernel_init_flags |= datatools::init_no_inhibit_variant;
+  kernel_init_flags |= datatools::init_no_locale_category;
+  kernel_init_flags |= datatools::init_no_inhibit_qt_gui;
+  kernel_init_flags |= datatools::init_no_inhibit_urnquery;
   return kernel_init_flags;
 }
 


### PR DESCRIPTION
Falaise develop is not compiling with Bayeux develop following a recent update on Bayeux init flags 