### PR TITLE
Fix missing GID mapping rules for source strips in basic source layout

### DIFF
--- a/resources/snemo/demonstrator/geometry/5.0/GeometryModels/source_module/basic/source_strips.geom
+++ b/resources/snemo/demonstrator/geometry/5.0/GeometryModels/source_module/basic/source_strips.geom
@@ -140,6 +140,7 @@
   material.ref : string = "tracking_gas"
   visibility.color : string = "green"
   mapping.daughter_id.back_film  : string = "[source_strip_film:film=0]"
+  mapping.daughter_id.source     : string = "[source_strip]"
   mapping.daughter_id.front_film : string = "[source_strip_film:film=1]"
 
 
@@ -178,5 +179,6 @@
   material.ref : string = "tracking_gas"
   visibility.color : string = "green"
   mapping.daughter_id.back_film  : string = "[source_strip_film:film=0]"
+  mapping.daughter_id.source     : string = "[source_strip]"
   mapping.daughter_id.front_film : string = "[source_strip_film:film=1]"
 


### PR DESCRIPTION
Some GID mapping rules were missing from geometry config files associated to the "Basic" source layout. The consequence was that no vertex extrapolation was done at PTD reconstruction.