### PR TITLE
Add reconstructed variables to things2root module

### DIFF
--- a/modules/things2root/Things2Root.cpp
+++ b/modules/things2root/Things2Root.cpp
@@ -43,6 +43,10 @@ struct Things2Root::working_space {
   std::vector<double> trackersigmar;
   std::vector<double> trackerdelayedtime;
   std::vector<double> trackerdelayedtimeerror;
+  std::vector<bool> isdelayed;
+  std::vector<bool> isnoisy;
+  std::vector<bool> isbottomcathodemissing;
+  std::vector<bool> istopcathodemissing;
   std::vector<int> trackertruehitid;
   std::vector<int> trackertruetrackid;
   std::vector<int> trackertrueparenttrackid;
@@ -117,9 +121,13 @@ void Things2Root::working_space::clear() {
   trackersigmar.clear();
   trackerdelayedtime.clear();
   trackerdelayedtimeerror.clear();
+  isdelayed.clear();
+  isnoisy.clear();
+  isbottomcathodemissing.clear();
+  istopcathodemissing.clear();
   trackertruehitid.clear();
   trackertruetrackid.clear();
-  trackertrueparenttrackid.clear();
+  trackertrueparenttrackid.clear()  ;
 
   // clear calibrated calorimeter data
   caloid.clear();
@@ -251,6 +259,10 @@ void Things2Root::initialize(const datatools::properties& myConfig,
   tree_->Branch("tracker.sigmar", &tracker_.sigmar_);
   tree_->Branch("tracker.delayedtime", &tracker_.delayed_time_);
   tree_->Branch("tracker.delayedtimeerror", &tracker_.delayed_time_error_);
+  tree_->Branch("tracker.isdelayed", &tracker_.is_delayed_);
+  tree_->Branch("tracker.isnoisy", &tracker_.is_noisy_);
+  tree_->Branch("tracker.isbottomcathodemissing", &tracker_.is_bottom_cathode_missing_);
+  tree_->Branch("tracker.istopcathodemissing", &tracker_.is_top_cathode_missing_);
   tree_->Branch("tracker.truehitid", &tracker_.truehitid_);
 
   // calibrated calorimeter data
@@ -571,7 +583,12 @@ dpp::base_module::process_status Things2Root::process(datatools::things& workIte
       ws_->trackersigmar.push_back(sncore_gg_hit.get_sigma_r());
       ws_->trackerdelayedtime.push_back(sncore_gg_hit.get_delayed_time());
       ws_->trackerdelayedtimeerror.push_back(sncore_gg_hit.get_delayed_time_error());
+      ws_->isdelayed.push_back(sncore_gg_hit.is_delayed());
+      ws_->isnoisy.push_back(sncore_gg_hit.is_noisy());
+      ws_->isbottomcathodemissing.push_back(sncore_gg_hit.is_bottom_cathode_missing());
+      ws_->istopcathodemissing.push_back(sncore_gg_hit.is_top_cathode_missing());
       ws_->trackertruehitid.push_back(sncore_gg_hit.get_id());
+
       // special infos about truth tracks:
       int truth_track_id = -1;
       if (sncore_gg_hit.get_auxiliaries().has_key(mctools::track_utils::TRACK_ID_KEY)) {
@@ -599,6 +616,10 @@ dpp::base_module::process_status Things2Root::process(datatools::things& workIte
     tracker_.sigmar_ = &ws_->trackersigmar;
     tracker_.delayed_time_ = &ws_->trackerdelayedtime;
     tracker_.delayed_time_error_ = &ws_->trackerdelayedtimeerror;
+    tracker_.is_delayed_ = &ws_->isdelayed;
+    tracker_.is_noisy_ = &ws_->isnoisy;
+    tracker_.is_bottom_cathode_missing_ = &ws_->isbottomcathodemissing;
+    tracker_.is_top_cathode_missing_ = &ws_->istopcathodemissing;
     tracker_.truehitid_ = &ws_->trackertruehitid;
     tracker_.truetrackid_ = &ws_->trackertruetrackid;
     tracker_.trueparenttrackid_ = &ws_->trackertrueparenttrackid;

--- a/modules/things2root/Things2Root.cpp
+++ b/modules/things2root/Things2Root.cpp
@@ -41,6 +41,8 @@ struct Things2Root::working_space {
   std::vector<double> trackersigmaz;
   std::vector<double> trackerr;
   std::vector<double> trackersigmar;
+  std::vector<double> trackerdelayedtime;
+  std::vector<double> trackerdelayedtimeerror;
   std::vector<int> trackertruehitid;
   std::vector<int> trackertruetrackid;
   std::vector<int> trackertrueparenttrackid;
@@ -113,6 +115,8 @@ void Things2Root::working_space::clear() {
   trackersigmaz.clear();
   trackerr.clear();
   trackersigmar.clear();
+  trackerdelayedtime.clear();
+  trackerdelayedtimeerror.clear();
   trackertruehitid.clear();
   trackertruetrackid.clear();
   trackertrueparenttrackid.clear();
@@ -245,6 +249,8 @@ void Things2Root::initialize(const datatools::properties& myConfig,
   tree_->Branch("tracker.sigmaz", &tracker_.sigmaz_);
   tree_->Branch("tracker.r", &tracker_.r_);
   tree_->Branch("tracker.sigmar", &tracker_.sigmar_);
+  tree_->Branch("tracker.delayedtime", &tracker_.delayed_time_);
+  tree_->Branch("tracker.delayedtimeerror", &tracker_.delayed_time_error_);
   tree_->Branch("tracker.truehitid", &tracker_.truehitid_);
 
   // calibrated calorimeter data
@@ -563,6 +569,8 @@ dpp::base_module::process_status Things2Root::process(datatools::things& workIte
       ws_->trackersigmaz.push_back(sncore_gg_hit.get_sigma_z());
       ws_->trackerr.push_back(sncore_gg_hit.get_r());
       ws_->trackersigmar.push_back(sncore_gg_hit.get_sigma_r());
+      ws_->trackerdelayedtime.push_back(sncore_gg_hit.get_delayed_time());
+      ws_->trackerdelayedtimeerror.push_back(sncore_gg_hit.get_delayed_time_error());
       ws_->trackertruehitid.push_back(sncore_gg_hit.get_id());
       // special infos about truth tracks:
       int truth_track_id = -1;
@@ -589,6 +597,8 @@ dpp::base_module::process_status Things2Root::process(datatools::things& workIte
     tracker_.sigmaz_ = &ws_->trackersigmaz;
     tracker_.r_ = &ws_->trackerr;
     tracker_.sigmar_ = &ws_->trackersigmar;
+    tracker_.delayed_time_ = &ws_->trackerdelayedtime;
+    tracker_.delayed_time_error_ = &ws_->trackerdelayedtimeerror;
     tracker_.truehitid_ = &ws_->trackertruehitid;
     tracker_.truetrackid_ = &ws_->trackertruetrackid;
     tracker_.trueparenttrackid_ = &ws_->trackertrueparenttrackid;

--- a/modules/things2root/Things2Root.h
+++ b/modules/things2root/Things2Root.h
@@ -50,6 +50,10 @@ typedef struct TrackerEventStorage {
   std::vector<double>* sigmar_;
   std::vector<double>* delayed_time_;
   std::vector<double>* delayed_time_error_;
+  std::vector<bool>* is_delayed_;
+  std::vector<bool>* is_noisy_;
+  std::vector<bool>* is_bottom_cathode_missing_;
+  std::vector<bool>* is_top_cathode_missing_;
   std::vector<int>* truehitid_;
   std::vector<int>* truetrackid_;
   std::vector<int>* trueparenttrackid_;
@@ -69,6 +73,10 @@ TrackerEventStorage()
     sigmar_(0),
     delayed_time_(0),
     delayed_time_error_(0),
+    is_delayed_(0),
+    is_noisy_(0),
+    is_bottom_cathode_missing_(0),
+    is_top_cathode_missing_(0),
     truehitid_(0),
     truetrackid_(0),
     trueparenttrackid_(0) {}

--- a/modules/things2root/Things2Root.h
+++ b/modules/things2root/Things2Root.h
@@ -48,26 +48,30 @@ typedef struct TrackerEventStorage {
   std::vector<double>* sigmaz_;
   std::vector<double>* r_;
   std::vector<double>* sigmar_;
+  std::vector<double>* delayed_time_;
+  std::vector<double>* delayed_time_error_;
   std::vector<int>* truehitid_;
   std::vector<int>* truetrackid_;
   std::vector<int>* trueparenttrackid_;
 
-  TrackerEventStorage()
-      : nohits_(0),
-        id_(0),
-        module_(0),
-        side_(0),
-        layer_(0),
-        column_(0),
-        x_(0),
-        y_(0),
-        z_(0),
-        sigmaz_(0),
-        r_(0),
-        sigmar_(0),
-        truehitid_(0),
-        truetrackid_(0),
-        trueparenttrackid_(0) {}
+TrackerEventStorage()
+: nohits_(0),
+    id_(0),
+    module_(0),
+    side_(0),
+    layer_(0),
+    column_(0),
+    x_(0),
+    y_(0),
+    z_(0),
+    sigmaz_(0),
+    r_(0),
+    sigmar_(0),
+    delayed_time_(0),
+    delayed_time_error_(0),
+    truehitid_(0),
+    truetrackid_(0),
+    trueparenttrackid_(0) {}
 } trackereventstorage;
 
 typedef struct CaloEventStorage {
@@ -84,19 +88,19 @@ typedef struct CaloEventStorage {
   std::vector<double>* energy_;
   std::vector<double>* sigmaenergy_;
 
-  CaloEventStorage()
-      : nohits_(0),
-        id_(0),
-        type_(0),
-        module_(0),
-        side_(0),
-        column_(0),
-        row_(0),
-        wall_(0),
-        time_(0),
-        sigmatime_(0),
-        energy_(0),
-        sigmaenergy_(0) {}
+CaloEventStorage()
+: nohits_(0),
+    id_(0),
+    type_(0),
+    module_(0),
+    side_(0),
+    column_(0),
+    row_(0),
+    wall_(0),
+    time_(0),
+    sigmatime_(0),
+    energy_(0),
+    sigmaenergy_(0) {}
 } caloeventstorage;
 
 typedef struct TrueVertexStorage {
@@ -116,8 +120,8 @@ typedef struct TrueParticleStorage {
   std::vector<double>* time_;
   std::vector<double>* ke_;
 
-  TrueParticleStorage()
-      : noparticles_(0), id_(0), type_(0), px_(0), py_(0), pz_(0), time_(0), ke_(0) {}
+TrueParticleStorage()
+: noparticles_(0), id_(0), type_(0), px_(0), py_(0), pz_(0), time_(0), ke_(0) {}
 } TrueParticleStorage;
 
 typedef struct TrueCaloStorage {
@@ -135,20 +139,20 @@ typedef struct TrueCaloStorage {
   std::vector<double>* time_;
   std::vector<double>* energy_;
 
-  TrueCaloStorage()
-      : nohits_(0),
-        id_(0),
-        type_(0),
-        module_(0),
-        side_(0),
-        column_(0),
-        row_(0),
-        wall_(0),
-        x_(0),
-        y_(0),
-        z_(0),
-        time_(0),
-        energy_(0) {}
+TrueCaloStorage()
+: nohits_(0),
+    id_(0),
+    type_(0),
+    module_(0),
+    side_(0),
+    column_(0),
+    row_(0),
+    wall_(0),
+    x_(0),
+    y_(0),
+    z_(0),
+    time_(0),
+    energy_(0) {}
 } truecalostorage;
 
 typedef struct TrueTrackerStorage {
@@ -168,22 +172,22 @@ typedef struct TrueTrackerStorage {
   std::vector<int>* trackid_;
   std::vector<int>* parenttrackid_;
 
-  TrueTrackerStorage()
-      : nohits_(0),
-        id_(0),
-        module_(0),
-        side_(0),
-        layer_(0),
-        column_(0),
-        time_(0),
-        xstart_(0),
-        ystart_(0),
-        zstart_(0),
-        xstop_(0),
-        ystop_(0),
-        zstop_(0),
-        trackid_(0),
-        parenttrackid_(0) {}
+TrueTrackerStorage()
+: nohits_(0),
+    id_(0),
+    module_(0),
+    side_(0),
+    layer_(0),
+    column_(0),
+    time_(0),
+    xstart_(0),
+    ystart_(0),
+    zstart_(0),
+    xstop_(0),
+    ystop_(0),
+    zstop_(0),
+    trackid_(0),
+    parenttrackid_(0) {}
 } TrueTrackerStorage;
 
 class Things2Root : public dpp::base_module {
@@ -232,5 +236,5 @@ class Things2Root : public dpp::base_module {
   // Macro which automatically creates the interface needed
   // to enable the module to be loaded at runtime
   DPP_MODULE_REGISTRATION_INTERFACE(Things2Root)
-};
+    };
 #endif  // THINGS2ROOT_H


### PR DESCRIPTION
Laurent's request to add the tracker delayed_time to the output in the thing2root module. Also added the associated delayed_time_error