### PR TITLE
Comment too much verbosity in gg locator.

### DIFF
--- a/source/falaise/snemo/geometry/gg_locator.cc
+++ b/source/falaise/snemo/geometry/gg_locator.cc
@@ -495,7 +495,7 @@ bool gg_locator::isWorldPointInModule(const geomtools::vector_3d &worldPoint,
 bool gg_locator::find_geom_id(const geomtools::vector_3d &worldPoint, int type,
                               geomtools::geom_id &gid, double tolerance) const {
   datatools::logger::priority logging = datatools::logger::PRIO_FATAL;
-  logging = datatools::logger::PRIO_DEBUG;
+  // logging = datatools::logger::PRIO_DEBUG;
   DT_THROW_IF(type != (int)cellGIDType_, std::logic_error, "Only works with type " << cellGIDType_);
   gid.invalidate();
   DT_LOG_DEBUG(logging, "worldPoint = " << worldPoint);


### PR DESCRIPTION
Remove the forced logging in PRIO_DEBUG mode causing too much verbosity during flsimulate and each time the method gg_locator::find_geom_id is called.


Introduced 6 months ago by @fmauger  and LTTC implementation. Probably forget to be removed