### PR TITLE
Update contribution documents

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -326,7 +326,16 @@ Be careful with `rebase` after you have pushed your Topic Branch to your Fork
 as `rebase` changes the commit history. We'll discuss how to handle this later.
 
 You should also frequently check that your changes compile and pass needed tests.
-Please consult the main [README](README.md) for complete details on configuration, build, and testing options.
+Please consult the main [README](README.md) for complete details on configuration, build, and testing options,
+but in short, make sure you do:
+
+```
+$ mkdir my-topic-branch.build
+$ cd my-topic-branch.build
+$ cmake -DFALAISE_ENABLE_TESTING=ON ../Falaise.git
+$ make -jN
+$ ctest -VV -jN
+```
 
 Do remember that you have the power of a local git repository at your fingertips
 during the development process so:
@@ -486,7 +495,7 @@ online in the Pull Request comments to keep everyone in the loop on changes.
 
 The stages of review and testing are listed below:
 
-1. Automatic Travis-CI Build and Test against latest `develop`
+1. Automatic Build and Test against latest `develop`
 2. Code Fixes and Review
 3. Acceptance and merge to `develop`
 
@@ -661,6 +670,19 @@ $ git fetch upstream
 $ git rebase upstream/develop
 $ git push origin develop
 $ git checkout -b name-of-topic
+```
+
+### Building and Testing a Topic Branch
+``` console
+$ mkdir name-of-topic.build
+$ cd name-of-topic.build
+$ cmake -DFALAISE_ENABLE_TESTING=ON ../Falaise.git
+$ make -jN
+$ ctest -VV -jN
+... make some edits ...
+$ make -jN
+$ ctest -VV -jN
+... edit/repeat ...
 ```
 
 ### Developing a Topic Branch Locally

--- a/README.md
+++ b/README.md
@@ -89,11 +89,11 @@ your choice:
 
 With these in place, to get set up on your local system to develop Falaise you should then:
 
-1. Create your own Fork of the SuperNEMO-DBD/Falaise repository on GitHub
+1. Create your own Fork of the [SuperNEMO-DBD/Falaise](https://github.com/SuperNEMO-DBD/Falaise) repository on GitHub
 2. Clone your Fork to your local system
 3. Build and test Falaise
 4. Start developing and testing on a _Topic Branch_
-5. Submit your _Topic Branch_ to SuperNEMO-DBD/Falaise as a Pull Request
+5. Submit your _Topic Branch_ to [SuperNEMO-DBD/Falaise](https://github.com/SuperNEMO-DBD/Falaise) as a Pull Request
 
 Please see [CONTRIBUTING.md](CONTRIBUTING.md) for comprehensive guides and cheatsheets on this workflow. Here,
 we will quickly demonstrate steps 2 and 3.
@@ -101,7 +101,7 @@ we will quickly demonstrate steps 2 and 3.
 To get the source code from your Fork of Falaise locally, simply clone it:
 
 ```
-$ git clone https://github.com/<yourgithubid>Falaise.git Falaise.git
+$ git clone https://github.com/<yourgithubid>/Falaise.git Falaise.git
 ```
 
 With the source code cloned, it can be configured and compiled by doing:

--- a/README.md
+++ b/README.md
@@ -22,30 +22,27 @@ with each module (or set of modules) having its own directory.
 Additional modules from external sources and individual contribution
 can be used too.
 
-# Getting and Using Falaise
-## Quickstart
-We recommend installing Falaise and its requirements as documented on our
-[fork of Homebrew](https://github.com/SuperNEMO-DBD/brew). By default this will
-install the latest stable release of Falaise. All releases with details of the changes
+# Installing and Using Falaise
+If you are _using_ Falaise, i.e. running the applications to generate, process,
+and analyse data, _then you only require an install of Falaise_. If you need to _develop_
+Falaise, i.e. make changes to the code to fix issues or add new features, please
+see [Developing and Testing Falaise](#developing-and-testing-falaise) below.
+
+We recommend installing Falaise and its requirements as documented on our [fork of Homebrew](https://github.com/SuperNEMO-DBD/brew).
+By default this will install the latest **stable release** of Falaise. All releases with details of the changes
 introduced are listed on the [GitHub Releases page](https://github.com/SuperNEMO-DBD/Falaise/releases).
 For production and general work, you should only use a **stable release** (i.e. a git tag using a version
 number such as `v4.0.3`). These are _not_ guaranteed to be bug free, but have passed all
 known/implemented tests at the time of their release (i.e. no known bugs at that time), with physics
-related features validated to the same level. If you wish to develop
-Falaise, e.g. find and fix a bug, or add new functionality, then you should start this work
-from the `develop` branch and build Falaise from source as detailed later in this document.
-The `develop` branch is used to integrate fixes and new functionality, and whilst it is tested
-to the same level as releases, it should not be used for production work as this development cycle
-may introduce new and as-yet unidentified bugs. Please see the [CONTRIBUTING.md](CONTRIBUTING.md) document
-for further details on using the `develop` branch and contributing to the development of Falaise.
+related features validated to the same level.
 
-Build-from-source and [Docker](https://www.docker.com)/[Singularity](https://www.sylabs.io/singularity/)
-Image installs are available, both providing a complete suite of software and tools for using and developing Falaise and extension modules.
+[Docker](https://www.docker.com)/[Singularity](https://www.sylabs.io/singularity/)
+Image installs are also available, both providing a complete suite of software and tools for using and developing Falaise and extension modules. We strongly recommend Docker/Singularity Images on systems which support these tools,
+especially on institution systems/clusters such as CC-IN2P3, as they provide the most
+reliable and reproducible Falaise installs.
 
-We strongly recommend Docker/Singularity Images on systems which support these tools,
-especially on institution systems/clusters such as CC-IN2P3, as these provide the most
-reliable and reproducible environments. For both systems, we strongly recommend that you
-run and develop Falaise from within the `snemo-shell` environment provided, which is started and exited by running:
+For both native image installs we strongly recommend that you run the Falaise applications from within
+the `snemo-shell` shell environment provided, which is started and exited by running:
 
 ```console
 $ brew snemo-shell
@@ -60,71 +57,101 @@ $
 ```
 
 Once installed and setup, consult the [online documentation](https://supernemo-dbd.github.io/Falaise)
-for a full guide to running `flsimulate`, `flreconstruct`, and writing new plugin modules.
+for a full guide to running `flsimulate`, `flreconstruct`, and writing your own plugin modules.
 
 
-## Developing, Building, Testing and Installing from Source
-To get the source code, either download a release tarball or to get the latest development,
-do
+# Building and Testing Falaise
+If you wish to _develop_ Falaise, e.g. find and fix a bug, or add new functionality, then you
+_will need to get the Falaise source code and build and test it yourself_. The first step here
+is to install of the tools and libraries needed to build and test Falaise. The aforementioned
+[SuperNEMO Homebrew](https://github.com/SuperNEMO-DBD/brew) installer or Docker/Singularity
+installers can be used here for simplicity as they provide an install of all the needed software
+for development. You can also install the full list of prerequisites using the package manager of
+your choice:
+
+- Linux or macOS Operating System
+  - Supported Linux systems: CentOS7, Ubuntu 20.04LTS
+  - Other Linux distributions are known to work, but are **not supported**
+  - Supported macOS systems: 10.14/15 (Mojave, Catalina)
+- GCC (>= 7), Clang (>=6) or Xcode >= 10
+- [Git](https://git-scm.com)
+- [CMake](https://cmake.org) 3.12 or higher
+- [Doxygen](http://www.doxygen.org) 1.8 or higher
+- [Bayeux](https://github.com/SuperNEMO-DBD/Bayeux) 3.4.1 or higher
+- [Boost](https:/boost.org) 1.69.0 **only**
+  - Must provide `program_options`, `thread`, `serialization`, `filesystem` and `system` components
+- [Camp](https://github.com/tegesoft/camp) 0.7.1 or higher
+- [GSL](http://www.gnu.org/s/gsl) 2 or higher
+- [CLHEP](http://proj-clhep.web.cern.ch) 2.1.3.1 only
+- [Geant4](http://geant4.cern.ch) 9.6.4 only
+   - with GDML support enabled
+- [ROOT](http://root.cern.ch) 6.16 or higher
+
+With these in place, to get set up on your local system to develop Falaise you should then:
+
+1. Create your own Fork of the SuperNEMO-DBD/Falaise repository on GitHub
+2. Clone your Fork to your local system
+3. Build and test Falaise
+4. Start developing and testing on a _Topic Branch_
+5. Submit your _Topic Branch_ to SuperNEMO-DBD/Falaise as a Pull Request
+
+Please see [CONTRIBUTING.md](CONTRIBUTING.md) for comprehensive guides and cheatsheets on this workflow. Here,
+we will quickly demonstrate steps 2 and 3.
+
+To get the source code from your Fork of Falaise locally, simply clone it:
 
 ```
-$ git clone https://github.com/supernemo-dbd/Falaise.git Falaise.git
+$ git clone https://github.com/<yourgithubid>Falaise.git Falaise.git
 ```
 
-If you are building and testing Falaise for new developments (see [CONTRIBUTING.md](CONTRIBUTING.md),
-it's recommended to run the following inside a `snemo-shell` session so that `cmake` and the correct
-build environment are pre-configured. To build Falaise, do
+With the source code cloned, it can be configured and compiled by doing:
 
 ```
 $ mkdir Falaise.build
 $ cd Falaise.build
-$ cmake -DCMAKE_INSTALL_PREFIX=/where/you/want/to/install ../Falaise.git
-...
-```
-
-If you wish to enable `make test` after building, add the following option to cmake.
-
-```
-$ cmake -DFALAISE_ENABLE_TESTING=ON
+$ cmake -DFALAISE_ENABLE_TESTING=ON ../Falaise.git
 ```
 
 Errors at this stage are likely to be due to missing/unfound packages. If this is the
 case, `cmake` can be directed to look in specific places using the `CMAKE_PREFIX_PATH`
-variable (If you are running in an `snemo-shell` session, this is preset for you).
-For example, if `Boost` is installed in `$HOME/boost` and `GSL` in `$HOME/software/gsl`,
+variable. For example, if `Boost` is installed in `$HOME/boost` and `GSL` in `$HOME/software/gsl`,
 `cmake` would be run as:
 
 ```
-$ cmake -DCMAKE_PREFIX_PATH="$HOME/boost;$HOME/software/gsl" -DCMAKE_INSTALL_PREFIX=/some/path ../Falaise.git
+$ cmake -DCMAKE_PREFIX_PATH="$HOME/boost;$HOME/software/gsl" -DFALAISE_ENABLE_TESTING=ON ../Falaise.git
 ```
-
-The `CMAKE_INSTALL_PREFIX` variable tells CMake where the products of the build
-should be installed. Ensure you have write permissions to this location.
 
 After configuration is successful, the build is run by:
 
 ```
-$ make -j<N>
+$ make -jN
 ```
 
-Adjust `<N>` to the number of cores on your machine for a faster build. After a
-successful build, unit tests can be run using the `test` target:
+Adjust `N` to the number of cores on your machine for a faster build. After a
+successful build, unit tests can be run using `ctest`:
 
 ```
-$ make test
+$ ctest -jN
 ```
 
-This will run each test in sequence and provide a report of successes and failures.
+This will run the tests in parallel and provide a summary report of successes and failures. You
+can see full output from the tests, e.g. to check failures, by doing
+
+```
+$ ctest -jN -VV
+```
+
+See `man ctest` for further options.
 
 On completion of the build, the Falaise programs, libraries and documentation are available
-for use under a POSIX-style hierarchy under the `BuildProducts` subdirectory of
+for direct use under a POSIX-style hierarchy under the `BuildProducts` subdirectory of
 the directory in which you ran the build. For example,
 
 ```
 $ ./BuildProducts/bin/flsimulate --help
 ```
 
-Documentation for the build is viewable by opening the main page in your browser.
+Documentation is browsable by opening the main page in your browser.
 On macOS, the `open` command can be used:
 
 ```
@@ -143,55 +170,22 @@ $ xdg-open ./BuildProducts/share/Falaise-<VERSION>/Documentation/API/html/index.
 though ``xdg-open`` may not always be present (``gnome-open`` may be used
 instead, for example).
 
-If you need to install Falaise, you can run
-
-```
-$ make install
-```
-
-to install everything in a standard POSIX style hierarchy under the directory
-passed as ``CMAKE_INSTALL_PREFIX``.
+The above only covers the basics of creating a local development setup, and you
+should consult the full [CONTRIBUTING.md](CONTRIBUTING.md) for details of the
+development, testing and Pull Request submission process.
 
 
-## Full Prerequisites
-To build and run Falaise on your machine, the following OS and Software must be
-present:
+## Stability of the `develop` branch
 
-- Linux or macOS System
-  - Supported Linux systems: CentOS7, Ubuntu 16.04/18.04LTS
-  - Other Linux distributions are known to work, but are not
-    officially supported. However, patches are welcome to resolve encountered issues!
-  - Suported macOS systems: 10.13/14 (High Sierra/Mojave, 10.15/Catalina in progress)
-- GCC (>= 7), Clang (>=6) or Xcode >= 10
-- [CMake](https://cmake.org) 3.12 or higher
-- [Doxygen](http://www.doxygen.org) 1.8 or higher
-- [Bayeux](https://github.com/SuperNEMO-DBD/Bayeux) 3.4.1 or higher
-- [Boost](https:/boost.org) 1.69.0 only
-  - Must provide `program_options`, `thread`, `serialization`, `filesystem` and `system` components
-- [Camp](https://github.com/tegesoft/camp) 0.7.1 or higher
-- [GSL](http://www.gnu.org/s/gsl) 2 or higher
-- [CLHEP](http://proj-clhep.web.cern.ch) 2.1.3.1 only
-- [Geant4](http://geant4.cern.ch) 9.6.4 only
-   - with GDML support enabled
-- [ROOT](http://root.cern.ch) 6.16 or higher
-
-Falaise requires use of the C++11 or higher standard, so all of the above packages
-and their C++ dependencies must be built/installed using this standard. This is
-to ensure binary compatibility.
-
-The [SuperNEMO brew system](https://github.com/SuperNEMO-DBD/brew) can install the
-above, either as build-from-source or as Docker/Singularity Images.
+Please note that builds like the above **must not be used for production or analysis work**.
+The `develop` branch that provides the foundation for new developments is used only to _integrate fixes and new functionality_. Whilst it is tested to the same level as releases through the Pull Request process, the development
+cycle _may_ introduce new and as-yet unidentified bugs.
 
 
 # Getting Help
 
 If you have problems, questions, ideas or suggestions on Falaise or
 any of its submodules, [just raise this on the project board](https://supernemo-dbd.github.io/Falaise/issues).
-
-# Contributing to Falaise
-
-Please see the [Contribution Guide](https://github.com/SuperNEMO-DBD/Falaise/blob/develop/CONTRIBUTING.md#)
-for a detailed guide.
 
 # Naming
 Falaise is named thus because [Falaise is the town in Normandy](http://en.wikipedia.org/wiki/Falaise,_Calvados) where William
@@ -201,8 +195,6 @@ the Conqueror was born. Note this has nothing to do with SuperNEMO software!
 Please study the file ``LICENSE.txt`` for the distribution terms and
 conditions of use of Falaise.
 
-
-
-## Contributors
+# Contributors
 
 Many thanks go to Falaise's [contributors](https://github.com/SuperNEMO-DBD/Falaise/graphs/contributors)


### PR DESCRIPTION
As discussed in integration meetings, try and improve and make more obvious documents on contributing and when an install of Falaise is needed vs needing to build locally.

Needs a couple more eyes to check things over, but I'm not sure much more simplification/hand holding can be done...

