### PR TITLE
Fix compiler warnings when using Bayeux 3.5.0

### DIFF
--- a/source/falaise/snemo/cuts/event_header_cut.h
+++ b/source/falaise/snemo/cuts/event_header_cut.h
@@ -79,10 +79,10 @@ class event_header_cut : public cuts::i_cut {
   /// Initilization
   virtual void initialize(const datatools::properties& dps,
                           datatools::service_manager& services,
-                          cuts::cut_handle_dict_type& cuts);
+                          cuts::cut_handle_dict_type& cuts) override;
 
   /// Reset
-  virtual void reset();
+  virtual void reset() override;
 
   /// Set the 'Event header' bank label/name
   void setEventHeaderTag(const std::string& tag);
@@ -124,7 +124,7 @@ class event_header_cut : public cuts::i_cut {
   void _set_defaults();
 
   /// Selection
-  virtual int _accept();
+  virtual int _accept() override;
 
  private:
   std::string eventHeaderTag_;  //!< Name of the "Event header" bank

--- a/source/falaise/snemo/cuts/simulated_data_cut.h
+++ b/source/falaise/snemo/cuts/simulated_data_cut.h
@@ -75,10 +75,10 @@ class simulated_data_cut : public cuts::i_cut {
   /// Initilization
   virtual void initialize(const datatools::properties& dps,
                           datatools::service_manager& services,
-                          cuts::cut_handle_dict_type& cuts);
+                          cuts::cut_handle_dict_type& cuts) override;
 
   /// Reset
-  virtual void reset();
+  virtual void reset() override;
 
   /// Set the SD bank key
   void setSDTag(const std::string& tag);
@@ -112,7 +112,7 @@ class simulated_data_cut : public cuts::i_cut {
   void _set_defaults();
 
   /// Selection
-  virtual int _accept();
+  virtual int _accept() override;
 
  private:
   std::string SDTag_;  //!< Name of the "Simulated data" bank

--- a/source/falaise/snemo/datamodels/calibrated_calorimeter_hit.h
+++ b/source/falaise/snemo/datamodels/calibrated_calorimeter_hit.h
@@ -69,14 +69,14 @@ class calibrated_calorimeter_hit : public geomtools::base_hit {
   void set_sigma_energy(double);
 
   /// Check if the internal data of the hit are valid
-  bool is_valid() const;
+  bool is_valid() const override;
 
   /// Invalidate the internal data of hit
-  void invalidate();
+  void invalidate() override;
 
   /// Smart print
   virtual void tree_dump(std::ostream& out = std::clog, const std::string& title = "",
-                         const std::string& indent = "", bool is_last = false) const;
+                         const std::string& indent = "", bool is_last = false) const override;
 
  private:
   double energy_{datatools::invalid_real()};        //!< Energy associated to the hit

--- a/source/falaise/snemo/datamodels/calibrated_data.h
+++ b/source/falaise/snemo/datamodels/calibrated_data.h
@@ -58,11 +58,11 @@ class calibrated_data : public datatools::i_serializable,
   TrackerHitHdlCollection& tracker_hits();
 
   /// Clear attributes
-  virtual void clear();
+  virtual void clear() override;
 
   /// Smart print
   virtual void tree_dump(std::ostream& out = std::clog, const std::string& title = "",
-                         const std::string& indent = "", bool is_last = false) const;
+                         const std::string& indent = "", bool is_last = false) const override;
 
  private:
   CalorimeterHitHdlCollection calorimeter_hits_;  //!< Collection of calibrated calorimeter hits

--- a/source/falaise/snemo/datamodels/calibrated_tracker_hit.h
+++ b/source/falaise/snemo/datamodels/calibrated_tracker_hit.h
@@ -180,17 +180,17 @@ class calibrated_tracker_hit : public geomtools::base_hit {
   void set_fake(bool);
 
   /// Check if minimal calibration informations are present to consider the hit as valid and usable
-  bool is_valid() const;
+  bool is_valid() const override;
 
   /// Invalidate calibration informations stored in the hit
-  void invalidate();
+  void invalidate() override;
 
   /// Invalidate calibration informations stored in the hit
-  virtual void clear();
+  virtual void clear() override;
 
   /// Smart print method
   virtual void tree_dump(std::ostream& out = std::clog, const std::string& title = "",
-                         const std::string& indent = "", bool is_last = false) const;
+                         const std::string& indent = "", bool is_last = false) const override;
 
 
  protected:

--- a/source/falaise/snemo/datamodels/event_header.h
+++ b/source/falaise/snemo/datamodels/event_header.h
@@ -85,11 +85,11 @@ class event_header : public datatools::i_serializable,
   bool is_simulated() const;
 
   /// Clear the event header internal data
-  virtual void clear();
+  virtual void clear() override;
 
   /// Smart print
   virtual void tree_dump(std::ostream &out = std::clog, const std::string &title = "",
-                         const std::string &indent = "", bool is_last = false) const;
+                         const std::string &indent = "", bool is_last = false) const override;
 
  private:
   datatools::event_id id_{};                        //!< Run/Event ID

--- a/source/falaise/snemo/datamodels/helix_trajectory_pattern.h
+++ b/source/falaise/snemo/datamodels/helix_trajectory_pattern.h
@@ -42,7 +42,7 @@ class helix_trajectory_pattern : public base_trajectory_pattern {
   const geomtools::helix_3d& get_helix() const;
 
   /// Return the reference to the 1D shape associated to the trajectory
-  virtual const geomtools::i_shape_1d& get_shape() const;
+  virtual const geomtools::i_shape_1d& get_shape() const override;
 
  private:
   geomtools::helix_3d _helix_{};  //!< The helix embedded model

--- a/source/falaise/snemo/datamodels/line_trajectory_pattern.h
+++ b/source/falaise/snemo/datamodels/line_trajectory_pattern.h
@@ -39,7 +39,7 @@ class line_trajectory_pattern : public base_trajectory_pattern {
   const geomtools::line_3d& get_segment() const;
 
   /// Return the reference to the 1D shape associated to the trajectory
-  virtual const geomtools::i_shape_1d& get_shape() const;
+  virtual const geomtools::i_shape_1d& get_shape() const override;
 
  private:
   geomtools::line_3d _segment_{};  //!< The line/segment embedded model

--- a/source/falaise/snemo/datamodels/particle_track.h
+++ b/source/falaise/snemo/datamodels/particle_track.h
@@ -166,11 +166,11 @@ class particle_track : public geomtools::base_hit {
   const CalorimeterHitHdlCollection &get_associated_calorimeter_hits() const;
 
   /// Empty the contents of the particle track
-  void clear();
+  void clear() override;
 
   /// Smart print
   virtual void tree_dump(std::ostream &out = std::clog, const std::string &title = "",
-                         const std::string &indent = "", bool is_last = false) const;
+                         const std::string &indent = "", bool is_last = false) const override;
 
  private:
   charge_type charge_from_source_{UNDEFINED};  //!< Particle charge

--- a/source/falaise/snemo/datamodels/particle_track_data.h
+++ b/source/falaise/snemo/datamodels/particle_track_data.h
@@ -71,11 +71,11 @@ class particle_track_data : public datatools::i_serializable,
   void clearIsolatedCalorimeters();
 
   /// Clear the object
-  virtual void clear();
+  virtual void clear() override;
 
   /// Smart print
   virtual void tree_dump(std::ostream& out = std::clog, const std::string& title = "",
-                         const std::string& indent = "", bool is_last = false) const;
+                         const std::string& indent = "", bool is_last = false) const override;
 
  private:
   ParticleHdlCollection particles_;                    //!< Collection of particle track handles

--- a/source/falaise/snemo/datamodels/polyline_trajectory_pattern.h
+++ b/source/falaise/snemo/datamodels/polyline_trajectory_pattern.h
@@ -39,7 +39,7 @@ class polyline_trajectory_pattern : public base_trajectory_pattern {
   const geomtools::polyline_3d& get_path() const;
 
   /// Return the reference to the 1D shape associated to the trajectory
-  virtual const geomtools::i_shape_1d& get_shape() const;
+  virtual const geomtools::i_shape_1d& get_shape() const override;
 
  private:
   geomtools::polyline_3d _path_{};  //!< The polyline path embedded model

--- a/source/falaise/snemo/datamodels/tracker_cluster.h
+++ b/source/falaise/snemo/datamodels/tracker_cluster.h
@@ -58,11 +58,11 @@ class tracker_cluster : public geomtools::base_hit {
   const calibrated_tracker_hit& at(size_t index) const;
 
   /// Reset/invalidate the contents of the tracker cluster
-  void clear();
+  void clear() override;
 
   /// Smart print
   virtual void tree_dump(std::ostream& out = std::clog, const std::string& title = "",
-                         const std::string& indent = "", bool is_last = false) const;
+                         const std::string& indent = "", bool is_last = false) const override;
 
  private:
   TrackerHitHdlCollection hits_;  //!< Collection of Geiger hit handles

--- a/source/falaise/snemo/datamodels/tracker_clustering_data.h
+++ b/source/falaise/snemo/datamodels/tracker_clustering_data.h
@@ -143,7 +143,7 @@ class tracker_clustering_data : public datatools::i_serializable,
   const tracker_clustering_solution& at(size_t index) const;
 
   /// Reset the clustering solutions
-  virtual void clear();
+  virtual void clear() override;
 
   /// Check if there is some default clustering solution
   bool has_default() const;
@@ -165,7 +165,7 @@ class tracker_clustering_data : public datatools::i_serializable,
 
   /// Smart print
   virtual void tree_dump(std::ostream& out = std::clog, const std::string& title = "",
-                         const std::string& indent = "", bool is_last = false) const;
+                         const std::string& indent = "", bool is_last = false) const override;
 
  private:
   TrackerClusteringSolutionHdlCollection solutions_{};  //!< Collection of Geiger cluster solutions

--- a/source/falaise/snemo/datamodels/tracker_trajectory.h
+++ b/source/falaise/snemo/datamodels/tracker_trajectory.h
@@ -62,11 +62,11 @@ class tracker_trajectory : public geomtools::base_hit {
   const TrajectoryPattern& get_pattern() const;
 
   /// Empty the contents of the tracker trajectory
-  virtual void clear();
+  virtual void clear() override;
 
   /// Smart print
   virtual void tree_dump(std::ostream& out = std::clog, const std::string& title = "",
-                         const std::string& indent = "", bool is_last = false) const;
+                         const std::string& indent = "", bool is_last = false) const override;
 
  private:
   /// Detach the cluster

--- a/source/falaise/snemo/datamodels/tracker_trajectory_data.h
+++ b/source/falaise/snemo/datamodels/tracker_trajectory_data.h
@@ -68,11 +68,11 @@ class tracker_trajectory_data : public datatools::i_serializable,
   void reset();
 
   /// Clear the object
-  virtual void clear();
+  virtual void clear() override;
 
   /// Smart print
   virtual void tree_dump(std::ostream& out = std::clog, const std::string& title = "",
-                         const std::string& indent = "", bool is_last = false) const;
+                         const std::string& indent = "", bool is_last = false) const override;
 
  private:
   TrackerTrajectorySolutionHdlCollection

--- a/source/falaise/snemo/datamodels/tracker_trajectory_solution.h
+++ b/source/falaise/snemo/datamodels/tracker_trajectory_solution.h
@@ -93,11 +93,11 @@ class tracker_trajectory_solution : public datatools::i_serializable,
   void invalidate_unfitted_clusters();
 
   /// Empty the contents of the tracker trajectories solution
-  virtual void clear();
+  virtual void clear() override;
 
   /// Smart print
   virtual void tree_dump(std::ostream& out = std::clog, const std::string& title = "",
-                         const std::string& indent = "", bool is_last = false) const;
+                         const std::string& indent = "", bool is_last = false) const override;
 
   /*** Auxiliaries ***/
   // These are marked as deprecated to warn/fail compilation if they are used

--- a/source/falaise/snemo/geometry/mapped_magnetic_field.h
+++ b/source/falaise/snemo/geometry/mapped_magnetic_field.h
@@ -61,22 +61,22 @@ class mapped_magnetic_field : public ::emfield::base_electromagnetic_field {
 
   /// Initialization
   virtual void initialize(const datatools::properties &, datatools::service_manager &,
-                          emfield::base_electromagnetic_field::field_dict_type &);
+                          emfield::base_electromagnetic_field::field_dict_type &) override;
 
   /// Reset
-  virtual void reset();
+  virtual void reset() override;
 
   /// Compute electric field
   virtual int compute_electric_field(const geomtools::vector_3d &position, double time,
-                                     geomtools::vector_3d &efield) const;
+                                     geomtools::vector_3d &efield) const override;
 
   /// Compute magnetic field
   virtual int compute_magnetic_field(const geomtools::vector_3d &position, double time,
-                                     geomtools::vector_3d &magnetic_field) const;
+                                     geomtools::vector_3d &magnetic_field) const override;
 
   /// Smart print
   virtual void tree_dump(std::ostream &out = std::clog, const std::string &title = "",
-                         const std::string &indent = "", bool inherit = false) const;
+                         const std::string &indent = "", bool inherit = false) const override;
 
   /// Set the map source filename
   void setMapFilename(const std::string &);

--- a/source/falaise/snemo/test/test_service_external.cxx
+++ b/source/falaise/snemo/test/test_service_external.cxx
@@ -13,10 +13,10 @@
 // Compiled in, so should always be present,
 class builtin_service : public datatools::base_service {
  public:
-  virtual int initialize(const datatools::properties&, datatools::service_dict_type&) {return 0;}
-  virtual int reset() { return 0;}
+  virtual int initialize(const datatools::properties&, datatools::service_dict_type&) override {return 0;}
+  virtual int reset() override { return 0;}
 
-  virtual bool is_initialized() const { return false; }
+  virtual bool is_initialized() const override { return false; }
 
   void builtin_impl() { std::cout << "builtin_impl" << std::endl; }
 


### PR DESCRIPTION
This is the minimum set of changes needed to compile Falaise with Bayeux 3.5.0 (with bxdecay0 1.0.10), at least on macOS. All changes are compatible with 3.4.2. Whilst the CI/testing isn't using 3.5.0 just yet, at least we can get these in to start with!

NB: There *will* still be one test failure to address when the CI does move to Bayeux 3.5, but will need separate work as it affects GammaClustering. This is due to the change to use bxdecay0 and how this is seeded (hence different primaries, and thus clusters) compared to the older Bayeux version. However, it needs someone to confirm the new results and extract the expected clusters/particles for comparison.