### PR TITLE
[WIP] Add  trigger digitized hit to UDD format

### DIFF
--- a/source/falaise/snemo.cmake
+++ b/source/falaise/snemo.cmake
@@ -9,6 +9,7 @@ list(APPEND FalaiseLibrary_HEADERS
   snemo/datamodels/precalibrated_calorimeter_hit.h
   snemo/datamodels/precalibrated_data.h
   snemo/datamodels/precalibrated_tracker_hit.h
+  snemo/datamodels/trigger_digitized_hit.h
   snemo/datamodels/calorimeter_digitized_hit.h
   snemo/datamodels/unified_digitized_data.h
   snemo/datamodels/tracker_digitized_hit.h
@@ -36,6 +37,7 @@ list(APPEND FalaiseLibrary_HEADERS
   snemo/datamodels/boost_io/precalibrated_calorimeter_hit.ipp
   snemo/datamodels/boost_io/precalibrated_data.ipp
   snemo/datamodels/boost_io/precalibrated_tracker_hit.ipp
+  snemo/datamodels/boost_io/trigger_digitized_hit.ipp
   snemo/datamodels/boost_io/calorimeter_digitized_hit.ipp
   snemo/datamodels/boost_io/unified_digitized_data.ipp
   snemo/datamodels/boost_io/tracker_digitized_hit.ipp
@@ -126,6 +128,7 @@ list(APPEND FalaiseLibrary_SOURCES
   snemo/datamodels/calibrated_calorimeter_hit.cc
   snemo/datamodels/calibrated_tracker_hit.cc
   snemo/datamodels/calibrated_data.cc
+  snemo/datamodels/trigger_digitized_hit.cc
   snemo/datamodels/calorimeter_digitized_hit.cc
   snemo/datamodels/unified_digitized_data.cc
   snemo/datamodels/tracker_digitized_hit.cc
@@ -233,6 +236,7 @@ list(APPEND FalaiseLibrary_TESTS
   snemo/test/test_snemo_datamodel_calibrated_tracker_hit.cxx
   snemo/test/test_snemo_datamodel_precalibrated_calorimeter_hit.cxx
   snemo/test/test_snemo_datamodel_precalibrated_tracker_hit.cxx
+  snemo/test/test_snemo_datamodel_trigger_digitized_hit.cxx
   snemo/test/test_snemo_datamodel_calorimeter_digitized_hit.cxx
   snemo/test/test_snemo_datamodel_tracker_digitized_hit.cxx
   snemo/test/test_snemo_datamodel_unified_digitized_data.cxx

--- a/source/falaise/snemo/datamodels/boost_io/the_serializable.cc
+++ b/source/falaise/snemo/datamodels/boost_io/the_serializable.cc
@@ -66,6 +66,13 @@ DATATOOLS_SERIALIZATION_CLASS_SERIALIZE_INSTANTIATE_ALL(snemo::datamodel::precal
 DATATOOLS_SERIALIZATION_CLASS_SERIALIZE_INSTANTIATE_ALL(snemo::datamodel::precalibrated_data)
 BOOST_CLASS_EXPORT_IMPLEMENT(snemo::datamodel::precalibrated_data)
 
+/*******************************************
+ * snemo::datamodel::trigger_digitized_hit *
+ *******************************************/
+
+#include <falaise/snemo/datamodels/boost_io/trigger_digitized_hit.ipp>
+DATATOOLS_SERIALIZATION_CLASS_SERIALIZE_INSTANTIATE_ALL(snemo::datamodel::trigger_digitized_hit)
+
 /************************************************
  * snemo::datamodel::calorimeter_digitized_hit *
  ************************************************/
@@ -80,9 +87,9 @@ DATATOOLS_SERIALIZATION_CLASS_SERIALIZE_INSTANTIATE_ALL(snemo::datamodel::calori
 #include <falaise/snemo/datamodels/boost_io/tracker_digitized_hit.ipp>
 DATATOOLS_SERIALIZATION_CLASS_SERIALIZE_INSTANTIATE_ALL(snemo::datamodel::tracker_digitized_hit)
 
-/*************************************
+/********************************************
  * snemo::datamodel::unified_digitized_data *
- *************************************/
+ ********************************************/
 
 #include <falaise/snemo/datamodels/boost_io/unified_digitized_data.ipp>
 DATATOOLS_SERIALIZATION_CLASS_SERIALIZE_INSTANTIATE_ALL(snemo::datamodel::unified_digitized_data)

--- a/source/falaise/snemo/datamodels/boost_io/trigger_digitized_hit.ipp
+++ b/source/falaise/snemo/datamodels/boost_io/trigger_digitized_hit.ipp
@@ -12,8 +12,6 @@
 #include <boost/serialization/base_object.hpp>
 #include <boost/serialization/map.hpp>
 #include <boost/serialization/nvp.hpp>
-// - Bayeux/geomtools:
-#include <geomtools/base_hit.ipp>
 
 namespace snemo {
 
@@ -31,12 +29,10 @@ namespace snemo {
 
     /// Serialization method
     template <class Archive>
-    void trigger_digitized_hit::serialize(Archive & ar_,
+    void trigger_digitized_hit::serialize(Archive & /* ar_ */,
                                           const unsigned int /* version */)
     {
-      // Inherit from the 'base_hit' mother class:
-      ar_ & boost::serialization::make_nvp("geomtools__base_hit",
-                                           boost::serialization::base_object<geomtools::base_hit>(*this));
+      //ar_ & DATATOOLS_SERIALIZATION_I_SERIALIZABLE_BASE_OBJECT_NVP;
       return;
     }
 

--- a/source/falaise/snemo/datamodels/boost_io/trigger_digitized_hit.ipp
+++ b/source/falaise/snemo/datamodels/boost_io/trigger_digitized_hit.ipp
@@ -1,0 +1,53 @@
+// -*- mode: c++ ; -*-
+/// \file falaise/snemo/datamodels/trigger_digitized_hit.ipp
+
+#ifndef FALAISE_SNEMO_DATAMODEL_TRIGGER_DIGITIZED_HIT_IPP
+#define FALAISE_SNEMO_DATAMODEL_TRIGGER_DIGITIZED_HIT_IPP 1
+
+// This project:
+#include <falaise/snemo/datamodels/trigger_digitized_hit.h>
+
+// Third party:
+// - Boost:
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/map.hpp>
+#include <boost/serialization/nvp.hpp>
+// - Bayeux/geomtools:
+#include <geomtools/base_hit.ipp>
+
+namespace snemo {
+
+  namespace datamodel {
+
+    /// Serialization method
+    template <class Archive>
+    void trigger_digitized_hit::rtd_origin::serialize(Archive & ar_,
+                                                      const unsigned int /* version */)
+    {
+      ar_ & boost::serialization::make_nvp("hit_number", _hit_number_);
+      ar_ & boost::serialization::make_nvp("trigger_id", _trigger_id_);
+      return;
+    }
+
+    /// Serialization method
+    template <class Archive>
+    void trigger_digitized_hit::serialize(Archive & ar_,
+                                          const unsigned int /* version */)
+    {
+      // Inherit from the 'base_hit' mother class:
+      ar_ & boost::serialization::make_nvp("geomtools__base_hit",
+                                           boost::serialization::base_object<geomtools::base_hit>(*this));
+      return;
+    }
+
+  } // namespace datamodel
+
+} // namespace snemo
+
+#endif // FALAISE_SNEMO_DATAMODEL_TRIGGER_DIGITIZED_HIT_IPP
+
+// Local Variables: --
+// mode: c++ --
+// c-file-style: "gnu" --
+// tab-width: 2 --
+// End: --

--- a/source/falaise/snemo/datamodels/tracker_digitized_hit.h
+++ b/source/falaise/snemo/datamodels/tracker_digitized_hit.h
@@ -140,12 +140,12 @@ namespace snemo {
       ///
       /// Usage:
       /// \code
-      /// snemo::datamodel::tracker_digitized_hit caloDigiHit
+      /// snemo::datamodel::tracker_digitized_hit trackDigiHit
       /// ...
       /// boost::property_tree::ptree poptions;
       /// poptions.put("title", "Tracker Digitized Hit:");
       /// poptions.put("indent", ">>> ");
-      /// caloDigiHit.print_tree(std::clog, poptions);
+      /// trackDigiHit.print_tree(std::clog, poptions);
       /// \endcode
       void print_tree(std::ostream & out_ = std::clog,
                       const boost::property_tree::ptree & options_ = empty_options()) const override;

--- a/source/falaise/snemo/datamodels/trigger_digitized_hit.cc
+++ b/source/falaise/snemo/datamodels/trigger_digitized_hit.cc
@@ -1,0 +1,103 @@
+// -*- mode: c++ ; -*-
+/** \file falaise/snemo/datamodel/trigger_digitized_hit.cc
+ */
+
+// This project:
+#include <falaise/snemo/datamodels/trigger_digitized_hit.h>
+
+// Third party:
+// - Bayeux:
+#include <bayeux/datatools/exception.h>
+
+namespace snemo {
+  namespace datamodel {
+
+    DATATOOLS_SERIALIZATION_IMPLEMENTATION(trigger_digitized_hit,
+                                           "snemo::datamodel::trigger_digitized_hit")
+
+    /*** trigger_digitized_hit::rtd_origin ***/
+
+    trigger_digitized_hit::rtd_origin::rtd_origin(int32_t hit_number_,
+                                                  int32_t trigger_id_)
+    : _hit_number_(hit_number_)
+      , _trigger_id_(trigger_id_)
+    {
+      return;
+    }
+
+    int32_t trigger_digitized_hit::rtd_origin::get_hit_number() const
+    {
+      return _hit_number_;
+    }
+
+    int32_t trigger_digitized_hit::rtd_origin::get_trigger_id() const
+    {
+      return _trigger_id_;
+    }
+
+    bool trigger_digitized_hit::rtd_origin::is_valid() const
+    {
+      if (_hit_number_ < 0) return false;
+      if (_trigger_id_ < 0) return false;
+      return true;
+    }
+
+    void trigger_digitized_hit::rtd_origin::invalidate()
+    {
+      _hit_number_ = INVALID_HIT_ID;
+      _trigger_id_ = INVALID_TRIGGER_ID;
+      return;
+    }
+
+    // virtual
+    void trigger_digitized_hit::rtd_origin::print_tree(std::ostream & out_,
+                                                       const boost::property_tree::ptree & options_) const
+    {
+      base_print_options popts;
+      popts.configure_from(options_);
+
+      if (popts.title.length()) {
+        out_ << popts.indent << popts.title << std::endl;
+      }
+
+      out_ << popts.indent << tag
+           << "Hit number : " << _hit_number_ << std::endl;
+
+      out_ << popts.indent << inherit_tag(popts.inherit)
+           << "Trigger ID : " << _trigger_id_ << std::endl;
+
+      return;
+    }
+
+
+    bool trigger_digitized_hit::is_valid() const
+    {
+      if (not this->geomtools::base_hit::is_valid()) return true;
+      return true;
+    }
+
+    void trigger_digitized_hit::invalidate()
+    {
+      this->geomtools::base_hit::invalidate();
+      return;
+    }
+
+    // virtual
+    void trigger_digitized_hit::print_tree(std::ostream & out_,
+                                           const boost::property_tree::ptree & options_) const
+    {
+      base_print_options popts;
+      popts.configure_from(options_);
+
+      this->geomtools::base_hit::print_tree(out_,
+                                            base_print_options::force_inheritance(options_));
+
+      out_ << popts.indent << inherit_tag(popts.inherit)
+           << "Valid : " << std::boolalpha << is_valid() << std::endl;
+
+      return;
+    }
+
+  } // namespace datamodel
+
+} // namespace snemo

--- a/source/falaise/snemo/datamodels/trigger_digitized_hit.cc
+++ b/source/falaise/snemo/datamodels/trigger_digitized_hit.cc
@@ -72,13 +72,11 @@ namespace snemo {
 
     bool trigger_digitized_hit::is_valid() const
     {
-      if (not this->geomtools::base_hit::is_valid()) return true;
       return true;
     }
 
     void trigger_digitized_hit::invalidate()
     {
-      this->geomtools::base_hit::invalidate();
       return;
     }
 
@@ -88,9 +86,6 @@ namespace snemo {
     {
       base_print_options popts;
       popts.configure_from(options_);
-
-      this->geomtools::base_hit::print_tree(out_,
-                                            base_print_options::force_inheritance(options_));
 
       out_ << popts.indent << inherit_tag(popts.inherit)
            << "Valid : " << std::boolalpha << is_valid() << std::endl;

--- a/source/falaise/snemo/datamodels/trigger_digitized_hit.h
+++ b/source/falaise/snemo/datamodels/trigger_digitized_hit.h
@@ -1,10 +1,10 @@
 // -*- mode: c++ ; -*-
-/// \file  falaise/snemo/datamodels/tracker_digitized_hit.h
+/// \file  falaise/snemo/datamodels/trigger_digitized_hit.h
 /* Author(s) :    François Mauger <mauger@lpccaen.in2p3.fr>
  *                Guillaume Oliviero <oliviero@cenbg.in2p3.fr>
  *                Emmanuel Chauveau <chauveau@cenbg.in2p3.fr>
- * Creation date: 2022-05-03
- * Last modified: 2022-05-13
+ * Creation date: 2022-12-21
+ * Last modified: 2022-12-22
  *
  * Description:
  *
@@ -36,8 +36,8 @@ namespace snemo {
   namespace datamodel {
 
     /// \brief Trigger digitized hit
-    class trigger_digitized_hit
-      : public geomtools::base_hit
+    class trigger_digitized_hit : public datatools::i_serializable,
+                                  public datatools::i_tree_dumpable
     {
     public:
 
@@ -69,10 +69,10 @@ namespace snemo {
       virtual ~trigger_digitized_hit() = default;
 
       /// Check if the internal data of the hit are valid
-      bool is_valid() const override;
+      bool is_valid() const;
 
       /// Invalidate the internal data of hit
-      void invalidate() override;
+      void invalidate();
 
       /// Smart print
       ///
@@ -86,7 +86,7 @@ namespace snemo {
       /// trigDigiHit.print_tree(std::clog, poptions);
       /// \endcode
       void print_tree(std::ostream & out_ = std::clog,
-                      const boost::property_tree::ptree & options_ = empty_options()) const override;
+                      const boost::property_tree::ptree & options_ = empty_options()) const;
 
     private:
 

--- a/source/falaise/snemo/datamodels/trigger_digitized_hit.h
+++ b/source/falaise/snemo/datamodels/trigger_digitized_hit.h
@@ -1,0 +1,106 @@
+// -*- mode: c++ ; -*-
+/// \file  falaise/snemo/datamodels/tracker_digitized_hit.h
+/* Author(s) :    François Mauger <mauger@lpccaen.in2p3.fr>
+ *                Guillaume Oliviero <oliviero@cenbg.in2p3.fr>
+ *                Emmanuel Chauveau <chauveau@cenbg.in2p3.fr>
+ * Creation date: 2022-05-03
+ * Last modified: 2022-05-13
+ *
+ * Description:
+ *
+ *   SuperNEMO trigger digitized hit in the Raw Event Data (RED) bank
+ *
+ * History:
+ *
+ */
+
+#ifndef FALAISE_SNEMO_DATAMODELS_TRIGGER_DIGITIZED_HIT_H
+#define FALAISE_SNEMO_DATAMODELS_TRIGGER_DIGITIZED_HIT_H 1
+
+// Standard Library:
+#include <vector>
+
+// Third party:
+// - Bayeux:
+#include <datatools/handle.h>
+#include <datatools/i_tree_dump.h>
+#include <datatools/i_serializable.h>
+#include <geomtools/base_hit.h>
+
+// This project:
+#include <falaise/snemo/datamodels/timestamp.h>
+#include <falaise/snemo/datamodels/udd_utils.h>
+
+namespace snemo {
+
+  namespace datamodel {
+
+    /// \brief Trigger digitized hit
+    class trigger_digitized_hit
+      : public geomtools::base_hit
+    {
+    public:
+
+      /// \brief RTD origin (trigger_hit_record instance) of the trigger hit (for backtracing)
+      class rtd_origin
+        : public datatools::i_tree_dumpable
+      {
+      public:
+
+        rtd_origin() = default;
+        virtual ~rtd_origin() = default;
+        rtd_origin(int32_t hit_number_, int32_t trigger_id_);
+        int32_t get_hit_number() const;
+        int32_t get_trigger_id() const;
+        bool is_valid() const;
+        void invalidate();
+        void print_tree(std::ostream & out_ = std::clog,
+                        const boost::property_tree::ptree & options_ = empty_options()) const override;
+
+      private:
+
+        int32_t _hit_number_ = INVALID_HIT_ID; ///< Trigger hit record number
+        int32_t _trigger_id_ = INVALID_TRIGGER_ID; ///< Trigger ID
+
+        BOOST_SERIALIZATION_BASIC_DECLARATION()
+      };
+
+      trigger_digitized_hit() = default;
+      virtual ~trigger_digitized_hit() = default;
+
+      /// Check if the internal data of the hit are valid
+      bool is_valid() const override;
+
+      /// Invalidate the internal data of hit
+      void invalidate() override;
+
+      /// Smart print
+      ///
+      /// Usage:
+      /// \code
+      /// snemo::datamodel::trigger_digitized_hit trigDigiHit
+      /// ...
+      /// boost::property_tree::ptree poptions;
+      /// poptions.put("title", "Trigger Digitized Hit:");
+      /// poptions.put("indent", ">>> ");
+      /// trigDigiHit.print_tree(std::clog, poptions);
+      /// \endcode
+      void print_tree(std::ostream & out_ = std::clog,
+                      const boost::property_tree::ptree & options_ = empty_options()) const override;
+
+    private:
+
+
+      DATATOOLS_SERIALIZATION_DECLARATION()
+
+    };
+
+    /// Handle of trigger digitized hit
+    using TriggerDigiHit = trigger_digitized_hit;
+    using TriggerDigiHitHdl = datatools::handle<TriggerDigiHit>;
+
+  } // namespace datamodel
+
+} // namespace snemo
+
+#endif // FALAISE_SNEMO_DATAMODELS_TRIGGER_DIGITIZED_HIT_H

--- a/source/falaise/snemo/datamodels/unified_digitized_data.h
+++ b/source/falaise/snemo/datamodels/unified_digitized_data.h
@@ -1,5 +1,5 @@
 // -*- mode: c++ ; -*-
-/// \file  falaise/snemo/datamodels/unified_digitized_data_hit.h
+/// \file  falaise/snemo/datamodels/unified_digitized_data.h
 /* Author(s) :    François Mauger <mauger@lpccaen.in2p3.fr>
  *                Guillaume Oliviero <oliviero@cenbg.in2p3.fr>
  *                Emmanuel Chauveau <chauveau@cenbg.in2p3.fr>
@@ -9,7 +9,8 @@
  * Description:
  *
  *  The Unified Digitized Data (UDD) datamodel.
- *  It contains a collection of a calorimeter digitized hit and a collection of a tracker digitized hit.
+ *  It contains a trigger digitized hit, a collection of calorimeter digitized
+ *  hits and a collection of tracker digitized hits.
  *
  * History:
  *
@@ -33,6 +34,7 @@
 #include <datatools/properties.h>
 
 // This project:
+#include <falaise/snemo/datamodels/trigger_digitized_hit.h>
 #include <falaise/snemo/datamodels/calorimeter_digitized_hit.h>
 #include <falaise/snemo/datamodels/tracker_digitized_hit.h>
 #include <falaise/snemo/datamodels/udd_utils.h>

--- a/source/falaise/snemo/test/test_snemo_datamodel_trigger_digitized_hit.cxx
+++ b/source/falaise/snemo/test/test_snemo_datamodel_trigger_digitized_hit.cxx
@@ -22,9 +22,6 @@ int main(/* int argc_, char ** argv_ */) {
 
     {
       sdm::trigger_digitized_hit triggerDigiHit;
-      triggerDigiHit.set_hit_id(42);
-      geomtools::geom_id geomId(0, 7, 52);;
-      triggerDigiHit.set_geom_id(geomId);
 
       std::clog << "A trigger digitized (raw) hit:\n";
       triggerDigiHit.print_tree(std::clog);

--- a/source/falaise/snemo/test/test_snemo_datamodel_trigger_digitized_hit.cxx
+++ b/source/falaise/snemo/test/test_snemo_datamodel_trigger_digitized_hit.cxx
@@ -1,0 +1,73 @@
+// test_trigger_digitized_hit.cxx
+
+// Standard library:
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <string>
+
+// Third party:
+// - Bayeux/datatools:
+#include <bayeux/datatools/io_factory.h>
+
+// This project:
+#include <falaise/snemo/datamodels/trigger_digitized_hit.h>
+
+int main(/* int argc_, char ** argv_ */) {
+  int error_code = EXIT_SUCCESS;
+  try {
+    std::clog << "Test program for class 'snemo::datamodel::trigger_digitized_hit'" << std::endl;
+
+    namespace sdm = snemo::datamodel;
+
+    {
+      sdm::trigger_digitized_hit triggerDigiHit;
+      triggerDigiHit.set_hit_id(42);
+      geomtools::geom_id geomId(0, 7, 52);;
+      triggerDigiHit.set_geom_id(geomId);
+
+      std::clog << "A trigger digitized (raw) hit:\n";
+      triggerDigiHit.print_tree(std::clog);
+      std::clog << "\n";
+
+      // TODO:  Fill trigger digi data with some examples
+
+
+      {
+        datatools::data_writer xout("test_trigger_digitized_hit.xml", datatools::using_multi_archives);
+        datatools::data_writer bout("test_trigger_digitized_hit.data", datatools::using_multi_archives);
+        xout.store(triggerDigiHit);
+        bout.store(triggerDigiHit);
+      }
+
+    }
+
+    {
+      sdm::trigger_digitized_hit triggerDigiHit;
+      datatools::data_reader xin("test_trigger_digitized_hit.xml", datatools::using_multi_archives);
+      xin.load(triggerDigiHit);
+      std::clog << "A trigger digitized (raw) hit (from XML file):\n";
+      triggerDigiHit.print_tree(std::clog);
+      std::clog << "\n";
+    }
+
+    {
+      sdm::trigger_digitized_hit triggerDigiHit;
+      datatools::data_reader bin("test_trigger_digitized_hit.data", datatools::using_multi_archives);
+      bin.load(triggerDigiHit);
+      std::clog << "A trigger digitized (raw) hit (from binary file):\n";
+      triggerDigiHit.print_tree(std::clog);
+      std::clog << "\n";
+    }
+
+    std::clog << "The end." << std::endl;
+  } catch (std::exception& x) {
+    std::cerr << "error: " << x.what() << std::endl;
+    error_code = EXIT_FAILURE;
+  } catch (...) {
+    std::cerr << "error: "
+              << "unexpected error!" << std::endl;
+    error_code = EXIT_FAILURE;
+  }
+  return (error_code);
+}


### PR DESCRIPTION
Preliminary work for now.

Add trigger digitized hit to the official Unified Digitized Data datamodel in Falaise. 
A trigger digitized hit is composed by a lot of low-level information givent by the trigger board in SNComdaq and SNFEE. 