### PR TITLE
Fix vertex extrapolation on Bi207 calib sources

### DIFF
--- a/modules/ChargedParticleTracking/ChargedParticleTracking/charged_particle_tracking_module.cc
+++ b/modules/ChargedParticleTracking/ChargedParticleTracking/charged_particle_tracking_module.cc
@@ -151,7 +151,7 @@ namespace snemo {
       the_particle_track_data.clear();
 
       if (datatools::logger::is_debug(get_logging_priority())) {
-        std::cerr << "\n\n[debug] ************ CHARGED_PARTICLE_TRACKING_MODULE : NEW EVENT **************\n\n\n";
+        std::cerr << "\n\n[debug] ************ CHARGED_PARTICLE_TRACKING_MODULE : NEW EVENT #" << counter_ << " **************\n\n\n";
       }
 
       // Main processing method :
@@ -159,7 +159,7 @@ namespace snemo {
       this->_process(the_calibrated_data, the_tracker_trajectory_data, the_particle_track_data);
       DT_LOG_TRACE(get_logging_priority(), "Post processing...");
       this->_post_process(the_calibrated_data, the_particle_track_data);
-
+      counter_++;
       return dpp::base_module::PROCESS_SUCCESS;
     }
 

--- a/modules/ChargedParticleTracking/ChargedParticleTracking/charged_particle_tracking_module.h
+++ b/modules/ChargedParticleTracking/ChargedParticleTracking/charged_particle_tracking_module.h
@@ -103,6 +103,7 @@ namespace snemo {
       std::string CDTag_;   //!< The label of the calibrated data bank
       std::string TTDTag_;  //!< The label of the tracker trajectory data bank
       std::string PTDTag_;  //!< The label of the particle track data bank
+			int counter_ = 0;
 
       /// Vertex Extrapolation Driver :
       std::unique_ptr<snemo::reconstruction::vertex_extrapolation_driver> VEAlgo_;

--- a/modules/ChargedParticleTracking/ChargedParticleTracking/vertex_extrapolation_driver.cc
+++ b/modules/ChargedParticleTracking/ChargedParticleTracking/vertex_extrapolation_driver.cc
@@ -77,6 +77,14 @@ namespace snemo {
       DT_LOG_DEBUG(logPriority_, "Max calo extrapolation XY-length = " << _max_calo_extrapolation_xy_length_ / CLHEP::cm << " cm");
       DT_LOG_DEBUG(logPriority_, "Max source extrapolation XY-length = " << _max_source_extrapolation_xy_length_ / CLHEP::cm << " cm");
 
+      // Extend the effective size of the calibration source carriers for vertex extrapolation :
+      vertexSourceCalibrationExtendY_ = ps.get<double>("vertex_source_extrapolation.extend_y", 1.0);
+      vertexSourceCalibrationExtendZ_ = ps.get<double>("vertex_source_extrapolation.extend_z", 1.0);
+      DT_THROW_IF(vertexSourceCalibrationExtendY_ < 1.0, std::domain_error, "Invalid vertexSourceCalibrationExtendY factor");
+      DT_THROW_IF(vertexSourceCalibrationExtendZ_ < 1.0, std::domain_error, "Invalid vertexSourceCalibrationExtendZ factor");
+      DT_LOG_DEBUG(logPriority_, "Vertex on calibration source extrapolation Y extend factor (>=1) = " << vertexSourceCalibrationExtendY_);
+      DT_LOG_DEBUG(logPriority_, "Vertex on calibration source extrapolation Z extend factor (>=1) = " << vertexSourceCalibrationExtendZ_);
+
       // Identify source submodule:
       _sourceSubmoduleType_ = geomtools::geom_id::INVALID_TYPE;
       if (geoIdMgr.has_category_info("source_submodule")) {
@@ -188,8 +196,22 @@ namespace snemo {
       }
       DT_LOG_DEBUG(logPriority_, "Source calibration spot type = " << _sourceCalibrationSpotType_);
       DT_LOG_DEBUG(logPriority_, "Found " << _sourceCalibrationSpotGids_.size() << " calibration source spots");
+      _sourceCalibTrackMinId_ = +100000;
+      _sourceCalibTrackMaxId_ = -100000;
+      static const int32_t trackNumIdx = 1;
+      for (const auto & spotGid : _sourceCalibrationSpotGids_) {
+	int32_t trackId = (int32_t) spotGid.get(trackNumIdx);
+	if (trackId > _sourceCalibTrackMaxId_) {
+	  _sourceCalibTrackMaxId_ = trackId;
+	}
+	if (trackId < _sourceCalibTrackMinId_) {
+	  _sourceCalibTrackMinId_ = trackId;
+	}
+      }
+      DT_LOG_DEBUG(logPriority_, "Min source calib track ID=" << _sourceCalibTrackMinId_);
+      DT_LOG_DEBUG(logPriority_, "Max source calib track ID=" << _sourceCalibTrackMaxId_);
 
-      // Identify calibration source strip:
+      // Identify calibration source tracks:
       _sourceCalibTrackType_ = geomtools::geom_id::INVALID_TYPE;
       if (geoIdMgr.has_category_info("source_calibration_track")) {
         _sourceCalibTrackType_ = geoIdMgr.get_category_info("source_calibration_track").get_type();
@@ -202,14 +224,26 @@ namespace snemo {
       if (_sourceCalibTrackGids_.size()) {
         DT_LOG_DEBUG(logPriority_, "Extracting geometry infos about source calibration tracks...");
         const geomtools::geom_info & srcCalibTrackGinfo = geoManager().get_mapping().get_geom_info(_sourceCalibTrackGids_[0]);
-        const geomtools::logical_volume & srcCalibTrackLog   = srcCalibTrackGinfo.get_logical();
-        const geomtools::i_shape_3d & srcCalibTrackShape     = srcCalibTrackLog.get_shape();    
+        const geomtools::logical_volume & srcCalibTrackLog = srcCalibTrackGinfo.get_logical();
+        const geomtools::i_shape_3d & srcCalibTrackShape = srcCalibTrackLog.get_shape();    
         const geomtools::placement & srcCalibTrackPlacement = srcCalibTrackGinfo.get_world_placement();
         _sourceCalibTrackX_ = srcCalibTrackPlacement.get_translation().x();
         _sourceCalibTrackZ_ = srcCalibTrackPlacement.get_translation().z();
         const geomtools::box & srcCalibTrackBox = dynamic_cast<const geomtools::box &>(srcCalibTrackShape);
         _sourceCalibTrackHeight_ = srcCalibTrackBox.get_z();
-        _sourceCalibTrackBoxPtr_ = std::make_unique<geomtools::box>(4.0 * CLHEP::mm, srcCalibTrackBox.get_y(), _sourceCalibTrackHeight_);
+	// double effectiveTrackBoxThickness = 4.0 * CLHEP::mm;
+	double effectiveTrackBoxThickness = 4.1 * CLHEP::mm;
+	// double effectiveCalibSourceBoxThickness = 1.0 * CLHEP::mm;
+	double effectiveCalibSourceBoxThickness = effectiveTrackBoxThickness;
+	double effectiveCalibSourceBoxWidth  = 15.0 * CLHEP::mm;
+	double effectiveCalibSourceBoxHeight = 35.0 * CLHEP::mm;
+	
+        _sourceCalibTrackBoxPtr_ = std::make_unique<geomtools::box>(effectiveTrackBoxThickness,
+								    srcCalibTrackBox.get_y(),
+								    _sourceCalibTrackHeight_);
+        _sourceCalibrationSpotEffectiveBoxPtr_ = std::make_unique<geomtools::box>(effectiveCalibSourceBoxHeight * vertexSourceCalibrationExtendZ_,
+										  effectiveCalibSourceBoxWidth * vertexSourceCalibrationExtendY_,
+										  effectiveCalibSourceBoxThickness);
       }
  
       // Identify main calo submodule:
@@ -326,7 +360,7 @@ namespace snemo {
       DT_LOG_DEBUG(logPriority_, "Found " << _gvetoBlockGids_.size() << " G-veto blocks");
   
       return;
-    }
+    } // vertex_extrapolation_driver::vertex_extrapolation_driver
 
     void vertex_extrapolation_driver::process(const snemo::datamodel::tracker_trajectory & trajectory_,
                                               snemo::datamodel::particle_track & particle_)
@@ -715,7 +749,7 @@ namespace snemo {
         // caloVertexes[iFrom].clear();
       } // for (iFrom...)
       return;
-    } // helix_trajectory_calo_intercept
+    } // vertex_extrapolation_driver::helix_trajectory_calo_intercept
   
     /* 
      *
@@ -737,8 +771,6 @@ namespace snemo {
       DT_LOG_DEBUG(logPrio, "\nSearch line intercepts on calorimeter blocks: ");
       vertexes_.clear();
       const geomtools::line_3d & line = line_traj_.get_segment();
-      // static const int CALO_MAIN  = 0;
-      // static const int CALO_XCALO = 1;
       std::set<int> blockTypes;
       if (_use_vertices_.find(snemo::geometry::vertex_info::CATEGORY_ON_MAIN_CALORIMETER)->second) {
         blockTypes.insert(CALO_MAIN);
@@ -971,7 +1003,7 @@ namespace snemo {
         // // caloVertexes[iFrom].clear();
       }
       return;
-    } // line_trajectory_calo_intercept
+    } // vertex_extrapolation_driver::line_trajectory_calo_intercept
 
   
     void vertex_extrapolation_driver::line_trajectory_source_intercept(snemo::geometry::vertex_info_list & vertexes_,
@@ -1031,14 +1063,16 @@ namespace snemo {
         }
         int16_t minStripId = _sourceStripMinId_;
         int16_t maxStripId = _sourceStripMaxId_;
+        int16_t minTrackId = _sourceCalibTrackMinId_;
+        int16_t maxTrackId = _sourceCalibTrackMaxId_;
         bool sourceSubmoduleInterceptSuccess = true;
         
         // Optimization for strip scanning:
         if (use_foils or use_calib_src) {
           DT_LOG_DEBUG(logPrio, "Searching line intercept on source submodule #" << _sourceSubmoduleGid_ << "...");
-          const geomtools::geom_info & srcSubmodGinfo      = geoManager().get_mapping().get_geom_info(_sourceSubmoduleGid_);
-          const geomtools::logical_volume & srcSubmodLog   = srcSubmodGinfo.get_logical();
-          const geomtools::i_shape_3d & srcSubmodShape     = srcSubmodLog.get_shape();         
+          const geomtools::geom_info & srcSubmodGinfo = geoManager().get_mapping().get_geom_info(_sourceSubmoduleGid_);
+          const geomtools::logical_volume & srcSubmodLog = srcSubmodGinfo.get_logical();
+          const geomtools::i_shape_3d & srcSubmodShape = srcSubmodLog.get_shape();         
           const geomtools::placement & srcSubmodPlacement = srcSubmodGinfo.get_world_placement();
           DT_LOG_DEBUG(logPrio, "Source submodule shape = " << srcSubmodShape.get_shape_name());
           DT_LOG_DEBUG(logPrio, "Source submodule world placement = " << srcSubmodPlacement);
@@ -1057,8 +1091,9 @@ namespace snemo {
             DT_LOG_DEBUG(logPrio, "Found an intercept on the source submodule #" << _sourceSubmoduleGid_ << " at " << srcSubmodFii.get_impact());
             const geomtools::vector_3d & impact = srcSubmodFii.get_impact();
             double yImpact = impact.y();
-            int32_t minId = 100000;
+            int32_t minId = +100000;
             int32_t maxId = -100000;
+	    // Source strip range:
             for (uint32_t iStrip = 0; iStrip < _sourceStripGids_.size(); iStrip++) {
               const geomtools::geom_id & sourceStripGid = _sourceStripGids_[iStrip];
               const geomtools::geom_info & sourceStripGinfo = geoManager().get_mapping().get_geom_info(sourceStripGid);
@@ -1076,6 +1111,28 @@ namespace snemo {
             }
             minStripId = std::max(minStripId, (int16_t) (minId - 1));
             maxStripId = std::min(maxStripId, (int16_t) (maxId + 1));
+
+	    // 2024-05-13, FM: NEW:
+	    // Calib track range:
+	    minId = 100000;
+            maxId = -100000;
+            for (uint32_t iTrack = 0; iTrack < _sourceCalibTrackGids_.size(); iTrack++) {
+              const geomtools::geom_id & sourceCalibTrackGid = _sourceCalibTrackGids_[iTrack];
+              const geomtools::geom_info & sourceCalibTrackGinfo = geoManager().get_mapping().get_geom_info(sourceCalibTrackGid);
+              const geomtools::placement & sourceCalibTrackPlacement = sourceCalibTrackGinfo.get_world_placement();
+              double yTrack = sourceCalibTrackPlacement.get_translation().y();
+              if (std::abs(yTrack - yImpact) < _max_source_extrapolation_xy_length_) {
+                int32_t sourceTrackId = (int32_t) sourceCalibTrackGid.get(1);
+                if (sourceTrackId > maxId) {
+                  maxId = sourceTrackId;
+                }
+                if (sourceTrackId < minId) {
+                  minId = sourceTrackId;
+                } 
+              }
+	      minTrackId = std::max(minTrackId, (int16_t) (minId - 1));
+	      maxTrackId = std::min(maxTrackId, (int16_t) (maxId + 1));
+            }
           } else {
             DT_LOG_DEBUG(logPrio, "No intercept on the source submodule #" << _sourceSubmoduleGid_);
           }
@@ -1083,6 +1140,8 @@ namespace snemo {
         }
         DT_LOG_DEBUG(logPrio, "minStripId=" << minStripId);
         DT_LOG_DEBUG(logPrio, "maxStripId=" << maxStripId);
+        DT_LOG_DEBUG(logPrio, "minTrackId=" << minTrackId);
+        DT_LOG_DEBUG(logPrio, "maxTrackId=" << maxTrackId);
 
         // Scan strips/pads...
         if (use_foils and sourceSubmoduleInterceptSuccess) {
@@ -1095,12 +1154,13 @@ namespace snemo {
               continue;
             }
             if ((int32_t) sourceStripId < minStripId or (int32_t) sourceStripId > maxStripId) { 
-              continue;
+	      DT_LOG_DEBUG(logPrio, "  Pass source strip GID : " << sourceStripGid << "...");
+	      continue;
             } 
             DT_LOG_DEBUG(logPrio, "Searching line intercept on strip #" << sourceStripId);
-            const geomtools::geom_info & sourceStripGinfo     = geoManager().get_mapping().get_geom_info(sourceStripGid);
-            const geomtools::logical_volume & sourceStripLog  = sourceStripGinfo.get_logical();
-            const geomtools::i_shape_3d & sourceStripShape    = sourceStripLog.get_shape();
+            const geomtools::geom_info & sourceStripGinfo = geoManager().get_mapping().get_geom_info(sourceStripGid);
+            const geomtools::logical_volume & sourceStripLog = sourceStripGinfo.get_logical();
+            const geomtools::i_shape_3d & sourceStripShape = sourceStripLog.get_shape();
             const geomtools::placement & sourceStripPlacement = sourceStripGinfo.get_world_placement();
             geomtools::vector_3d srcStripRefPoint;
             sourceStripPlacement.mother_to_child(refPoint, srcStripRefPoint);
@@ -1190,13 +1250,15 @@ namespace snemo {
                   if (datatools::logger::is_debug(logPrio)) {
                     padVtxInfo.print(std::cerr, "[debug] ");
                   }
+		  DT_LOG_DEBUG(logPrio, "padVtxInfo.distance_xy = " << padVtxInfo.distance_xy / CLHEP::mm << " mm");
+		  // Extrapolation distance check:
                   if (padVtxInfo.distance_xy <= _max_calo_extrapolation_xy_length_) {
                     sourcePadInterceptSuccess = true;
                   } else {
                     DT_LOG_DEBUG(logPrio, "Line intercept is to far from source pad #" << sourcePadGid);
-                  } // extrapolation distance check
+                  } 
                 } else {
-                  DT_LOG_DEBUG(logPrio, "No line intercept on source pad #" << sourcePadGid);
+                  DT_LOG_DEBUG(logPrio, "No line intercept on source pad #" << sourcePadGid << " (max=" << _max_calo_extrapolation_xy_length_ / CLHEP::mm << " mm)");
                 }
               }
               
@@ -1297,55 +1359,81 @@ namespace snemo {
         } // if (use_foils and sourceSubmoduleInterceptSuccess)
 
         if (use_calib_src) {
+          DT_LOG_DEBUG(logPrio, "Scanning calibration spots...");
           // Calibration spot:
           for (uint32_t iSpot = 0; iSpot < _sourceCalibrationSpotGids_.size(); iSpot++) {
             const geomtools::geom_id & sourceCalibrationSpotGid = _sourceCalibrationSpotGids_[iSpot];
+	    static const int32_t trackNumIdx = 1;
+	    int32_t trackId = sourceCalibrationSpotGid.get(trackNumIdx);
+            if (sourceCalibrationSpotGid.get(0) != _module_id_) { 
+              continue;
+            }
+	    if (trackId < minTrackId or trackId > maxTrackId) {
+	      DT_LOG_DEBUG(logPrio, "  Pass calibration track #" << trackId << " [" << minTrackId << ':' << maxTrackId << ']');
+	      continue;
+	    }
             DT_LOG_DEBUG(logPrio, "Searching line intercept on calibration source spot #" << sourceCalibrationSpotGid);
-            const geomtools::geom_info  & sourceCalibrationSpotGinfo  = geoManager().get_mapping().get_geom_info(sourceCalibrationSpotGid);
-            const geomtools::logical_volume & sourceCalibrationSpotLog   = sourceCalibrationSpotGinfo.get_logical();
-            const geomtools::i_shape_3d & sourceCalibrationSpotShape     = sourceCalibrationSpotLog.get_shape();
-            const geomtools::placement  & sourceCalibrationSpotPlacement = sourceCalibrationSpotGinfo.get_world_placement();
+            const geomtools::geom_info  & sourceCalibrationSpotGinfo = geoManager().get_mapping().get_geom_info(sourceCalibrationSpotGid);
+            const geomtools::logical_volume & sourceCalibrationSpotLog = sourceCalibrationSpotGinfo.get_logical();
+            const geomtools::i_shape_3d & sourceCalibrationSpotShape = sourceCalibrationSpotLog.get_shape();
+            const geomtools::placement & sourceCalibrationSpotPlacement = sourceCalibrationSpotGinfo.get_world_placement();
             geomtools::vector_3d srcCalibrationSpotRefPoint;
+            DT_LOG_DEBUG(logPrio, "Ref point (world) : " << geomtools::to_xyz(refPoint) );
+	    DT_LOG_DEBUG(logPrio, "Direction (world) : " << geomtools::to_xyz(direction) );
             sourceCalibrationSpotPlacement.mother_to_child(refPoint, srcCalibrationSpotRefPoint);
             geomtools::vector_3d srcCalibrationSpotDirection;
             sourceCalibrationSpotPlacement.mother_to_child_direction(direction, srcCalibrationSpotDirection);
             DT_LOG_DEBUG(logPrio, "Ref point   : " << geomtools::to_xyz(srcCalibrationSpotRefPoint) );
             DT_LOG_DEBUG(logPrio, "Direction   : " << geomtools::to_xyz(srcCalibrationSpotDirection) );
             DT_LOG_DEBUG(logPrio, "Calibration spot shape : '" << sourceCalibrationSpotShape.get_shape_name() << "'");
+            DT_LOG_DEBUG(logPrio, "Calibration spot shape : '" << sourceCalibrationSpotShape.get_shape_name() << "'");
+	    _sourceCalibrationSpotEffectiveBoxPtr_->tree_dump(std::cerr, "sourceCalibrationSpotEffectiveBoxPtr", "[devel] ");
             geomtools::face_intercept_info srcCalibrationSpotFii;
-            bool success = sourceCalibrationSpotShape.find_intercept(srcCalibrationSpotRefPoint,
-                                                                     srcCalibrationSpotDirection,
-                                                                     srcCalibrationSpotFii,
-                                                                     _intercept_tolerance_);
+            // bool success = sourceCalibrationSpotShape.find_intercept(srcCalibrationSpotRefPoint,
+            //                                                          srcCalibrationSpotDirection,
+            //                                                          srcCalibrationSpotFii,
+            //                                                          _intercept_tolerance_);
+            bool success = _sourceCalibrationSpotEffectiveBoxPtr_->find_intercept(srcCalibrationSpotRefPoint,
+										  srcCalibrationSpotDirection,
+										  srcCalibrationSpotFii,
+										  _intercept_tolerance_);
             if (! success) {
-              DT_LOG_DEBUG(logPrio, "Give up calibration source");
+              DT_LOG_DEBUG(logPrio, "Give up with calibration source spot GID " << sourceCalibrationSpotGid);
               continue;
             }
-            DT_LOG_DEBUG(logPrio, "Found line intercept on calibration source spot #" << sourceCalibrationSpotGid);
+            DT_LOG_DEBUG(logPrio, "Found line intercept on calibration source spot GID " << sourceCalibrationSpotGid);
             geomtools::vector_3d srcCalibrationSpotImpact = srcCalibrationSpotFii.get_impact();
             geomtools::vector_3d srcCalibrationSpotWorldImpact;
             sourceCalibrationSpotPlacement.child_to_mother(srcCalibrationSpotImpact, srcCalibrationSpotWorldImpact);
             srcCalibrationSpotFii.set_impact(srcCalibrationSpotWorldImpact);
             double srcCalibrationSpotDistRef2Impact = (srcCalibrationSpotWorldImpact - refPoint).mag();
             double srcCalibrationSpotExtrapolationDist = srcCalibrationSpotDistRef2Impact - distRef2End;
-            vertex_info calibrationSpotVtxInfo;
+	    DT_LOG_DEBUG(logPrio, "srcCalibrationSpotExtrapolationDist = " << srcCalibrationSpotExtrapolationDist / CLHEP::mm << "  mm");
+	    // XY-extrapolation:
+	    geomtools::vector_2d srcCalibrationSpotWorldImpact_Xy(srcCalibrationSpotWorldImpact.x(), srcCalibrationSpotWorldImpact.y());
+	    double srcCalibrationSpotDistRef2Impact_Xy = (srcCalibrationSpotWorldImpact_Xy - refPoint_Xy).mag();
+	    double srcCalibrationSpotExtrapolationDist_Xy = srcCalibrationSpotDistRef2Impact_Xy - distRef2End_Xy;
+	    DT_LOG_DEBUG(logPrio, "srcCalibrationSpotExtrapolationDist_Xy = " << srcCalibrationSpotExtrapolationDist_Xy / CLHEP::mm << "  mm");
+	    vertex_info calibrationSpotVtxInfo;
             calibrationSpotVtxInfo.category = snemo::geometry::vertex_info::CATEGORY_ON_CALIBRATION_SOURCE;
             calibrationSpotVtxInfo.from = iFrom;
             calibrationSpotVtxInfo.extrapolation_mode = vertex_info::EXTRAPOLATION_LINE;
             calibrationSpotVtxInfo.gid = sourceCalibrationSpotGid;
             calibrationSpotVtxInfo.face_intercept = srcCalibrationSpotFii;
             if (srcCalibrationSpotExtrapolationDist > 0.0) {
-              calibrationSpotVtxInfo.distance = srcCalibrationSpotExtrapolationDist;
-              calibrationSpotVtxInfo.distance_xy = (srcCalibrationSpotWorldImpact - refPoint).perp();
+              calibrationSpotVtxInfo.distance    = srcCalibrationSpotExtrapolationDist;
+              calibrationSpotVtxInfo.distance_xy = srcCalibrationSpotExtrapolationDist_Xy;
             } else {
               calibrationSpotVtxInfo.distance = 0.0;
               calibrationSpotVtxInfo.distance_xy = 0.0;
             }
             calibrationSpotVtxInfo.tolerance = _intercept_tolerance_;
+	    DT_LOG_DEBUG(logPrio, "calibrationSpotVtxInfo.distance_xy = " << calibrationSpotVtxInfo.distance_xy / CLHEP::mm << " mm");
+	    // Extrapolation distance check:
             if (calibrationSpotVtxInfo.distance_xy <= _max_source_extrapolation_xy_length_) {
               srcVertexes.push_back(calibrationSpotVtxInfo);
             } else {
-              DT_LOG_DEBUG(logPrio, "Line intercept is to far from the caibration source spot");
+              DT_LOG_DEBUG(logPrio, "Line intercept is too XY-far from the calibration source spot (max=" << _max_source_extrapolation_xy_length_ / CLHEP::mm << " mm)");
             }
           }
         } // if (use_calib_src)
@@ -1369,7 +1457,7 @@ namespace snemo {
         // srcVertexes.clear();
       } // for (int iFrom=...) 
       return;
-    } // line_trajectory_source_intercept
+    } // vertex_extrapolation_driver::line_trajectory_source_intercept
 
     
     void vertex_extrapolation_driver::helix_trajectory_source_intercept(snemo::geometry::vertex_info_list & vertexes_,
@@ -1453,14 +1541,16 @@ namespace snemo {
         }
         int16_t minStripId = _sourceStripMinId_;
         int16_t maxStripId = _sourceStripMaxId_;
-        bool sourceSubmoduleInterceptSuccess = true;
+        int16_t minTrackId = _sourceCalibTrackMinId_;
+        int16_t maxTrackId = _sourceCalibTrackMaxId_;
+	bool sourceSubmoduleInterceptSuccess = true;
         
         // Optimization for strip scanning:
         if (use_foils or use_calib_src) {
           DT_LOG_DEBUG(logPrio, "Searching line intercept on source submodule #" << _sourceSubmoduleGid_ << "...");
-          const geomtools::geom_info & srcSubmodGinfo      = geoManager().get_mapping().get_geom_info(_sourceSubmoduleGid_);
-          const geomtools::logical_volume & srcSubmodLog   = srcSubmodGinfo.get_logical();
-          const geomtools::i_shape_3d & srcSubmodShape     = srcSubmodLog.get_shape();         
+          const geomtools::geom_info & srcSubmodGinfo = geoManager().get_mapping().get_geom_info(_sourceSubmoduleGid_);
+          const geomtools::logical_volume & srcSubmodLog = srcSubmodGinfo.get_logical();
+          const geomtools::i_shape_3d & srcSubmodShape = srcSubmodLog.get_shape();         
           const geomtools::placement & srcSubmodPlacement = srcSubmodGinfo.get_world_placement();
           DT_LOG_DEBUG(logPrio, "Source submodule shape = " << srcSubmodShape.get_shape_name());
           DT_LOG_DEBUG(logPrio, "Source submodule world placement = " << srcSubmodPlacement);
@@ -1486,7 +1576,7 @@ namespace snemo {
                            << _sourceSubmoduleGid_ << " at " << srcSubmodFii.get_impact());
               const geomtools::vector_3d & impact = srcSubmodFii.get_impact();
               double yImpact = impact.y();
-              int32_t minId = 100000;
+              int32_t minId = +100000;
               int32_t maxId = -100000;
               for (uint32_t iStrip = 0; iStrip < _sourceStripGids_.size(); iStrip++) {
                 const geomtools::geom_id & sourceStripGid = _sourceStripGids_[iStrip];
@@ -1528,7 +1618,7 @@ namespace snemo {
               // srcSubmodPlacement.mother_to_child(srcSubmodWorldImpact, srcSubmodImpact);
               // DT_LOG_DEBUG(logPrio, "impact on source submodule=" << srcSubmodWorldImpact << " (child)");
               double yImpactWorld = srcSubmodWorldImpact.y();
-              int32_t minId = 100000;
+              int32_t minId = +100000;
               int32_t maxId = -100000;
               // Find candidate source strips 
               for (uint32_t iStrip = 0; iStrip < _sourceStripGids_.size(); iStrip++) {
@@ -1548,6 +1638,7 @@ namespace snemo {
               }
               minStripId = std::max(minStripId, (int16_t) (minId - 1));
               maxStripId = std::min(maxStripId, (int16_t) (maxId + 1));
+      
             } else {
               DT_LOG_DEBUG(logPrio, "No helix intercept on the source submodule #" << _sourceSubmoduleGid_);
             }
@@ -1572,13 +1663,12 @@ namespace snemo {
             }
             if ((int32_t) sourceStripId < minStripId or (int32_t) sourceStripId > maxStripId) { 
               continue;
-            }
-            
+            }         
             DT_LOG_DEBUG(logPrio, "Searching helix intercept on strip #" << sourceStripId);
-            const geomtools::geom_info  & sourceStripGinfo     = geoManager().get_mapping().get_geom_info(sourceStripGid);
-            const geomtools::logical_volume & sourceStripLog   = sourceStripGinfo.get_logical();
-            const geomtools::i_shape_3d & sourceStripShape     = sourceStripLog.get_shape();
-            const geomtools::placement  & sourceStripPlacement = sourceStripGinfo.get_world_placement();
+            const geomtools::geom_info & sourceStripGinfo = geoManager().get_mapping().get_geom_info(sourceStripGid);
+            const geomtools::logical_volume & sourceStripLog = sourceStripGinfo.get_logical();
+            const geomtools::i_shape_3d & sourceStripShape = sourceStripLog.get_shape();
+            const geomtools::placement & sourceStripPlacement = sourceStripGinfo.get_world_placement();
             DT_LOG_DEBUG(logPrio, "Source strip shape  : '" << sourceStripShape.get_shape_name() << "'");
             DT_LOG_DEBUG(logPrio, "Intercept tolerance : " << _intercept_tolerance_ / CLHEP::mm << " mm");
             
@@ -1639,10 +1729,10 @@ namespace snemo {
                 continue;
               }
               uint32_t sourcePadId = sourcePadGid.get(2);
-              const geomtools::geom_info  & sourcePadGinfo     = geoManager().get_mapping().get_geom_info(sourcePadGid);
-              const geomtools::logical_volume & sourcePadLog   = sourcePadGinfo.get_logical();
-              const geomtools::i_shape_3d & sourcePadShape     = sourcePadLog.get_shape();
-              const geomtools::placement  & sourcePadPlacement = sourcePadGinfo.get_world_placement();
+              const geomtools::geom_info & sourcePadGinfo = geoManager().get_mapping().get_geom_info(sourcePadGid);
+              const geomtools::logical_volume & sourcePadLog = sourcePadGinfo.get_logical();
+              const geomtools::i_shape_3d & sourcePadShape = sourcePadLog.get_shape();
+              const geomtools::placement & sourcePadPlacement = sourcePadGinfo.get_world_placement();
               DT_LOG_DEBUG(logPrio, "  Source pad " << sourcePadId << " shape : '" << sourcePadShape.get_shape_name() << "'");
  
               // Attempt to find an intercept on a source pad:
@@ -1671,12 +1761,12 @@ namespace snemo {
                   geomtools::vector_3d srcPadImpactWorld;
                   sourcePadPlacement.child_to_mother(srcPadImpact, srcPadImpactWorld);
                   srcPadFii.set_impact(srcPadImpactWorld);
-                  double distRef2Impact    = (srcPadImpactWorld - refPoint).mag();
+                  double distRef2Impact = (srcPadImpactWorld - refPoint).mag();
                   double extrapolationDist = distRef2Impact - distRef2End;
                   DT_LOG_DEBUG(logPrio, "extrapolationDist = " << extrapolationDist / CLHEP::mm << "  mm");
                   // XY-extrapolation:
                   geomtools::vector_2d srcPadImpactWorld_Xy(srcPadImpactWorld.x(), srcPadImpactWorld.y());
-                  double distRef2Impact_Xy  = (srcPadImpactWorld_Xy - refPoint_Xy).mag();
+                  double distRef2Impact_Xy = (srcPadImpactWorld_Xy - refPoint_Xy).mag();
                   double extrapolationDist_Xy = distRef2Impact_Xy - distRef2End_Xy;
                   DT_LOG_DEBUG(logPrio, "extrapolationDist_Xy = " << extrapolationDist_Xy / CLHEP::mm << "  mm");
                   padVtxInfo.category = snemo::geometry::vertex_info::CATEGORY_ON_SOURCE_FOIL;
@@ -1710,7 +1800,8 @@ namespace snemo {
               } // if (useSourcePadLineExtrapolation)
               
               if (_use_helix_interpolation_ and not sourcePadLineExtrapolationSuccess ) {            
-                DT_LOG_DEBUG(logPrio, "Searching helix intercept on source pad #" << sourcePadGid << " in strip #" << sourceStripGid);            
+                DT_LOG_DEBUG(logPrio, "Searching helix intercept on source pad #" << sourcePadGid
+			     << " in strip #" << sourceStripGid);            
                 snemo::geometry::helix_intercept::extrapolation_info srcPadEi;
                 snemo::geometry::helix_intercept hIntercept(helix,
                                                             sourcePadShape,
@@ -1766,7 +1857,8 @@ namespace snemo {
                     continue;
                   }
                   hasCandidatePadBulk = true;
-                  DT_LOG_DEBUG(logPrio, "Searching helix intercept on pad bulk #" << sourcePadBulkGid << " in pad #" << sourcePadGid);
+                  DT_LOG_DEBUG(logPrio, "Searching helix intercept on pad bulk #" << sourcePadBulkGid
+			       << " in pad #" << sourcePadGid);
                   const geomtools::geom_info & sourcePadBulkGinfo = geoManager().get_mapping().get_geom_info(sourcePadBulkGid);
                   const geomtools::logical_volume & sourcePadBulkLog = sourcePadBulkGinfo.get_logical();
                   const geomtools::i_shape_3d & sourcePadBulkShape = sourcePadBulkLog.get_shape();
@@ -1801,7 +1893,8 @@ namespace snemo {
                       double extrapolationDist = distRef2Impact - distRef2End;
                       DT_LOG_DEBUG(logPrio, "extrapolationDist    = " << extrapolationDist / CLHEP::mm << "  mm");
                       // XY-extrapolation:
-                      geomtools::vector_2d srcPadBulkImpactWorld_Xy(srcPadBulkImpactWorld.x(), srcPadBulkImpactWorld.y());
+                      geomtools::vector_2d srcPadBulkImpactWorld_Xy(srcPadBulkImpactWorld.x(),
+								    srcPadBulkImpactWorld.y());
                       double distRef2Impact_Xy  = (srcPadBulkImpactWorld_Xy - refPoint_Xy).mag();
                       double extrapolationDist_Xy = distRef2Impact_Xy - distRef2End_Xy;
                       DT_LOG_DEBUG(logPrio, "extrapolationDist_Xy = " << extrapolationDist_Xy / CLHEP::mm << "  mm");
@@ -1901,11 +1994,18 @@ namespace snemo {
           // Calibration spot:
           for (uint32_t iSpot = 0; iSpot < _sourceCalibrationSpotGids_.size(); iSpot++) {
             const geomtools::geom_id & sourceCalibrationSpotGid = _sourceCalibrationSpotGids_[iSpot];
-            DT_LOG_DEBUG(logPrio, "Searching helix intercept on calibration source spot #" << sourceCalibrationSpotGid);
-            const geomtools::geom_info  & sourceCalibrationSpotGinfo  = geoManager().get_mapping().get_geom_info(sourceCalibrationSpotGid);
-            const geomtools::logical_volume & sourceCalibrationSpotLog   = sourceCalibrationSpotGinfo.get_logical();
-            const geomtools::i_shape_3d & sourceCalibrationSpotShape     = sourceCalibrationSpotLog.get_shape();
-            const geomtools::placement  & sourceCalibrationSpotPlacement = sourceCalibrationSpotGinfo.get_world_placement();
+ 	    static const int32_t trackNumIdx = 1;
+	    int32_t trackId = sourceCalibrationSpotGid.get(trackNumIdx);
+            if (sourceCalibrationSpotGid.get(0) != _module_id_) { 
+              continue;
+            }
+	    if (trackId < minTrackId) continue;
+	    if (trackId > maxTrackId) continue;
+	    DT_LOG_DEBUG(logPrio, "Searching helix intercept on calibration source spot #" << sourceCalibrationSpotGid);
+            const geomtools::geom_info & sourceCalibrationSpotGinfo = geoManager().get_mapping().get_geom_info(sourceCalibrationSpotGid);
+            const geomtools::logical_volume & sourceCalibrationSpotLog = sourceCalibrationSpotGinfo.get_logical();
+            const geomtools::i_shape_3d & sourceCalibrationSpotShape = sourceCalibrationSpotLog.get_shape();
+            const geomtools::placement & sourceCalibrationSpotPlacement = sourceCalibrationSpotGinfo.get_world_placement();
             DT_LOG_DEBUG(logPrio, "Calibration spot shape : '" << sourceCalibrationSpotShape.get_shape_name() << "'");
 
             bool calibrationSpotLineExtrapolationSuccess = false;
@@ -1921,20 +2021,24 @@ namespace snemo {
               DT_LOG_DEBUG(logPrio, "Calib. spot strip shape  : '" << sourceCalibrationSpotShape.get_shape_name() << "'");
               DT_LOG_DEBUG(logPrio, "Intercept tolerance : " << _intercept_tolerance_ / CLHEP::mm << " mm");
               geomtools::face_intercept_info calibSpotFii;
-              bool success = sourceCalibrationSpotShape.find_intercept(calibSpotRefPoint,
-                                                                       calibSpotDirection,
-                                                                       calibSpotFii,
-                                                                       _intercept_tolerance_);
+              // bool success = sourceCalibrationSpotShape.find_intercept(calibSpotRefPoint,
+              //                                                          calibSpotDirection,
+              //                                                          calibSpotFii,
+              //                                                          _intercept_tolerance_);
+              bool success = _sourceCalibrationSpotEffectiveBoxPtr_->find_intercept(calibSpotRefPoint,
+										    calibSpotDirection,
+										    calibSpotFii,
+										    _intercept_tolerance_);
               if (success) {
                 geomtools::vector_3d calibSpotImpact = calibSpotFii.get_impact();
                 geomtools::vector_3d calibSpotWorldImpact;
                 sourceCalibrationSpotPlacement.child_to_mother(calibSpotImpact, calibSpotWorldImpact);
                 calibSpotFii.set_impact(calibSpotWorldImpact);
-                double calibSpotDistRef2Impact    = (calibSpotWorldImpact - refPoint).mag();
+                double calibSpotDistRef2Impact = (calibSpotWorldImpact - refPoint).mag();
                 double calibSpotExtrapolationDist = calibSpotDistRef2Impact - distRef2End;
                 // XY extrapolation:
                 geomtools::vector_2d calibSpotImpact_Xy(calibSpotWorldImpact.x(), calibSpotWorldImpact.y());
-                double calibSpotDistRef2Impact_Xy    = (calibSpotImpact_Xy - refPoint_Xy).mag();
+                double calibSpotDistRef2Impact_Xy = (calibSpotImpact_Xy - refPoint_Xy).mag();
                 double calibSpotExtrapolationDist_Xy = calibSpotDistRef2Impact_Xy - distRef2End_Xy;
                 // Result:
                 vertex_info calibSpotVtxInfo;
@@ -1944,10 +2048,10 @@ namespace snemo {
                 calibSpotVtxInfo.gid = sourceCalibrationSpotGid;
                 calibSpotVtxInfo.face_intercept = calibSpotFii;
                 if (calibSpotExtrapolationDist > 0.0) {
-                  calibSpotVtxInfo.distance    = calibSpotDistRef2Impact;
+                  calibSpotVtxInfo.distance = calibSpotDistRef2Impact;
                   calibSpotVtxInfo.distance_xy = calibSpotExtrapolationDist_Xy;
                 } else {
-                  calibSpotVtxInfo.distance    = 0.0;
+                  calibSpotVtxInfo.distance = 0.0;
                   calibSpotVtxInfo.distance_xy = 0.0;
                 }
                 DT_LOG_DEBUG(logPrio, "calibSpotExtrapolationDist    = " << calibSpotExtrapolationDist / CLHEP::mm << "  mm");
@@ -1964,8 +2068,14 @@ namespace snemo {
             } // if (useCalibrationSpotLineExtrapolation) 
 
             if (_use_helix_interpolation_ and not calibrationSpotLineExtrapolationSuccess) {
+              // snemo::geometry::helix_intercept hCalibrationSpotIntercept(helix,
+              //                                                            sourceCalibrationSpotShape,
+              //                                                            sourceCalibrationSpotPlacement,
+              //                                                            _finder_step_,
+              //                                                            _intercept_tolerance_,
+              //                                                            logPrio);
               snemo::geometry::helix_intercept hCalibrationSpotIntercept(helix,
-                                                                         sourceCalibrationSpotShape,
+                                                                         *_sourceCalibrationSpotEffectiveBoxPtr_,
                                                                          sourceCalibrationSpotPlacement,
                                                                          _finder_step_,
                                                                          _intercept_tolerance_,
@@ -2019,7 +2129,7 @@ namespace snemo {
         
       } // for (int iFrom=...) 
       return;
-    } // helix_trajectory_source_intercept
+    } // vertex_extrapolation_driver::helix_trajectory_source_intercept
 
     
     void vertex_extrapolation_driver::_measure_vertices_(const snemo::datamodel::tracker_trajectory & trajectory_,
@@ -2254,7 +2364,7 @@ namespace snemo {
       //   } else ...
       //
       return;
-    } // _measure_vertices_
+    } // vertex_extrapolation_driver::_measure_vertices_
 
     
     void vertex_extrapolation_driver::_check_vertices_(const snemo::datamodel::tracker_trajectory & trajectory_,
@@ -2302,7 +2412,7 @@ namespace snemo {
 	DT_LOG_DEBUG(logPriority_, "Use vertice '" << snemo::geometry::vertex_info::to_label(p.first) << "' : " << std::boolalpha << p.second);
       }
       return;
-    } // _check_vertices_
+    } // vertex_extrapolation_driver::_check_vertices_
 
  
     void vertex_extrapolation_driver::_post_process_source_vertex_(snemo::geometry::vertex_info_list & src_vertexes_) const
@@ -2320,7 +2430,7 @@ namespace snemo {
       
       src_vertexes_ = workVertexes;
       return;
-    }
+    } // vertex_extrapolation_driver::_post_process_source_vertex_
 
     void vertex_extrapolation_driver::_post_process_calo_vertex_(snemo::geometry::vertex_info_list & calo_vertexes_) const
     {
@@ -2385,7 +2495,7 @@ namespace snemo {
       
       calo_vertexes_ = workVertexes;
       return;
-    }
+    } // vertex_extrapolation_driver::_post_process_calo_vertex_
       
     // static
     void vertex_extrapolation_driver::init_ocd(datatools::object_configuration_description & ocd_)

--- a/modules/ChargedParticleTracking/ChargedParticleTracking/vertex_extrapolation_driver.h
+++ b/modules/ChargedParticleTracking/ChargedParticleTracking/vertex_extrapolation_driver.h
@@ -179,13 +179,20 @@ namespace snemo {
       double _sourceStripGapHeight_ = datatools::invalid_real();
       std::unique_ptr<geomtools::box> _sourceStripGapBoxPtr_;
 
-     // Source calibration tracks:
-       uint32_t _sourceCalibTrackType_ = geomtools::geom_id::INVALID_TYPE;
+			// Source calibration tracks:
+			uint32_t _sourceCalibTrackType_ = geomtools::geom_id::INVALID_TYPE;
+      int32_t _sourceCalibTrackMinId_ =  100000; 
+      int32_t _sourceCalibTrackMaxId_ = -100000;
       std::vector<geomtools::geom_id> _sourceCalibTrackGids_;
       double _sourceCalibTrackX_ = datatools::invalid_real();
       double _sourceCalibTrackZ_ = datatools::invalid_real();
       double _sourceCalibTrackHeight_ = datatools::invalid_real();
       std::unique_ptr<geomtools::box> _sourceCalibTrackBoxPtr_;
+			std::unique_ptr<geomtools::box> _sourceCalibrationSpotEffectiveBoxPtr_;
+			double vertexSourceCalibrationExtendY_ = 1.0;
+			double vertexSourceCalibrationExtendZ_ = 1.0;
+
+			// Source calibration spots:
 
       // Registered calorimeter blocks:
       uint32_t _caloSubmoduleType_ = geomtools::geom_id::INVALID_TYPE; //!< Calorimeter submodule type (for GID)
@@ -202,10 +209,10 @@ namespace snemo {
       std::unique_ptr<geomtools::box> _effectiveXcaloBlockBoxPtr2_;
 
       // Specific dimensions about the positioning of main calo blocks (world frame)
-      double _main_calo_y_first_;
-      double _main_calo_z_first_;
-      double _main_calo_y_step_;
-      double _main_calo_z_step_;
+      double _main_calo_y_first_ = datatools::invalid_real();
+      double _main_calo_z_first_ = datatools::invalid_real();
+      double _main_calo_y_step_ = datatools::invalid_real();
+      double _main_calo_z_step_ = datatools::invalid_real();
 
       // Dynamic
       std::map<snemo::geometry::vertex_info::category_type, bool> _use_vertices_; //!< Vertices reliability
@@ -215,18 +222,16 @@ namespace snemo {
 
     };
 
-  }  // end of namespace reconstruction
+  } // end of namespace reconstruction
 
-}  // end of namespace snemo
+} // end of namespace snemo
 
 #include <datatools/ocd_macros.h>
 
 // Declare the OCD interface of the module
 DOCD_CLASS_DECLARATION(snemo::reconstruction::vertex_extrapolation_driver)
 
-#endif  // FALAISE_CHARGEDPARTICLETRACKING_PLUGIN_RECONSTRUCTION_VERTEX_EXTRAPOLATION_DRIVER_H
-
-// end of falaise/snemo/reconstruction/vertex_extrapolation_driver.h
+#endif // FALAISE_CHARGEDPARTICLETRACKING_PLUGIN_RECONSTRUCTION_VERTEX_EXTRAPOLATION_DRIVER_H
 /*
 ** Local Variables: --
 ** mode: c++ --

--- a/programs/flreconstruct/tests/CMakeLists.txt
+++ b/programs/flreconstruct/tests/CMakeLists.txt
@@ -152,3 +152,13 @@ add_test(NAME flreconstruct-fix-issue-201
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
 set_falaise_test_environment(flreconstruct-fix-issue-201)
+
+
+# Tests dedicated to the validation of fixes
+# - Validation of issue #281 fix
+add_test(NAME flreconstruct-fix-issue281
+  COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/fix-issue281/run.sh
+  --work-dir "${CMAKE_CURRENT_BINARY_DIR}"
+  --cfg-dir "${CMAKE_CURRENT_SOURCE_DIR}/fix-issue281"
+  )
+set_falaise_test_environment(flreconstruct-fix-issue281)

--- a/programs/flreconstruct/tests/fix-issue281/fix-issue281-bi207.vprofile
+++ b/programs/flreconstruct/tests/fix-issue281/fix-issue281-bi207.vprofile
@@ -1,0 +1,33 @@
+#@format=datatools::configuration::variant
+#@format.version=1.0
+#@organization=snemo
+#@application=falaise
+
+[registry="geometry"]
+layout = "Basic"
+layout/if_basic/magnetic_field = false
+layout/if_basic/source_layout = "RealisticFlat"
+layout/if_basic/source_calibration = true
+layout/if_basic/source_calibration/is_active/type = "SDS"
+layout/if_basic/source_calibration/is_active/type/if_sds/track0 = true
+layout/if_basic/source_calibration/is_active/type/if_sds/track1 = true
+layout/if_basic/source_calibration/is_active/type/if_sds/track2 = true
+layout/if_basic/source_calibration/is_active/type/if_sds/track3 = true
+layout/if_basic/source_calibration/is_active/type/if_sds/track4 = true
+layout/if_basic/source_calibration/is_active/type/if_sds/track5 = true
+layout/if_basic/shielding = false
+calo_film_thickness = 25 um
+tracking_gas_material = "HeliumMix"
+
+[registry="vertexes"]
+generator = "sds_bi207_calibration_source_all_tracks"
+
+[registry="primary_events"]
+generator = "calibBi207HighEnergyElectrons"
+
+[registry="simulation"]
+physics_mode = "Constructors"
+physics_mode/if_constructors/em_model = "standard"
+production_cuts = true
+output_profile = "all_details"
+

--- a/programs/flreconstruct/tests/fix-issue281/fix-issue281.vprofile
+++ b/programs/flreconstruct/tests/fix-issue281/fix-issue281.vprofile
@@ -1,0 +1,33 @@
+#@format=datatools::configuration::variant
+#@format.version=1.0
+#@organization=snemo
+#@application=falaise
+
+[registry="geometry"]
+layout = "Basic"
+layout/if_basic/magnetic_field = false
+layout/if_basic/source_layout = "RealisticFlat"
+layout/if_basic/source_calibration = true
+layout/if_basic/source_calibration/is_active/type = "SDS"
+layout/if_basic/source_calibration/is_active/type/if_sds/track0 = true
+layout/if_basic/source_calibration/is_active/type/if_sds/track1 = true
+layout/if_basic/source_calibration/is_active/type/if_sds/track2 = true
+layout/if_basic/source_calibration/is_active/type/if_sds/track3 = true
+layout/if_basic/source_calibration/is_active/type/if_sds/track4 = true
+layout/if_basic/source_calibration/is_active/type/if_sds/track5 = true
+layout/if_basic/shielding = false
+calo_film_thickness = 25 um
+tracking_gas_material = "HeliumMix"
+
+[registry="vertexes"]
+generator = "sds_bi207_calibration_source_all_tracks"
+
+[registry="primary_events"]
+generator = "calibBi207HighEnergyElectrons"
+
+[registry="simulation"]
+physics_mode = "Constructors"
+physics_mode/if_constructors/em_model = "standard"
+production_cuts = true
+output_profile = "all_details"
+

--- a/programs/flreconstruct/tests/fix-issue281/pipeline.conf
+++ b/programs/flreconstruct/tests/fix-issue281/pipeline.conf
@@ -1,0 +1,97 @@
+
+[name="pipeline" type="dpp::chain_module"]
+  #logging.priority : string = "debug"
+  modules : string[4] =  \
+    "MockCalibration" \
+    "CATTrackerClusterizer" \
+    "TrackFit" \
+    "ChargedParticleTracker"
+
+[name="MockCalibration" type="dpp::chain_module"]
+  #logging.priority : string = "debug"
+  modules : string[2] = "CalibrateTracker" "CalibrateCalorimeters"
+
+[name="CalibrateTracker" type="snemo::processing::mock_tracker_s2c_module"]
+  #logging.priority : string = "debug"
+  random.seed : integer = 12345
+  store_mc_hit_id : boolean = true
+  delayed_drift_time_threshold  : real as time = 13.0 microsecond
+
+[name="CalibrateCalorimeters" type="snemo::processing::mock_calorimeter_s2c_module"]
+  #logging.priority : string = "debug"
+  Geo_label : string = "geometry"
+  random.seed : integer = 12345
+  store_mc_hit_id : boolean = true
+  hit_categories : string[3]  = "calo" "xcalo" "gveto"
+    calo.energy.resolution      : real as fraction = 8  %
+    calo.alpha_quenching_parameters  : real[3] = 77.4 0.639 2.34
+    calo.energy.low_threshold   : real as energy =  50 keV
+    calo.energy.high_threshold  : real as energy = 150 keV
+    calo.scintillator_relaxation_time  : real as time = 6.0 ns
+
+    xcalo.energy.resolution     : real as fraction = 12 %
+    xcalo.alpha_quenching_parameters : real[3] = 77.4 0.639 2.34
+    xcalo.energy.low_threshold  : real as energy =  50 keV
+    xcalo.energy.high_threshold : real as energy = 150 keV
+    xcalo.scintillator_relaxation_time : real as time = 6.0 ns
+
+    gveto.energy.resolution     : real as fraction = 15 %
+    gveto.alpha_quenching_parameters : real[3] = 77.4 0.639 2.34
+    gveto.energy.low_threshold  : real as energy =  50 keV
+    gveto.energy.high_threshold : real as energy = 150 keV
+    gveto.scintillator_relaxation_time : real as time = 6.0 ns
+
+[name="CATTrackerClusterizer" type="snemo::reconstruction::cat_tracker_clustering_module"]
+  # logging.priority : string = "debug"
+  Geo_label : string  = "geometry"
+  TPC.delayed_hit_cluster_time : real = 13 us
+  TPC.processing_prompt_hits : boolean = true
+  TPC.processing_delayed_hits : boolean = true
+  TPC.split_chamber : boolean = false
+
+  #@variant_if geometry:layout/if_basic/magnetic_field/is_active|true
+    #@variant_only geometry:layout/if_basic/magnetic_field/is_active/type/if_uniform_vertical|true
+      CAT.magnetic_field : real = @variant(geometry:layout/if_basic/magnetic_field/is_active/type/if_uniform_vertical/magnitude|25 gauss)
+  #@variant_endif geometry:layout/if_basic/magnetic_field/is_active
+
+  #@variant_if geometry:layout/if_basic/magnetic_field/is_inactive|false
+    CAT.magnetic_field : real = 0 gauss
+  #@variant_endif geometry:layout/if_basic/magnetic_field/is_inactive
+
+[name="TrackFit" type="snemo::reconstruction::trackfit_tracker_fitting_module"]
+  logging.priority : string = "debug"
+  Geo_label : string  = "geometry"
+  maximum_number_of_fits : integer = 0
+  drift_time_calibration_label : string = "snemo"
+  # Base tracker fitter configuration:
+  BTF.logging.priority : string = "debug"
+  # fitting_models : string[2] = "helix" "line"
+  #   line.only_guess  : string[4] = "BB" "BT" "TB" "TT"
+  #   line.guess.fit_delayed_clusters : boolean = true
+  #   helix.only_guess : string[8] = "BBB" "BBT" "BTB" "BTT" "TBB" "TBT" "TTB" "TTT"
+  #@variant_devel
+  #@variant_if geometry:layout/if_basic/magnetic_field/is_active|true
+  fitting_models : string[2] = "helix" "line"
+    line.only_guess  : string[4] = "BB" "BT" "TB" "TT"
+    line.guess.fit_delayed_clusters : boolean = true
+    helix.only_guess : string[8] = "BBB" "BBT" "BTB" "BTT" "TBB" "TBT" "TTB" "TTT"
+  #@variant_endif geometry:layout/if_basic/magnetic_field/is_active
+  
+  #@variant_if geometry:layout/if_basic/magnetic_field/is_inactive|false
+  fitting_models : string[1] = "line"
+    line.only_guess  : string[4] = "BB" "BT" "TB" "TT"
+    line.guess.fit_delayed_clusters : boolean = true
+  #@variant_endif geometry:layout/if_basic/magnetic_field/is_inactive
+
+[name="ChargedParticleTracker" type="snemo::reconstruction::charged_particle_tracking_module"]
+  logging.priority : string = "debug"
+  Geo_label : string  = "geometry"
+  drivers : string[4] = "VED" "CCD" "CAD" "AFD"
+    VED.logging.priority : string = "debug"
+    VED.finder.step         : real as length = 2.0 cm
+    VED.intercept.tolerance : real as length = 1.0 mm
+    VED.max_calo_extrapolation.xy_length   : real as length = 15.0 cm
+    VED.max_source_extrapolation.xy_length : real as length = 30.0 cm
+    VED.vertex_source_extrapolation.extend_y : real = 1.0
+    VED.vertex_source_extrapolation.extend_z : real = 1.0
+    AFD.minimal_delayed_time : real as time = 13 us

--- a/programs/flreconstruct/tests/fix-issue281/reco.conf
+++ b/programs/flreconstruct/tests/fix-issue281/reco.conf
@@ -1,0 +1,35 @@
+# Author: F. Mauger <mauger@lpccaen.in2p3.fr>
+# Date:   2024-05-13
+# Format: datatools::multi_properties
+# Description: Sample configuration script for flreconstruct (Falaise 3.0.0)
+# Supports: SuperNEMO Demonstrator Simulation setup version 2.1
+
+#@description flreconstruct configuration script for fix-issue8 validation
+#@key_label  "name"
+#@meta_label "type"
+
+[name="flreconstruct.variantService" type="flreconstruct::section"]
+#@config Variants setup
+
+#@description Input variant profile configuration file
+profile : string as path = "${FLWORKDIR}/fix-issue281.vprofile"
+
+[name="flreconstruct.plugins" type="flreconstruct::section"]
+#@config Plugins
+
+#@description List of plugins
+plugins : string[4] = "Falaise_CAT"                     \
+                      "TrackFit"                        \
+                      "Falaise_TrackFit"                \
+		      "Falaise_ChargedParticleTracking"
+
+[name="flreconstruct.pipeline" type="flreconstruct::section"]
+#@config Pipeline
+
+# #@description Tagged pipeline
+# configUrn : string = "urn:snemo:demonstrator:reconstruction:3.0:pipeline:official-3.0"
+
+#@description The explicit path to the pipeline config file
+config : string as path = "${FLWORKDIR}/pipeline.conf"
+  
+# end

--- a/programs/flreconstruct/tests/fix-issue281/run.sh
+++ b/programs/flreconstruct/tests/fix-issue281/run.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+#
+# Author: F. Mauger
+# Date:   2024-05-13
+#
+# Test of the issue #281 fix
+# =========================
+#
+# This test must be run after Falaise installation and setup.
+#
+# Contents
+# --------
+#
+#  * ``config/simu.conf`` : main configuration file for flsimulate
+#  * ``config/reco.conf ``: main configuration file for flreconstruct
+#  * ``run.sh`` : test script
+#
+# Run the test script
+# -------------------
+#
+# flsimulate and flreconstruct must be in the PATH.
+# cd in the directory containing the script:
+#
+#  $ ./run.sh [--work-dir /tmp/${USER}/fltest-issue281] [--visu]
+#  $ echo $?
+#
+
+echo >&2 "[debug] PATH = '${PATH}'"
+
+label="run-fix-issue281"
+with_visu=0
+work_dir=""
+cfg_dir=""
+with_magfield=0
+
+function parse_cl_opts()
+{
+    while [ -n "$1" ]; do
+	local opt="$1"
+	if [ "${opt}" == "--work-dir" ]; then
+	    shift 1
+	    work_dir="$1"
+	elif [ "${opt}" == "--cfg-dir" ]; then
+	    shift 1
+	    cfg_dir="$1"
+	# elif [ "${arg}" = "-m" ]; then
+	#     with_magfield=0
+	# elif [ "${arg}" = "-M" ]; then
+	#     with_magfield=1
+	elif [ "${opt}" == "--visu" ]; then
+	    with_visu=1
+	else
+	    echo >&2 "[error] Invalid command line option '${opt}'! Abort!"
+	    return 1
+	fi
+	shift 1
+    done
+    return 0
+}
+
+parse_cl_opts $@
+if [ $? -ne 0 ]; then
+    exit 1
+fi
+
+if [ -z "${work_dir}" ]; then
+    work_dir="_work.d"
+fi
+if [ -z "${cfg_dir}" ]; then
+    cfg_dir="."
+fi
+
+#########################################
+export FLWORKDIR="${work_dir}/${label}"
+
+echo >&2 "[info] cfg_dir   = '${cfg_dir}'"
+echo >&2 "[info] work_dir  = '${work_dir}'"
+echo >&2 "[info] FLWORKDIR = '${FLWORKDIR}'"
+echo >&2 "[info] with_magfield = '${with_magfield}'"
+
+function my_exit()
+{
+    local error_code="$1"
+    shift 1
+    local error_msg="$@"
+    if [ -n "${error_msg}" ]; then
+	echo >&2 "[error] $@"
+    fi
+    if [ -d ${FLWORKDIR} ]; then
+	rm -fr ${FLWORKDIR}
+    fi
+    exit ${error_code}
+}
+
+which flsimulate > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+    my_exit 1 "flsimulate is not available! Abort!"
+fi
+
+if [ ! -d ${FLWORKDIR} ]; then
+    mkdir -p ${FLWORKDIR}
+fi
+cp -f ${cfg_dir}/pipeline.conf ${FLWORKDIR}/pipeline.conf
+
+echo >&2 "[info] Running flsimulate-configure..."
+# flsimulate-configure --no-gui \
+#     -s "geometry:layout/if_basic/magnetic_field=${with_magfield}" \
+#     -s "vertexes:generator=source_pads_bulk" \
+#     -s "primary_events:generator=Se82.0nubb" \
+#     -s "simulation:output_profile=all_details" \
+#     -o "${FLWORKDIR}/fix-issue281.vprofile"
+flsimulate-configure --no-gui \
+		     -i "${cfg_dir}/fix-issue281.vprofile" \
+		     -o "${FLWORKDIR}/fix-issue281.vprofile"
+if [ $? -ne 0 ]; then
+    my_exit 1 "flsimulate-configure failed! Abort!"
+fi
+
+echo >&2 "[info] Dump '${FLWORKDIR}/fix-issue281.vprofile' :"
+cat ${FLWORKDIR}/fix-issue281.vprofile
+echo >&2 ""
+
+echo >&2 "[info] Running flsimulate..."
+flsimulate -c ${cfg_dir}/simu.conf -o ${FLWORKDIR}/fix-issue281.brio
+if [ $? -ne 0 ]; then
+    my_exit 1 "flsimulate failed! Abort!"
+fi
+
+echo >&2 "[info] Running flreconstruct..."
+flreconstruct \
+    -p ${cfg_dir}/reco.conf \
+    -i ${FLWORKDIR}/fix-issue281.brio \
+    -o ${FLWORKDIR}/fix-issue281-rec.brio \
+    > ${FLWORKDIR}/reco.log 2>&1
+echo >&2 ""
+
+if [ ${with_visu} -eq 1 ]; then
+    echo >&2 "[info] Running flvisualize..."
+    flvisualize \
+	--variant-profile "${FLWORKDIR}/fix-issue281.vprofile" \
+	-i ${FLWORKDIR}/fix-issue281-rec.brio \
+	--focus-on-roi \
+	--show-simulated-vertex 1 \
+	--show-simulated-tracks 1 \
+	--show-simulated-hits 1 \
+	--show-calibrated-hits 1 \
+	--show-calibrated-info 1 \
+	--show-tracker-clustered-hits 1 \
+	--show-tracker-trajectories 1 \
+	--show-particle-tracks 1
+fi
+
+my_exit 0
+
+# end

--- a/programs/flreconstruct/tests/fix-issue281/simu.conf
+++ b/programs/flreconstruct/tests/fix-issue281/simu.conf
@@ -1,0 +1,39 @@
+# Author: F. Mauger <mauger@lpccaen.in2p3.fr>
+# Date:   2024-05-13
+# Format: datatools::multi_properties
+# Description: Sample configuration script for flsimulate (Falaise 3.0.0)
+# Supports: SuperNEMO Demonstrator Simulation setup version 2.1
+
+#@description flsimulate configuration script for fix-issue16 validation
+#@key_label  "name"
+#@meta_label "type"
+
+
+##############################################
+[name="flsimulate" type="flsimulate::section"]
+#@config Basic system setup
+
+#@description Number of events to simulate (default: 1)
+numberOfEvents : integer = 200
+
+
+#########################################################
+[name="flsimulate.simulation" type="flsimulate::section"]
+#@config Simulation module setup
+
+# Seeds for the embedded PRNGs
+rngEventGeneratorSeed         : integer = 1
+rngVertexGeneratorSeed        : integer = 2
+rngGeant4GeneratorSeed        : integer = 3
+rngHitProcessingGeneratorSeed : integer = 4
+
+
+#############################################################
+[name="flsimulate.variantService" type="flsimulate::section"]
+#@config Variants setup
+
+#@description Input variant profile configuration file
+profile : string as path = "${FLWORKDIR}/fix-issue281.vprofile"
+
+
+# end

--- a/programs/flvisualize/EventBrowser/detector_manager.cc
+++ b/programs/flvisualize/EventBrowser/detector_manager.cc
@@ -56,694 +56,695 @@
 
 namespace snemo {
 
-	namespace visualization {
-
-		namespace detector {
-
-			bool detector_manager::is_initialized() const { return _initialized_; }
-
-			bool detector_manager::is_constructed() const { return _constructed_; }
-
-			detector_manager::setup_label_type detector_manager::get_setup_label() const {
-				return _setup_label_;
-			}
-
-			const std::string &detector_manager::get_setup_label_name() const { return _setup_label_name_; }
-
-			bool detector_manager::is_special_volume(const std::string &volume_name_) const {
-				auto name_iter =
-					std::find(_special_volume_name_.begin(), _special_volume_name_.end(), volume_name_);
-				return (name_iter != _special_volume_name_.end());
-			}
-
-			i_volume *detector_manager::grab_volume(const geomtools::geom_id &id_) {
-				i_volume *volume = nullptr;
-				auto volume_iter = _volumes_.find(id_);
-
-				if (volume_iter != _volumes_.end()) {
-					volume = volume_iter->second;
-				}
-				return volume;
-			}
-
-			const i_volume *detector_manager::get_volume(const geomtools::geom_id &id_) const {
-				i_volume *volume = nullptr;
-				auto volume_iter = _volumes_.find(id_);
-
-				if (volume_iter != _volumes_.end()) {
-					volume = volume_iter->second;
-				}
-				return volume;
-			}
-
-			void detector_manager::get_matching_ids(const geomtools::geom_id &id_,
-																							std::vector<geomtools::geom_id> &vids_) const {
-				for (const auto &_volume : _volumes_) {
-					const geomtools::geom_id &gid = _volume.first;
-					if (geomtools::geom_id::match(gid, id_)) {
-						vids_.push_back(gid);
-					}
-				}
-			}
-
-			std::string detector_manager::get_volume_name(const geomtools::geom_id &id_) const {
-				return _geo_manager_->get_id_mgr().id_to_human_readable_format_string(id_);
-			}
-
-			std::string detector_manager::get_volume_category(const geomtools::geom_id &id_) const {
-				const geomtools::id_mgr &mgr = _geo_manager_->get_id_mgr();
-				std::string volume_category;
-				if (mgr.has_category_info(id_.get_type())) {
-					const geomtools::id_mgr::category_info &c_info = mgr.get_category_info(id_.get_type());
-					volume_category = c_info.get_category();
-				}
-				return volume_category;
-			}
-
-			bool detector_manager::has_external_geometry_manager() const {
-				return _has_external_geometry_manager_;
-			}
-
-			void detector_manager::set_external_geometry_manager(geomtools::manager &geometry_manager_) {
-				_has_external_geometry_manager_ = true;
-				_geo_manager_ = &geometry_manager_;
-			}
-
-			geomtools::manager &detector_manager::grab_geometry_manager() { return *_geo_manager_; }
-
-			const geomtools::manager &detector_manager::get_geometry_manager() const { return *_geo_manager_; }
-
-			TGeoVolume *detector_manager::grab_world_volume() { return _world_volume_; }
-
-			const TGeoVolume *detector_manager::get_world_volume() const { return _world_volume_; }
-
-			// ctor:
-			detector_manager::detector_manager() {
-				_initialized_ = false;
-				_constructed_ = false;
-				_setup_label_name_ = "";
-				_setup_label_ = SNEMO;
-				_has_external_geometry_manager_ = false;
-				_geo_manager_config_file_ = "";
-				_geo_manager_ = nullptr;
-				_world_volume_ = nullptr;
-				_world_length_ = 0.0;
-				_world_width_ = 0.0;
-				_world_height_ = 0.0;
-			}
-
-			// dtor:
-			detector_manager::~detector_manager() {
-				if (is_initialized()) {
-					this->reset();
-				}
-			}
-
-			void detector_manager::initialize(const std::string &geo_manager_config_file_) {
-				FL_LOG_DEVEL("Entering...");
-				DT_THROW_IF(is_initialized(), std::logic_error, "Already initialized !");
-				this->_at_init_(geo_manager_config_file_);
-				_initialized_ = true;
-				FL_LOG_DEVEL("Exiting...");
-			}
-
-			void detector_manager::construct() {
-				FL_LOG_DEVEL("Entering...");
-				DT_THROW_IF(!is_initialized(), std::logic_error, "Not initialized !");
-				this->_at_construct_();
-				_constructed_ = true;
-				FL_LOG_DEVEL("Exiting...");
-			}
-
-			void detector_manager::update() {
-				FL_LOG_DEVEL("Entering...");
-				for (volume_dict_type::const_iterator it_volume = _volumes_.begin(); it_volume != _volumes_.end();
-						 ++it_volume) {
-					it_volume->second->update();
-				}
-				FL_LOG_DEVEL("Exiting...");
-			}
-
-			void detector_manager::draw() {
-				FL_LOG_DEVEL("Entering...");
-				DT_THROW_IF(!is_initialized(), std::logic_error, "Not initialized !");
-				DT_THROW_IF(!is_constructed(), std::logic_error, "Not constructed !");
-
-				TGeoVolume *world_volume = this->grab_world_volume();
-				world_volume->Draw();
-
-				// Special treatment for special volumes
-				for (volume_dict_type::const_iterator it_volume = _volumes_.begin(); it_volume != _volumes_.end();
-						 ++it_volume) {
-					const i_volume &a_volume = *(it_volume->second);
-
-					// Discard other type of volume
-					if (a_volume.get_type() != "special") {
-						continue;
-					}
-
-					// ROOT volumes
-					const auto &a_special_volume = dynamic_cast<const special_volume &>(a_volume);
-					a_special_volume.draw();
-				}
-				FL_LOG_DEVEL("Exiting...");
-			}
-
-			void detector_manager::reset() {
-				FL_LOG_DEVEL("Entering...");
-				DT_THROW_IF(!is_initialized(), std::logic_error, "Not initialized !");
-				_initialized_ = false;
-				_constructed_ = false;
-
-				if (!has_external_geometry_manager()) {
-					if (_geo_manager_ != nullptr) {
-						delete _geo_manager_;
-						_geo_manager_ = nullptr;
-					}
-				}
-				delete gGeoManager;
-				_volumes_.clear();
-				_special_volume_name_.clear();
-				FL_LOG_DEVEL("Exiting...");
-			}
-
-			void detector_manager::tree_dump(std::ostream &out_, const std::string &title_,
-																			 const std::string &indent_, bool inherit_) const {
-				std::string indent;
-				if (!indent_.empty()) {
-					indent = indent_;
-				}
-				if (!title_.empty()) {
-					out_ << indent << title_ << std::endl;
-				}
-
-				out_ << indent << datatools::i_tree_dumpable::tag
-						 << "Initialized : " << (is_initialized() ? "Yes" : "No") << std::endl;
-
-				out_ << indent << datatools::i_tree_dumpable::tag
-						 << "Constructed : " << (is_constructed() ? "Yes" : "No") << std::endl;
-
-				out_ << indent << datatools::i_tree_dumpable::tag << "Setup       : " << _setup_label_name_
-						 << std::endl;
-
-				if (_world_volume_ != nullptr) {
-					out_ << indent << datatools::i_tree_dumpable::tag << "World volume : " << std::endl;
-					std::ostringstream indent_oss;
-					indent_oss << indent;
-					indent_oss << datatools::i_tree_dumpable::skip_tag;
-					out_ << indent_oss.str() << datatools::i_tree_dumpable::tag
-							 << "length : " << _world_length_ / CLHEP::m << " m" << std::endl;
-					out_ << indent_oss.str() << datatools::i_tree_dumpable::tag
-							 << "width  : " << _world_width_ / CLHEP::m << " m" << std::endl;
-					out_ << indent_oss.str() << datatools::i_tree_dumpable::last_tag
-							 << "height : " << _world_height_ / CLHEP::m << " m" << std::endl;
-				} else {
-					out_ << indent << datatools::i_tree_dumpable::tag << "World volume : "
-							 << "<empty>" << std::endl;
-				}
-
-				out_ << indent << datatools::i_tree_dumpable::tag
-						 << "Special volumes : " << _special_volume_name_.size() << std::endl;
-				for (auto it_volume = _special_volume_name_.begin(); it_volume != _special_volume_name_.end();
-						 ++it_volume) {
-					std::ostringstream indent_oss;
-					auto jt_volume = it_volume;
-					if (++jt_volume == _special_volume_name_.end()) {
-						indent_oss << indent << datatools::i_tree_dumpable::last_skip_tag;
-						out_ << indent << datatools::i_tree_dumpable::last_tag;
-					} else {
-						indent_oss << indent << datatools::i_tree_dumpable::skip_tag;
-						out_ << indent << datatools::i_tree_dumpable::tag;
-					}
-					out_ << "Special volume[" << std::distance(_special_volume_name_.begin(), it_volume)
-							 << "]: " << *it_volume << std::endl;
-				}
-
-				out_ << indent << datatools::i_tree_dumpable::tag << "Attached volumes : " << _volumes_.size()
-						 << std::endl;
-				for (auto it_volume = _volumes_.begin(); it_volume != _volumes_.end(); ++it_volume) {
-					std::ostringstream indent_oss;
-					auto jt_volume = it_volume;
-					if (++jt_volume == _volumes_.end()) {
-						indent_oss << indent << datatools::i_tree_dumpable::last_skip_tag;
-						out_ << indent << datatools::i_tree_dumpable::last_tag;
-					} else {
-						indent_oss << indent << datatools::i_tree_dumpable::skip_tag;
-						out_ << indent << datatools::i_tree_dumpable::tag;
-					}
-					out_ << "Volume[" << std::distance(_volumes_.begin(), it_volume) << "]: " << std::endl;
-					indent_oss << datatools::i_tree_dumpable::inherit_skip_tag(inherit_);
-					it_volume->second->tree_dump(out_, "", indent_oss.str());
-				}
-			}
-
-			void detector_manager::dump() const {
-				this->tree_dump(std::clog, "snemo::visualization::detector::detector_manager");
-			}
-
-			void detector_manager::compute_world_coordinates(const geomtools::vector_3d &mother_pos_,
-																											 geomtools::vector_3d &world_pos_) const {
-				if (_module_placement_ == nullptr) {
-					DT_LOG_WARNING(view::options_manager::get_instance().get_logging_priority(),
-												 "No 'module' placement setup !");
-					world_pos_ = mother_pos_;
-				} else {
-					_module_placement_->child_to_mother(mother_pos_, world_pos_);
-				}
-			}
-
-			void detector_manager::_at_init_(const std::string &geo_manager_config_file_) {
-				FL_LOG_DEVEL("Entering...");
-				// TGeoXXX stuff for ROOT
-				// reduce crazy TGeo output
-				gErrorIgnoreLevel = kError;
-
-				// Instantiate TGeoManager here and then use static pointer gGeoManager
-				new TGeoManager("ROOT TGeo Manager", "ROOT TGeo Manager");
-
-				// Setting geometry manager file
-				if (has_external_geometry_manager()) {
-					_setup_label_name_ = _geo_manager_->get_setup_label();
-				} else {
-					_geo_manager_ = new geomtools::manager;
-
-					if (!geo_manager_config_file_.empty()) {
-						_geo_manager_config_file_ = geo_manager_config_file_;
-					} else {
-						const std::string &geo_manager_config_file =
-							view::options_manager::get_instance().get_detector_config_file();
-
-						if (!geo_manager_config_file.empty()) {
-							_geo_manager_config_file_ = geo_manager_config_file;
-						} else {
-							// Otherwise, use SuperNEMO/demonstrator config 5.0
-							// DT_LOG_NOTICE(view::options_manager::get_instance().get_logging_priority(),
-							//               "Use default SuperNEMO/demonstrator config i.e. " << setup_name << " "
-							//               << "version " << setup_version);
-							_geo_manager_config_file_ = snemo::geometry::default_geometry_tag();
-							DT_LOG_NOTICE(
-														view::options_manager::get_instance().get_logging_priority(),
-														"Use default SuperNEMO/demonstrator config tag : " << _geo_manager_config_file_);
-						}
-					}
-				}
-				this->_read_detector_config_();
-				FL_LOG_DEVEL("Exiting...");
-				return;
-			}
-
-			void detector_manager::_at_construct_() {
-				FL_LOG_DEVEL("Entering...");
-				// set maximum dimension to world volume
-				this->_set_world_dimensions_();
-
-				// building world volume by ROOT
-				_world_volume_ = gGeoManager->MakeBox("World Volume", nullptr, _world_length_ / 2.,
-																							_world_width_ / 2., _world_height_ / 2.);
-				_world_volume_->SetVisibility(false);
-
-				// setting world volume for ROOT Geo Manager
-				gGeoManager->SetTopVolume(_world_volume_);
-
-				// adding each volume to the world one
-				this->_add_volumes_();
-
-				// closing geometry to not to modify it later
-				gGeoManager->CloseGeometry();
-
-				if (view::options_manager::get_instance().get_logging_priority() >=
-						datatools::logger::PRIO_DEBUG) {
-					DT_LOG_DEBUG(view::options_manager::get_instance().get_logging_priority(),
-											 "Detector manager dump:");
-					this->tree_dump(std::clog);
-				}
-				FL_LOG_DEVEL("Exiting...");
-				return;
-			}
-
-			void detector_manager::_read_detector_config_() {
-				FL_LOG_DEVEL("Entering...");
-				// Geometry manager property config
-				datatools::properties gmanager_config;
-
-				if (!has_external_geometry_manager()) {
-					const std::string gmanager_config_file = _geo_manager_config_file_;
-
-					// Load properties from the configuration file
-					uint32_t read_config_flags = datatools::properties::config::RESOLVE_PATH;
-					datatools::properties::read_config(gmanager_config_file, gmanager_config, read_config_flags);
-
-					// Prepare mapping configuration with a limited set of geo. categories
-					gmanager_config.update("build_mapping", true);
-
-					// Remove the 'exclusion' property if any
-					if (gmanager_config.has_key("mapping.excluded_categories")) {
-						gmanager_config.erase("mapping.excluded_categories");
-					}
-
-					// Get setup label (snemo, test bench, bipo ...)
-					_setup_label_name_ = gmanager_config.fetch_string("setup_label");
-				}
-
-				if (_setup_label_name_ == "snemo") {
-					_setup_label_ = SNEMO;
-				} else if (_setup_label_name_ == "test_bench") {
-					_setup_label_ = TEST_BENCH;
-				} else if (_setup_label_name_ == "bipo1") {
-					_setup_label_ = BIPO1;
-				} else if (_setup_label_name_ == "bipo3") {
-					_setup_label_ = BIPO3;
-					_special_volume_name_.emplace_back("light_guide.category");
-				} else if (_setup_label_name_ == "snemo::tracker_commissioning") {
-					_setup_label_ = TRACKER_COMMISSIONING;
-				} else if (_setup_label_name_ == "snemo::demonstrator") {
-					_setup_label_ = SNEMO_DEMONSTRATOR;
-					// XXX
-					_special_volume_name_.emplace_back("source_pad_bulk");
-					_special_volume_name_.emplace_back("source_pad_film");
-				} else if (_setup_label_name_ == "hpge") {
-					_setup_label_ = HPGE;
-				} else {
-					DT_LOG_WARNING(
-												 view::options_manager::get_instance().get_logging_priority(),
-												 "Geometry setup with label '" << _setup_label_name_ << "' is not natively supported !");
-					_setup_label_ = UNDEFINED;
-					// DT_THROW_IF(true, std::logic_error, "Setup label '" << _setup_label_name_
-					//              << "' is not (yet) supported !");
-				}
-
-				// Load the given style file in order to get the activated detectors
-				view::style_manager &style_mgr = view::style_manager::get_instance();
-				if (style_mgr.is_initialized()) {
-					style_mgr.reset();
-				}
-				style_mgr.set_setup_label(_setup_label_name_);
-				const std::string &style_config_file =
-					view::options_manager::get_instance().get_style_config_file();
-				style_mgr.initialize(style_config_file);
-
-				// Get volume categories
-				std::vector<std::string> only_categories;
-				this->_set_categories_(only_categories);
-
-				// Initialize geometry manager
-				geomtools::manager &gmgr = this->grab_geometry_manager();
-				gmgr.set_logging_priority(view::options_manager::get_instance().get_logging_priority());
-				if (!has_external_geometry_manager()) {
-					// Set the 'only' property
-					// gmanager_config.update("mapping.only_categories", only_categories);
-					gmgr.initialize(gmanager_config);
-				}
-
-				// If no categories has been set then add all category from id manager
-				// to the list of detector volume
-				if (only_categories.empty()) {
-					std::map<std::string, view::style_manager::volume_properties> &volumes =
-						style_mgr.grab_volumes_properties();
-
-					const geomtools::id_mgr::categories_by_name_col_type &categories =
-						gmgr.get_id_mgr().categories_by_name();
-					for (const auto &categorie : categories) {
-						const std::string &a_category = categorie.first;
-						only_categories.push_back(a_category);
-						view::style_manager::volume_properties dummy;
-						volumes[a_category] = dummy;
-						volumes[a_category]._visibility_ = VISIBLE;
-						volumes[a_category]._color_ = utils::root_utilities::get_random_color();
-					}
-				}
-
-				for (std::vector<std::string>::const_iterator it_category = only_categories.begin();
-						 it_category != only_categories.end(); ++it_category) {
-					const std::string &volume_category_name = *it_category;
-
-					const geomtools::mapping &mapping = gmgr.get_mapping();
-					const geomtools::id_mgr::categories_by_name_col_type &categories =
-						gmgr.get_id_mgr().categories_by_name();
-
-					const geomtools::id_mgr::categories_by_name_col_type::const_iterator found =
-						categories.find(volume_category_name);
-					if (found == categories.end()) {
-						DT_LOG_WARNING(
-													 view::options_manager::get_instance().get_logging_priority(),
-													 "Category '" << volume_category_name << "' is not mapped ! "
-													 << "Check categories.lis file to address the right category name");
-						continue;
-					}
-
-					const int volume_type = found->second.get_type();
-
-					geomtools::smart_id_locator volume_locator;
-					volume_locator.set_gmap(mapping);
-					volume_locator.initialize(volume_type);
-
-					const std::list<const geomtools::geom_info *> &geom_info_list = volume_locator.get_ginfos();
-
-					if (geom_info_list.empty()) {
-						DT_LOG_WARNING(view::options_manager::get_instance().get_logging_priority(),
-													 "No geom info for '" << volume_category_name << "' "
-													 << "has been associated with the geometry map !");
-					}
-
-					for (auto iptr_ginfo : geom_info_list) {
-						const geomtools::geom_info &ginfo = *iptr_ginfo;
-						this->_set_volume_(ginfo);
-
-						// Save 'module' placement for later coordinates conversion
-						if (volume_category_name == "module") {
-							_module_placement_ = &(ginfo.get_world_placement());
-						}
-					}  // end of geo_info
-				}    // end of enabled categories
-				FL_LOG_DEVEL("Exiting...");
-				return;
-			}
-
-			void detector_manager::_set_categories_(std::vector<std::string> &only_categories_) const {
-				view::style_manager &style_mgr = view::style_manager::get_instance();
-
-				std::map<std::string, view::style_manager::volume_properties> &volumes =
-					style_mgr.grab_volumes_properties();
-
-				// first get them from style file
-				if (!volumes.empty()) {
-					for (auto it_volume = volumes.begin(); it_volume != volumes.end(); ++it_volume) {
-						if (it_volume->second._visibility_ == DISABLE) {
-							continue;
-						}
-						DT_LOG_DEBUG(view::options_manager::get_instance().get_logging_priority(),
-												 "Add '" << it_volume->first << "' category");
-						only_categories_.push_back(it_volume->first);
-					}
-
-					// special treatment in case of all volumes disabled
-					if (only_categories_.empty()) {
-						switch (_setup_label_) {
-						case SNEMO:
-						case SNEMO_DEMONSTRATOR:
-						case TRACKER_COMMISSIONING:
-							only_categories_.emplace_back("module");
-							volumes["module"]._visibility_ = VISIBLE;
-							break;
-						case TEST_BENCH:
-							only_categories_.emplace_back("calo_light_line");
-							volumes["calo_light_line"]._visibility_ = VISIBLE;
-							break;
-						default:
-							break;
-						}
-					}
-				} else {
-					// if no volume are setup in style file
-					// then it behaves like the following
-					switch (_setup_label_) {
-					case TRACKER_COMMISSIONING:
-						only_categories_.emplace_back("hall");
-						only_categories_.emplace_back("module");
-						only_categories_.emplace_back("mu_trigger");
-						only_categories_.emplace_back("drift_cell_core");
-						break;
-					case SNEMO:
-					case SNEMO_DEMONSTRATOR:
-						only_categories_.emplace_back("hall");
-						// only_categories_.push_back("external_shield");
-						only_categories_.emplace_back("module");
-						// only_categories_.push_back("source_submodule");
-						only_categories_.emplace_back("source_strip");
-						only_categories_.emplace_back("source_pad");
-						only_categories_.emplace_back("source_pad_bulk");
-						only_categories_.push_back("source_calibration_track");
-						// only_categories_.push_back("source_calibration_carrier");
-						only_categories_.emplace_back("source_calibration_spot");
-						only_categories_.emplace_back("source_like_plate");
-						only_categories_.emplace_back("commissioning_source_spot");
-						only_categories_.emplace_back("drift_cell_core");
-						only_categories_.emplace_back("xcalo_block");
-						only_categories_.emplace_back("gveto_block");
-						only_categories_.emplace_back("calorimeter_block");
-						break;
-					case TEST_BENCH:
-						only_categories_.emplace_back("calo_light_line");
-						only_categories_.emplace_back("scin_block");
-						only_categories_.emplace_back("absorber");
-						only_categories_.emplace_back("diaphragm");
-						only_categories_.emplace_back("air_gap");
-						only_categories_.emplace_back("test_source");
-						break;
-					case BIPO1:
-					case BIPO3:
-						only_categories_.emplace_back("scin_block");
-						only_categories_.emplace_back("source");
-						//            only_categories_.push_back("bipo3_module");
-						break;
-					default:
-						break;
-					}
-
-					// adding the default detectors to detector_to_show list
-					for (std::vector<std::string>::const_iterator it_category = only_categories_.begin();
-							 it_category != only_categories_.end(); ++it_category) {
-						volumes[*it_category]._visibility_ = VISIBLE;
-					}
-				}
-				return;
-			}
-
-			void detector_manager::_set_volume_(const geomtools::geom_info &ginfo_) {
-				const geomtools::geom_id &volume_id = ginfo_.get_id();
-				// std::cerr << "*** devel *** detector_manager::_set_volume_() : volume_id='" << volume_id << "'\n";
-
-				const std::string volume_name = this->get_volume_name(volume_id);
-				const std::string volume_category = this->get_volume_category(volume_id);
-				// std::cerr << "*** devel *** detector_manager::_set_volume_() : volume_name='" << volume_name << "'\n";
-				// std::cerr << "*** devel *** detector_manager::_set_volume_() : volume_category='" << volume_category << "'\n";
-
-				const geomtools::logical_volume &a_log = ginfo_.get_logical();
-				const geomtools::i_shape_3d &a_shape = a_log.get_shape();
-				const std::string &shape_name = a_shape.get_shape_name();
-				// std::cerr << "*** devel *** detector_manager::_set_volume_() : shape_name='" << shape_name << "'\n";
+  namespace visualization {
+
+    namespace detector {
+
+      bool detector_manager::is_initialized() const { return _initialized_; }
+
+      bool detector_manager::is_constructed() const { return _constructed_; }
+
+      detector_manager::setup_label_type detector_manager::get_setup_label() const {
+	return _setup_label_;
+      }
+
+      const std::string &detector_manager::get_setup_label_name() const { return _setup_label_name_; }
+
+      bool detector_manager::is_special_volume(const std::string &volume_name_) const {
+	auto name_iter =
+	  std::find(_special_volume_name_.begin(), _special_volume_name_.end(), volume_name_);
+	return (name_iter != _special_volume_name_.end());
+      }
+
+      i_volume *detector_manager::grab_volume(const geomtools::geom_id &id_) {
+	i_volume *volume = nullptr;
+	auto volume_iter = _volumes_.find(id_);
+
+	if (volume_iter != _volumes_.end()) {
+	  volume = volume_iter->second;
+	}
+	return volume;
+      }
+
+      const i_volume *detector_manager::get_volume(const geomtools::geom_id &id_) const {
+	i_volume *volume = nullptr;
+	auto volume_iter = _volumes_.find(id_);
+
+	if (volume_iter != _volumes_.end()) {
+	  volume = volume_iter->second;
+	}
+	return volume;
+      }
+
+      void detector_manager::get_matching_ids(const geomtools::geom_id &id_,
+					      std::vector<geomtools::geom_id> &vids_) const {
+	for (const auto &_volume : _volumes_) {
+	  const geomtools::geom_id &gid = _volume.first;
+	  if (geomtools::geom_id::match(gid, id_)) {
+	    vids_.push_back(gid);
+	  }
+	}
+      }
+
+      std::string detector_manager::get_volume_name(const geomtools::geom_id &id_) const {
+	return _geo_manager_->get_id_mgr().id_to_human_readable_format_string(id_);
+      }
+
+      std::string detector_manager::get_volume_category(const geomtools::geom_id &id_) const {
+	const geomtools::id_mgr &mgr = _geo_manager_->get_id_mgr();
+	std::string volume_category;
+	if (mgr.has_category_info(id_.get_type())) {
+	  const geomtools::id_mgr::category_info &c_info = mgr.get_category_info(id_.get_type());
+	  volume_category = c_info.get_category();
+	}
+	return volume_category;
+      }
+
+      bool detector_manager::has_external_geometry_manager() const {
+	return _has_external_geometry_manager_;
+      }
+
+      void detector_manager::set_external_geometry_manager(geomtools::manager &geometry_manager_) {
+	_has_external_geometry_manager_ = true;
+	_geo_manager_ = &geometry_manager_;
+      }
+
+      geomtools::manager &detector_manager::grab_geometry_manager() { return *_geo_manager_; }
+
+      const geomtools::manager &detector_manager::get_geometry_manager() const { return *_geo_manager_; }
+
+      TGeoVolume *detector_manager::grab_world_volume() { return _world_volume_; }
+
+      const TGeoVolume *detector_manager::get_world_volume() const { return _world_volume_; }
+
+      // ctor:
+      detector_manager::detector_manager() {
+	_initialized_ = false;
+	_constructed_ = false;
+	_setup_label_name_ = "";
+	_setup_label_ = SNEMO;
+	_has_external_geometry_manager_ = false;
+	_geo_manager_config_file_ = "";
+	_geo_manager_ = nullptr;
+	_world_volume_ = nullptr;
+	_world_length_ = 0.0;
+	_world_width_ = 0.0;
+	_world_height_ = 0.0;
+      }
+
+      // dtor:
+      detector_manager::~detector_manager() {
+	if (is_initialized()) {
+	  this->reset();
+	}
+      }
+
+      void detector_manager::initialize(const std::string &geo_manager_config_file_) {
+	FL_LOG_DEVEL("Entering...");
+	DT_THROW_IF(is_initialized(), std::logic_error, "Already initialized !");
+	this->_at_init_(geo_manager_config_file_);
+	_initialized_ = true;
+	FL_LOG_DEVEL("Exiting...");
+      }
+
+      void detector_manager::construct() {
+	FL_LOG_DEVEL("Entering...");
+	DT_THROW_IF(!is_initialized(), std::logic_error, "Not initialized !");
+	this->_at_construct_();
+	_constructed_ = true;
+	FL_LOG_DEVEL("Exiting...");
+      }
+
+      void detector_manager::update() {
+	FL_LOG_DEVEL("Entering...");
+	for (volume_dict_type::const_iterator it_volume = _volumes_.begin(); it_volume != _volumes_.end();
+	     ++it_volume) {
+	  it_volume->second->update();
+	}
+	FL_LOG_DEVEL("Exiting...");
+      }
+
+      void detector_manager::draw() {
+	FL_LOG_DEVEL("Entering...");
+	DT_THROW_IF(!is_initialized(), std::logic_error, "Not initialized !");
+	DT_THROW_IF(!is_constructed(), std::logic_error, "Not constructed !");
+
+	TGeoVolume *world_volume = this->grab_world_volume();
+	world_volume->Draw();
+
+	// Special treatment for special volumes
+	for (volume_dict_type::const_iterator it_volume = _volumes_.begin(); it_volume != _volumes_.end();
+	     ++it_volume) {
+	  const i_volume &a_volume = *(it_volume->second);
+
+	  // Discard other type of volume
+	  if (a_volume.get_type() != "special") {
+	    continue;
+	  }
+
+	  // ROOT volumes
+	  const auto &a_special_volume = dynamic_cast<const special_volume &>(a_volume);
+	  a_special_volume.draw();
+	}
+	FL_LOG_DEVEL("Exiting...");
+      }
+
+      void detector_manager::reset() {
+	FL_LOG_DEVEL("Entering...");
+	DT_THROW_IF(!is_initialized(), std::logic_error, "Not initialized !");
+	_initialized_ = false;
+	_constructed_ = false;
+
+	if (!has_external_geometry_manager()) {
+	  if (_geo_manager_ != nullptr) {
+	    delete _geo_manager_;
+	    _geo_manager_ = nullptr;
+	  }
+	}
+	delete gGeoManager;
+	_volumes_.clear();
+	_special_volume_name_.clear();
+	FL_LOG_DEVEL("Exiting...");
+      }
+
+      void detector_manager::tree_dump(std::ostream &out_, const std::string &title_,
+				       const std::string &indent_, bool inherit_) const {
+	std::string indent;
+	if (!indent_.empty()) {
+	  indent = indent_;
+	}
+	if (!title_.empty()) {
+	  out_ << indent << title_ << std::endl;
+	}
+
+	out_ << indent << datatools::i_tree_dumpable::tag
+	     << "Initialized : " << (is_initialized() ? "Yes" : "No") << std::endl;
+
+	out_ << indent << datatools::i_tree_dumpable::tag
+	     << "Constructed : " << (is_constructed() ? "Yes" : "No") << std::endl;
+
+	out_ << indent << datatools::i_tree_dumpable::tag << "Setup       : " << _setup_label_name_
+	     << std::endl;
+
+	if (_world_volume_ != nullptr) {
+	  out_ << indent << datatools::i_tree_dumpable::tag << "World volume : " << std::endl;
+	  std::ostringstream indent_oss;
+	  indent_oss << indent;
+	  indent_oss << datatools::i_tree_dumpable::skip_tag;
+	  out_ << indent_oss.str() << datatools::i_tree_dumpable::tag
+	       << "length : " << _world_length_ / CLHEP::m << " m" << std::endl;
+	  out_ << indent_oss.str() << datatools::i_tree_dumpable::tag
+	       << "width  : " << _world_width_ / CLHEP::m << " m" << std::endl;
+	  out_ << indent_oss.str() << datatools::i_tree_dumpable::last_tag
+	       << "height : " << _world_height_ / CLHEP::m << " m" << std::endl;
+	} else {
+	  out_ << indent << datatools::i_tree_dumpable::tag << "World volume : "
+	       << "<empty>" << std::endl;
+	}
+
+	out_ << indent << datatools::i_tree_dumpable::tag
+	     << "Special volumes : " << _special_volume_name_.size() << std::endl;
+	for (auto it_volume = _special_volume_name_.begin(); it_volume != _special_volume_name_.end();
+	     ++it_volume) {
+	  std::ostringstream indent_oss;
+	  auto jt_volume = it_volume;
+	  if (++jt_volume == _special_volume_name_.end()) {
+	    indent_oss << indent << datatools::i_tree_dumpable::last_skip_tag;
+	    out_ << indent << datatools::i_tree_dumpable::last_tag;
+	  } else {
+	    indent_oss << indent << datatools::i_tree_dumpable::skip_tag;
+	    out_ << indent << datatools::i_tree_dumpable::tag;
+	  }
+	  out_ << "Special volume[" << std::distance(_special_volume_name_.begin(), it_volume)
+	       << "]: " << *it_volume << std::endl;
+	}
+
+	out_ << indent << datatools::i_tree_dumpable::tag << "Attached volumes : " << _volumes_.size()
+	     << std::endl;
+	for (auto it_volume = _volumes_.begin(); it_volume != _volumes_.end(); ++it_volume) {
+	  std::ostringstream indent_oss;
+	  auto jt_volume = it_volume;
+	  if (++jt_volume == _volumes_.end()) {
+	    indent_oss << indent << datatools::i_tree_dumpable::last_skip_tag;
+	    out_ << indent << datatools::i_tree_dumpable::last_tag;
+	  } else {
+	    indent_oss << indent << datatools::i_tree_dumpable::skip_tag;
+	    out_ << indent << datatools::i_tree_dumpable::tag;
+	  }
+	  out_ << "Volume[" << std::distance(_volumes_.begin(), it_volume) << "]: " << std::endl;
+	  indent_oss << datatools::i_tree_dumpable::inherit_skip_tag(inherit_);
+	  it_volume->second->tree_dump(out_, "", indent_oss.str());
+	}
+      }
+
+      void detector_manager::dump() const {
+	this->tree_dump(std::clog, "snemo::visualization::detector::detector_manager");
+      }
+
+      void detector_manager::compute_world_coordinates(const geomtools::vector_3d &mother_pos_,
+						       geomtools::vector_3d &world_pos_) const {
+	if (_module_placement_ == nullptr) {
+	  DT_LOG_WARNING(view::options_manager::get_instance().get_logging_priority(),
+			 "No 'module' placement setup !");
+	  world_pos_ = mother_pos_;
+	} else {
+	  _module_placement_->child_to_mother(mother_pos_, world_pos_);
+	}
+      }
+
+      void detector_manager::_at_init_(const std::string &geo_manager_config_file_) {
+	FL_LOG_DEVEL("Entering...");
+	// TGeoXXX stuff for ROOT
+	// reduce crazy TGeo output
+	gErrorIgnoreLevel = kError;
+
+	// Instantiate TGeoManager here and then use static pointer gGeoManager
+	new TGeoManager("ROOT TGeo Manager", "ROOT TGeo Manager");
+
+	// Setting geometry manager file
+	if (has_external_geometry_manager()) {
+	  _setup_label_name_ = _geo_manager_->get_setup_label();
+	} else {
+	  _geo_manager_ = new geomtools::manager;
+
+	  if (!geo_manager_config_file_.empty()) {
+	    _geo_manager_config_file_ = geo_manager_config_file_;
+	  } else {
+	    const std::string &geo_manager_config_file =
+	      view::options_manager::get_instance().get_detector_config_file();
+
+	    if (!geo_manager_config_file.empty()) {
+	      _geo_manager_config_file_ = geo_manager_config_file;
+	    } else {
+	      // Otherwise, use SuperNEMO/demonstrator config 5.0
+	      // DT_LOG_NOTICE(view::options_manager::get_instance().get_logging_priority(),
+	      //               "Use default SuperNEMO/demonstrator config i.e. " << setup_name << " "
+	      //               << "version " << setup_version);
+	      _geo_manager_config_file_ = snemo::geometry::default_geometry_tag();
+	      DT_LOG_NOTICE(
+			    view::options_manager::get_instance().get_logging_priority(),
+			    "Use default SuperNEMO/demonstrator config tag : " << _geo_manager_config_file_);
+	    }
+	  }
+	}
+	this->_read_detector_config_();
+	FL_LOG_DEVEL("Exiting...");
+	return;
+      }
+
+      void detector_manager::_at_construct_() {
+	FL_LOG_DEVEL("Entering...");
+	// set maximum dimension to world volume
+	this->_set_world_dimensions_();
+
+	// building world volume by ROOT
+	_world_volume_ = gGeoManager->MakeBox("World Volume", nullptr, _world_length_ / 2.,
+					      _world_width_ / 2., _world_height_ / 2.);
+	_world_volume_->SetVisibility(false);
+
+	// setting world volume for ROOT Geo Manager
+	gGeoManager->SetTopVolume(_world_volume_);
+
+	// adding each volume to the world one
+	this->_add_volumes_();
+
+	// closing geometry to not to modify it later
+	gGeoManager->CloseGeometry();
+
+	if (view::options_manager::get_instance().get_logging_priority() >=
+	    datatools::logger::PRIO_DEBUG) {
+	  DT_LOG_DEBUG(view::options_manager::get_instance().get_logging_priority(),
+		       "Detector manager dump:");
+	  this->tree_dump(std::clog);
+	}
+	FL_LOG_DEVEL("Exiting...");
+	return;
+      }
+
+      void detector_manager::_read_detector_config_() {
+	FL_LOG_DEVEL("Entering...");
+	// Geometry manager property config
+	datatools::properties gmanager_config;
+
+	if (!has_external_geometry_manager()) {
+	  const std::string gmanager_config_file = _geo_manager_config_file_;
+
+	  // Load properties from the configuration file
+	  uint32_t read_config_flags = datatools::properties::config::RESOLVE_PATH;
+	  datatools::properties::read_config(gmanager_config_file, gmanager_config, read_config_flags);
+
+	  // Prepare mapping configuration with a limited set of geo. categories
+	  gmanager_config.update("build_mapping", true);
+
+	  // Remove the 'exclusion' property if any
+	  if (gmanager_config.has_key("mapping.excluded_categories")) {
+	    gmanager_config.erase("mapping.excluded_categories");
+	  }
+
+	  // Get setup label (snemo, test bench, bipo ...)
+	  _setup_label_name_ = gmanager_config.fetch_string("setup_label");
+	}
+
+	if (_setup_label_name_ == "snemo") {
+	  _setup_label_ = SNEMO;
+	} else if (_setup_label_name_ == "test_bench") {
+	  _setup_label_ = TEST_BENCH;
+	} else if (_setup_label_name_ == "bipo1") {
+	  _setup_label_ = BIPO1;
+	} else if (_setup_label_name_ == "bipo3") {
+	  _setup_label_ = BIPO3;
+	  _special_volume_name_.emplace_back("light_guide.category");
+	} else if (_setup_label_name_ == "snemo::tracker_commissioning") {
+	  _setup_label_ = TRACKER_COMMISSIONING;
+	} else if (_setup_label_name_ == "snemo::demonstrator") {
+	  _setup_label_ = SNEMO_DEMONSTRATOR;
+	  // XXX
+	  _special_volume_name_.emplace_back("source_pad_bulk");
+	  _special_volume_name_.emplace_back("source_pad_film");
+	} else if (_setup_label_name_ == "hpge") {
+	  _setup_label_ = HPGE;
+	} else {
+	  DT_LOG_WARNING(
+			 view::options_manager::get_instance().get_logging_priority(),
+			 "Geometry setup with label '" << _setup_label_name_ << "' is not natively supported !");
+	  _setup_label_ = UNDEFINED;
+	  // DT_THROW_IF(true, std::logic_error, "Setup label '" << _setup_label_name_
+	  //              << "' is not (yet) supported !");
+	}
+
+	// Load the given style file in order to get the activated detectors
+	view::style_manager &style_mgr = view::style_manager::get_instance();
+	if (style_mgr.is_initialized()) {
+	  style_mgr.reset();
+	}
+	style_mgr.set_setup_label(_setup_label_name_);
+	const std::string &style_config_file =
+	  view::options_manager::get_instance().get_style_config_file();
+	style_mgr.initialize(style_config_file);
+
+	// Get volume categories
+	std::vector<std::string> only_categories;
+	this->_set_categories_(only_categories);
+
+	// Initialize geometry manager
+	geomtools::manager &gmgr = this->grab_geometry_manager();
+	gmgr.set_logging_priority(view::options_manager::get_instance().get_logging_priority());
+	if (!has_external_geometry_manager()) {
+	  // Set the 'only' property
+	  // gmanager_config.update("mapping.only_categories", only_categories);
+	  gmgr.initialize(gmanager_config);
+	}
+
+	// If no categories has been set then add all category from id manager
+	// to the list of detector volume
+	if (only_categories.empty()) {
+	  std::map<std::string, view::style_manager::volume_properties> &volumes =
+	    style_mgr.grab_volumes_properties();
+
+	  const geomtools::id_mgr::categories_by_name_col_type &categories =
+	    gmgr.get_id_mgr().categories_by_name();
+	  for (const auto &categorie : categories) {
+	    const std::string &a_category = categorie.first;
+	    only_categories.push_back(a_category);
+	    view::style_manager::volume_properties dummy;
+	    volumes[a_category] = dummy;
+	    volumes[a_category]._visibility_ = VISIBLE;
+	    volumes[a_category]._color_ = utils::root_utilities::get_random_color();
+	  }
+	}
+
+	for (std::vector<std::string>::const_iterator it_category = only_categories.begin();
+	     it_category != only_categories.end(); ++it_category) {
+	  const std::string &volume_category_name = *it_category;
+
+	  const geomtools::mapping &mapping = gmgr.get_mapping();
+	  const geomtools::id_mgr::categories_by_name_col_type &categories =
+	    gmgr.get_id_mgr().categories_by_name();
+
+	  const geomtools::id_mgr::categories_by_name_col_type::const_iterator found =
+	    categories.find(volume_category_name);
+	  if (found == categories.end()) {
+	    DT_LOG_WARNING(
+			   view::options_manager::get_instance().get_logging_priority(),
+			   "Category '" << volume_category_name << "' is not mapped ! "
+			   << "Check categories.lis file to address the right category name");
+	    continue;
+	  }
+
+	  const int volume_type = found->second.get_type();
+
+	  geomtools::smart_id_locator volume_locator;
+	  volume_locator.set_gmap(mapping);
+	  volume_locator.initialize(volume_type);
+
+	  const std::list<const geomtools::geom_info *> &geom_info_list = volume_locator.get_ginfos();
+
+	  if (geom_info_list.empty()) {
+	    DT_LOG_WARNING(view::options_manager::get_instance().get_logging_priority(),
+			   "No geom info for '" << volume_category_name << "' "
+			   << "has been associated with the geometry map !");
+	  }
+
+	  for (auto iptr_ginfo : geom_info_list) {
+	    const geomtools::geom_info &ginfo = *iptr_ginfo;
+	    this->_set_volume_(ginfo);
+
+	    // Save 'module' placement for later coordinates conversion
+	    if (volume_category_name == "module") {
+	      _module_placement_ = &(ginfo.get_world_placement());
+	    }
+	  }  // end of geo_info
+	}    // end of enabled categories
+	FL_LOG_DEVEL("Exiting...");
+	return;
+      }
+
+      void detector_manager::_set_categories_(std::vector<std::string> &only_categories_) const {
+	view::style_manager &style_mgr = view::style_manager::get_instance();
+
+	std::map<std::string, view::style_manager::volume_properties> &volumes =
+	  style_mgr.grab_volumes_properties();
+
+	// first get them from style file
+	if (!volumes.empty()) {
+	  for (auto it_volume = volumes.begin(); it_volume != volumes.end(); ++it_volume) {
+	    if (it_volume->second._visibility_ == DISABLE) {
+	      continue;
+	    }
+	    DT_LOG_DEBUG(view::options_manager::get_instance().get_logging_priority(),
+			 "Add '" << it_volume->first << "' category");
+	    only_categories_.push_back(it_volume->first);
+	  }
+
+	  // special treatment in case of all volumes disabled
+	  if (only_categories_.empty()) {
+	    switch (_setup_label_) {
+	    case SNEMO:
+	    case SNEMO_DEMONSTRATOR:
+	    case TRACKER_COMMISSIONING:
+	      only_categories_.emplace_back("module");
+	      volumes["module"]._visibility_ = VISIBLE;
+	      break;
+	    case TEST_BENCH:
+	      only_categories_.emplace_back("calo_light_line");
+	      volumes["calo_light_line"]._visibility_ = VISIBLE;
+	      break;
+	    default:
+	      break;
+	    }
+	  }
+	} else {
+	  // if no volume are setup in style file
+	  // then it behaves like the following
+	  switch (_setup_label_) {
+	  case TRACKER_COMMISSIONING:
+	    only_categories_.emplace_back("hall");
+	    only_categories_.emplace_back("module");
+	    only_categories_.emplace_back("mu_trigger");
+	    only_categories_.emplace_back("drift_cell_core");
+	    break;
+	  case SNEMO:
+	  case SNEMO_DEMONSTRATOR:
+	    only_categories_.emplace_back("hall");
+	    // only_categories_.push_back("external_shield");
+	    only_categories_.emplace_back("module");
+	    // only_categories_.push_back("source_submodule");
+	    only_categories_.emplace_back("source_strip");
+	    only_categories_.emplace_back("source_pad");
+	    only_categories_.emplace_back("source_pad_bulk");
+	    only_categories_.push_back("source_calibration_track");
+	    //
+	    only_categories_.push_back("source_calibration_carrier");
+	    only_categories_.emplace_back("source_calibration_spot");
+	    only_categories_.emplace_back("source_like_plate");
+	    only_categories_.emplace_back("commissioning_source_spot");
+	    only_categories_.emplace_back("drift_cell_core");
+	    only_categories_.emplace_back("xcalo_block");
+	    only_categories_.emplace_back("gveto_block");
+	    only_categories_.emplace_back("calorimeter_block");
+	    break;
+	  case TEST_BENCH:
+	    only_categories_.emplace_back("calo_light_line");
+	    only_categories_.emplace_back("scin_block");
+	    only_categories_.emplace_back("absorber");
+	    only_categories_.emplace_back("diaphragm");
+	    only_categories_.emplace_back("air_gap");
+	    only_categories_.emplace_back("test_source");
+	    break;
+	  case BIPO1:
+	  case BIPO3:
+	    only_categories_.emplace_back("scin_block");
+	    only_categories_.emplace_back("source");
+	    //            only_categories_.push_back("bipo3_module");
+	    break;
+	  default:
+	    break;
+	  }
+
+	  // adding the default detectors to detector_to_show list
+	  for (std::vector<std::string>::const_iterator it_category = only_categories_.begin();
+	       it_category != only_categories_.end(); ++it_category) {
+	    volumes[*it_category]._visibility_ = VISIBLE;
+	  }
+	}
+	return;
+      }
+
+      void detector_manager::_set_volume_(const geomtools::geom_info &ginfo_) {
+	const geomtools::geom_id &volume_id = ginfo_.get_id();
+	// std::cerr << "*** devel *** detector_manager::_set_volume_() : volume_id='" << volume_id << "'\n";
+
+	const std::string volume_name = this->get_volume_name(volume_id);
+	const std::string volume_category = this->get_volume_category(volume_id);
+	// std::cerr << "*** devel *** detector_manager::_set_volume_() : volume_name='" << volume_name << "'\n";
+	// std::cerr << "*** devel *** detector_manager::_set_volume_() : volume_category='" << volume_category << "'\n";
+
+	const geomtools::logical_volume &a_log = ginfo_.get_logical();
+	const geomtools::i_shape_3d &a_shape = a_log.get_shape();
+	const std::string &shape_name = a_shape.get_shape_name();
+	// std::cerr << "*** devel *** detector_manager::_set_volume_() : shape_name='" << shape_name << "'\n";
   
-				// if (! is_special_volume(volume_category)) {
-				//   DT_LOG_INFORMATION(view::options_manager::get_instance().get_logging_priority(),
-				//                      "'" << volume_category << "' is not a special volume !");
-				//   std::cerr << "*** devel *** detector_manager::_set_volume_() : "
-				//             << "shape_name='" << shape_name << "' of category '"
-				//             << volume_category << "' is not a special volume\n";
-				// }
-				if (is_special_volume(volume_category)) {
-					DT_LOG_INFORMATION(view::options_manager::get_instance().get_logging_priority(),
-														 "'" << volume_category << "' is a special volume !");
-					// std::cerr << "*** devel *** detector_manager::_set_volume_() : volume_id='" << volume_id << "'\n";
-					// std::cerr << "*** devel *** detector_manager::_set_volume_() : volume_name='" << volume_name << "'\n";
-					// std::cerr << "*** devel *** detector_manager::_set_volume_() : volume_category='" << volume_category << "'\n";
-					// std::cerr << "*** devel *** detector_manager::_set_volume_() : "
-					//           << "shape_name='" << shape_name << "' of category '"
-					//           << volume_category << "' is a special volume\n";
-					_volumes_[volume_id] = new special_volume(volume_name, volume_category);
-				} else if (a_shape.is_composite()) {
-					_volumes_[volume_id] = new composite_volume(volume_name, volume_category);
-				} else if (shape_name == "box") {
-					_volumes_[volume_id] = new box_volume(volume_name, volume_category);
-				} else if (shape_name == "cylinder") {
-					_volumes_[volume_id] = new cylinder_volume(volume_name, volume_category);
-				} else if (shape_name == "tube") {
-					_volumes_[volume_id] = new tube_volume(volume_name, volume_category);
-				} else if (shape_name == "sphere") {
-					_volumes_[volume_id] = new sphere_volume(volume_name, volume_category);
-				} else if (shape_name == "polycone") {
-					_volumes_[volume_id] = new polycone_volume(volume_name, volume_category);
-					// } else if (shape_name == "tessellated") {
-					//   _volumes_[volume_id] = new tessellated_volume(volume_name, volume_category);
-				} else {
-					DT_LOG_ERROR(view::options_manager::get_instance().get_logging_priority(),
-											 shape_name << "' not yet implemented for '" << volume_category << "' volume");
-					return;
-				}
+	// if (! is_special_volume(volume_category)) {
+	//   DT_LOG_INFORMATION(view::options_manager::get_instance().get_logging_priority(),
+	//                      "'" << volume_category << "' is not a special volume !");
+	//   std::cerr << "*** devel *** detector_manager::_set_volume_() : "
+	//             << "shape_name='" << shape_name << "' of category '"
+	//             << volume_category << "' is not a special volume\n";
+	// }
+	if (is_special_volume(volume_category)) {
+	  DT_LOG_INFORMATION(view::options_manager::get_instance().get_logging_priority(),
+			     "'" << volume_category << "' is a special volume !");
+	  // std::cerr << "*** devel *** detector_manager::_set_volume_() : volume_id='" << volume_id << "'\n";
+	  // std::cerr << "*** devel *** detector_manager::_set_volume_() : volume_name='" << volume_name << "'\n";
+	  // std::cerr << "*** devel *** detector_manager::_set_volume_() : volume_category='" << volume_category << "'\n";
+	  // std::cerr << "*** devel *** detector_manager::_set_volume_() : "
+	  //           << "shape_name='" << shape_name << "' of category '"
+	  //           << volume_category << "' is a special volume\n";
+	  _volumes_[volume_id] = new special_volume(volume_name, volume_category);
+	} else if (a_shape.is_composite()) {
+	  _volumes_[volume_id] = new composite_volume(volume_name, volume_category);
+	} else if (shape_name == "box") {
+	  _volumes_[volume_id] = new box_volume(volume_name, volume_category);
+	} else if (shape_name == "cylinder") {
+	  _volumes_[volume_id] = new cylinder_volume(volume_name, volume_category);
+	} else if (shape_name == "tube") {
+	  _volumes_[volume_id] = new tube_volume(volume_name, volume_category);
+	} else if (shape_name == "sphere") {
+	  _volumes_[volume_id] = new sphere_volume(volume_name, volume_category);
+	} else if (shape_name == "polycone") {
+	  _volumes_[volume_id] = new polycone_volume(volume_name, volume_category);
+	  // } else if (shape_name == "tessellated") {
+	  //   _volumes_[volume_id] = new tessellated_volume(volume_name, volume_category);
+	} else {
+	  DT_LOG_ERROR(view::options_manager::get_instance().get_logging_priority(),
+		       shape_name << "' not yet implemented for '" << volume_category << "' volume");
+	  return;
+	}
 
-				_volumes_[volume_id]->initialize(ginfo_);
-				_volumes_[volume_id]->update();
+	_volumes_[volume_id]->initialize(ginfo_);
+	_volumes_[volume_id]->update();
 
-				DT_LOG_DEBUG(
-										 view::options_manager::get_instance().get_logging_priority(),
-										 "Volume '" << volume_name << " with category '" << volume_category << "' has been added");
-			}
+	DT_LOG_DEBUG(
+		     view::options_manager::get_instance().get_logging_priority(),
+		     "Volume '" << volume_name << " with category '" << volume_category << "' has been added");
+      }
 
-			void detector_manager::_add_volumes_() {
-				for (auto &_volume : _volumes_) {
-					i_volume &a_volume = *(_volume.second);
+      void detector_manager::_add_volumes_() {
+	for (auto &_volume : _volumes_) {
+	  i_volume &a_volume = *(_volume.second);
 
-					// Discard special volume
-					if (a_volume.get_type() == "special") {
-						continue;
-					}
+	  // Discard special volume
+	  if (a_volume.get_type() == "special") {
+	    continue;
+	  }
 
-					const geomtools::placement &placement = a_volume.get_placement();
-					const geomtools::vector_3d &position = placement.get_translation();
-					TGeoTranslation translation(position.x(), position.y(), position.z());
+	  const geomtools::placement &placement = a_volume.get_placement();
+	  const geomtools::vector_3d &position = placement.get_translation();
+	  TGeoTranslation translation(position.x(), position.y(), position.z());
 
-					TGeoRotation rotation((std::string("rot") + a_volume.get_name()).c_str(),
-																placement.get_phi() / CLHEP::degree + 90.0,
-																placement.get_theta() / CLHEP::degree,
-																placement.get_delta() / CLHEP::degree + 90.0);
+	  TGeoRotation rotation((std::string("rot") + a_volume.get_name()).c_str(),
+				placement.get_phi() / CLHEP::degree + 90.0,
+				placement.get_theta() / CLHEP::degree,
+				placement.get_delta() / CLHEP::degree + 90.0);
 
-					// ROOT volumes
-					auto &a_root_volume = dynamic_cast<i_root_volume &>(a_volume);
-					auto *gvolume = static_cast<TGeoVolume *>(a_root_volume.grab_volume());
+	  // ROOT volumes
+	  auto &a_root_volume = dynamic_cast<i_root_volume &>(a_volume);
+	  auto *gvolume = static_cast<TGeoVolume *>(a_root_volume.grab_volume());
 
-					// sanity check
-					DT_THROW_IF(
-											!gvolume, std::logic_error,
-											"No TGeoVolume has been constructed for '" << a_root_volume.get_name() << "' volume !");
+	  // sanity check
+	  DT_THROW_IF(
+		      !gvolume, std::logic_error,
+		      "No TGeoVolume has been constructed for '" << a_root_volume.get_name() << "' volume !");
 
-					// The second parameter is related to replication of volume:
-					// 1 means that all volume are unique which is true but most of them
-					// have actually identical shape. Probably this needs improvements in future.
-					// To be continued ...
-					_world_volume_->AddNodeOverlap(gvolume, 1, new TGeoCombiTrans(translation, rotation));
-				}
-			}
+	  // The second parameter is related to replication of volume:
+	  // 1 means that all volume are unique which is true but most of them
+	  // have actually identical shape. Probably this needs improvements in future.
+	  // To be continued ...
+	  _world_volume_->AddNodeOverlap(gvolume, 1, new TGeoCombiTrans(translation, rotation));
+	}
+      }
 
-			void detector_manager::_set_world_dimensions_() {
-				const geomtools::manager &gmgr = this->get_geometry_manager();
-				const geomtools::mapping &mapping = gmgr.get_mapping();
-				const geomtools::id_mgr::categories_by_name_col_type &categories =
-					gmgr.get_id_mgr().categories_by_name();
+      void detector_manager::_set_world_dimensions_() {
+	const geomtools::manager &gmgr = this->get_geometry_manager();
+	const geomtools::mapping &mapping = gmgr.get_mapping();
+	const geomtools::id_mgr::categories_by_name_col_type &categories =
+	  gmgr.get_id_mgr().categories_by_name();
 
-				const int volume_type = categories.find("world")->second.get_type();
-				geomtools::smart_id_locator volume_locator;
-				volume_locator.set_gmap(mapping);
-				volume_locator.initialize(volume_type);
+	const int volume_type = categories.find("world")->second.get_type();
+	geomtools::smart_id_locator volume_locator;
+	volume_locator.set_gmap(mapping);
+	volume_locator.initialize(volume_type);
 
-				for (auto iptr_ginfo : volume_locator.get_ginfos()) {
-					const geomtools::geom_info &ginfo = *iptr_ginfo;
+	for (auto iptr_ginfo : volume_locator.get_ginfos()) {
+	  const geomtools::geom_info &ginfo = *iptr_ginfo;
 
-					const geomtools::logical_volume &a_log = ginfo.get_logical();
-					const geomtools::i_shape_3d &a_shape = a_log.get_shape();
+	  const geomtools::logical_volume &a_log = ginfo.get_logical();
+	  const geomtools::i_shape_3d &a_shape = a_log.get_shape();
 
-					const std::string &shape_name = a_shape.get_shape_name();
+	  const std::string &shape_name = a_shape.get_shape_name();
 
-					if (shape_name == "box") {
-						const auto &mbox = dynamic_cast<const geomtools::box &>(a_shape);
+	  if (shape_name == "box") {
+	    const auto &mbox = dynamic_cast<const geomtools::box &>(a_shape);
 
-						_world_length_ = mbox.get_x();
-						_world_width_ = mbox.get_y();
-						_world_height_ = mbox.get_z();
-					} else {
-						DT_LOG_ERROR(view::options_manager::get_instance().get_logging_priority(),
-												 "World volume only support box shape "
-												 << "and nothing else. Do not do crazy thing buddy !");
-					}
-				}
+	    _world_length_ = mbox.get_x();
+	    _world_width_ = mbox.get_y();
+	    _world_height_ = mbox.get_z();
+	  } else {
+	    DT_LOG_ERROR(view::options_manager::get_instance().get_logging_priority(),
+			 "World volume only support box shape "
+			 << "and nothing else. Do not do crazy thing buddy !");
+	  }
+	}
 
-				const double boundary = 1.1;
+	const double boundary = 1.1;
 
-				_world_length_ *= boundary;
-				_world_width_ *= boundary;
-				_world_height_ *= boundary;
-			}
+	_world_length_ *= boundary;
+	_world_width_ *= boundary;
+	_world_height_ *= boundary;
+      }
 
-		} // end of namespace detector
+    } // end of namespace detector
 
-	} // end of namespace visualization
+  } // end of namespace visualization
 
 } // end of namespace snemo

--- a/programs/flvisualize/EventBrowser/display_options.cc
+++ b/programs/flvisualize/EventBrowser/display_options.cc
@@ -181,6 +181,7 @@ void display_options::_build_volume_buttons_() {
   unsigned int id_button = _button_dictionnary_.size();
   for (const auto& volume : volumes) {
     const std::string& volume_name = volume.first;
+		DT_LOG_DEBUG(datatools::logger::PRIO_ALWAYS, "====> Volume = " << volume_name);
 
     // Volume name without _
     std::string volume_group_name = volume_name;

--- a/programs/flvisualize/EventBrowser/pad_embedded_viewer.cc
+++ b/programs/flvisualize/EventBrowser/pad_embedded_viewer.cc
@@ -510,7 +510,7 @@ namespace snemo {
 
       void pad_embedded_viewer::_scale_text_() {
 	datatools::logger::priority local_priority = datatools::logger::PRIO_WARNING;
-	local_priority = datatools::logger::PRIO_TRACE;
+	// local_priority = datatools::logger::PRIO_TRACE;
 	if (_text_objects_ == nullptr) {
 	  return;
 	}

--- a/programs/flvisualize/EventBrowser/visual_track_renderer.cc
+++ b/programs/flvisualize/EventBrowser/visual_track_renderer.cc
@@ -40,314 +40,333 @@
 
 namespace snemo {
 
-	namespace visualization {
+  namespace visualization {
 
-		namespace view {
+    namespace view {
 
-			// ctor:
-			visual_track_renderer::visual_track_renderer() = default;
+      // ctor:
+      visual_track_renderer::visual_track_renderer() = default;
 
-			// dtor:
-			visual_track_renderer::~visual_track_renderer() = default;
+      // dtor:
+      visual_track_renderer::~visual_track_renderer() = default;
 
-			void visual_track_renderer::push_mc_tracks() {
-				const io::event_record &event = _server->get_event();
-				const auto &sim_data = event.get<mctools::simulated_data>(io::SD_LABEL);
+      void visual_track_renderer::push_mc_tracks() {
+	const io::event_record &event = _server->get_event();
+	const auto &sim_data = event.get<mctools::simulated_data>(io::SD_LABEL);
 
-				// Get hit categories related to visual track
-				std::vector<std::string> visual_categories;
-				sim_data.get_step_hits_categories(
-																					visual_categories, mctools::simulated_data::HIT_CATEGORY_TYPE_PREFIX, "__visu.tracks");
-				if (visual_categories.empty()) {
-					DT_LOG_INFORMATION(options_manager::get_instance().get_logging_priority(),
-														 "Event has no __visu.tracks* hits");
-					return;
-				}
+	// Get hit categories related to visual track
+	std::vector<std::string> visual_categories;
+	sim_data.get_step_hits_categories(
+					  visual_categories, mctools::simulated_data::HIT_CATEGORY_TYPE_PREFIX, "__visu.tracks");
+	if (visual_categories.empty()) {
+	  DT_LOG_INFORMATION(options_manager::get_instance().get_logging_priority(),
+			     "Event has no __visu.tracks* hits");
+	  return;
+	}
 
-				// Enable/disable track hits
-				std::set<int> enable_tracks;
-				// Highlight track from primary particles
-				const mctools::simulated_data::primary_event_type &pevent = sim_data.get_primary_event();
-				const genbb::primary_event::particles_col_type &particles = pevent.get_particles();
+	// Enable/disable track hits
+	std::set<int> enable_tracks;
+	// Highlight track from primary particles
+	const mctools::simulated_data::primary_event_type &pevent = sim_data.get_primary_event();
+	const genbb::primary_event::particles_col_type &particles = pevent.get_particles();
 
-				for (const auto &a_primary : particles) {
-					if (!a_primary.has_generation_id()) {
-						continue;
-					}
-					const datatools::properties &particle_aux = a_primary.get_auxiliaries();
-					const int track_id = a_primary.get_generation_id() + 1;
-					if (particle_aux.has_key(browser_tracks::CHECKED_FLAG) &&
-							!particle_aux.has_flag(browser_tracks::CHECKED_FLAG)) {
-						enable_tracks.insert(track_id);
-					}
-				}
+	for (const auto &a_primary : particles) {
+	  if (!a_primary.has_generation_id()) {
+	    continue;
+	  }
+	  const datatools::properties &particle_aux = a_primary.get_auxiliaries();
+	  const int track_id = a_primary.get_generation_id() + 1;
+	  if (particle_aux.has_key(browser_tracks::CHECKED_FLAG) &&
+	      !particle_aux.has_flag(browser_tracks::CHECKED_FLAG)) {
+	    enable_tracks.insert(track_id);
+	  }
+	}
 
-				for (const auto &visual_categorie : visual_categories) {
-					const mctools::simulated_data::hit_handle_collection_type &hit_collection =
-						sim_data.get_step_hits(visual_categorie);
-					if (hit_collection.empty()) {
-						DT_LOG_INFORMATION(options_manager::get_instance().get_logging_priority(), "No MC hits");
-						continue;
-					}
+	for (const auto &visual_categorie : visual_categories) {
+	  const mctools::simulated_data::hit_handle_collection_type &hit_collection =
+	    sim_data.get_step_hits(visual_categorie);
+	  if (hit_collection.empty()) {
+	    DT_LOG_INFORMATION(options_manager::get_instance().get_logging_priority(), "No MC hits");
+	    continue;
+	  }
 
-					for (const auto &it_hit : hit_collection) {
-						const mctools::base_step_hit &a_hit = it_hit.get();
-						std::string particle_name = a_hit.get_particle_name();
+	  for (const auto &it_hit : hit_collection) {
+	    const mctools::base_step_hit &a_hit = it_hit.get();
+	    std::string particle_name = a_hit.get_particle_name();
 
-						const std::string delta_ray_from_alpha_flag = mctools::track_utils::DELTA_RAY_FROM_ALPHA_FLAG;
-						const bool is_delta_ray_from_alpha =
-							a_hit.get_auxiliaries().has_flag(delta_ray_from_alpha_flag);
+	    const std::string delta_ray_from_alpha_flag = mctools::track_utils::DELTA_RAY_FROM_ALPHA_FLAG;
+	    const bool is_delta_ray_from_alpha =
+	      a_hit.get_auxiliaries().has_flag(delta_ray_from_alpha_flag);
 
-						if (is_delta_ray_from_alpha) {
-							particle_name = "delta_ray_from_alpha";
-						} else if (particle_name == "e+") {
-							particle_name = "positron";
-						} else if (particle_name == "e-") {
-							particle_name = "electron";
-						} else if (particle_name == "mu+") {
-							particle_name = "muon_plus";
-						} else if (particle_name == "mu-") {
-							particle_name = "muon_minus";
-						}
+	    if (is_delta_ray_from_alpha) {
+	      particle_name = "delta_ray_from_alpha";
+	    } else if (particle_name == "e+") {
+	      particle_name = "positron";
+	    } else if (particle_name == "e-") {
+	      particle_name = "electron";
+	    } else if (particle_name == "mu+") {
+	      particle_name = "muon_plus";
+	    } else if (particle_name == "mu-") {
+	      particle_name = "muon_minus";
+	    }
 
-						style_manager &style_mgr = style_manager::get_instance();
-						if (!style_mgr.has_particle_properties(particle_name)) {
-							if (!style_mgr.add_particle_properties(particle_name)) {
-								DT_LOG_INFORMATION(options_manager::get_instance().get_logging_priority(),
-																	 "Particle '" << particle_name << "' has no properties set !");
-							}
-						}
+	    style_manager &style_mgr = style_manager::get_instance();
+	    if (!style_mgr.has_particle_properties(particle_name)) {
+	      if (!style_mgr.add_particle_properties(particle_name)) {
+		DT_LOG_INFORMATION(options_manager::get_instance().get_logging_priority(),
+				   "Particle '" << particle_name << "' has no properties set !");
+	      }
+	    }
 
-						if (!style_mgr.get_particle_visibility(particle_name)) {
-							continue;
-						}
+	    if (!style_mgr.get_particle_visibility(particle_name)) {
+	      continue;
+	    }
 
-						size_t line_color = style_mgr.get_particle_color(particle_name);
-						size_t line_width = style_mgr.get_mc_line_width();
-						size_t line_style = style_mgr.get_mc_line_style();
+	    size_t line_color = style_mgr.get_particle_color(particle_name);
+	    size_t line_width = style_mgr.get_mc_line_width();
+	    size_t line_style = style_mgr.get_mc_line_style();
 
-						const datatools::properties &hit_aux = a_hit.get_auxiliaries();
-						const int track_id = a_hit.get_track_id();
-						if (hit_aux.has_key(browser_tracks::CHECKED_FLAG) &&
-								!hit_aux.has_flag(browser_tracks::CHECKED_FLAG)) {
-							enable_tracks.insert(track_id);
-						}
-						if (enable_tracks.count(track_id) != 0u) {
-							continue;
-						}
+	    const datatools::properties &hit_aux = a_hit.get_auxiliaries();
+	    const int track_id = a_hit.get_track_id();
+	    if (hit_aux.has_key(browser_tracks::CHECKED_FLAG) &&
+		!hit_aux.has_flag(browser_tracks::CHECKED_FLAG)) {
+	      enable_tracks.insert(track_id);
+	    }
+	    if (enable_tracks.count(track_id) != 0u) {
+	      continue;
+	    }
 
-						if (hit_aux.has_flag(browser_tracks::HIGHLIGHT_FLAG)) {  //  &&
-							// a_hit.get_auxiliaries().has_flag(mctools::hit_utils::HIT_VISU_HIGHLIGHTED_KEY)) {
-							line_width += 3;
-							TPolyMarker3D *mark1 = base_renderer::make_polymarker(a_hit.get_position_start());
-							_objects->Add(mark1);
-							mark1->SetMarkerColor(kRed);
-							// mark1->SetMarkerStyle(kPlus);
-							mark1->SetMarkerStyle(kOpenCrossX);
-							TPolyMarker3D *mark2 = base_renderer::make_polymarker(a_hit.get_position_stop());
-							_objects->Add(mark2);
-							mark2->SetMarkerColor(kRed);
-							mark2->SetMarkerStyle(kCircle);
-						}
-						geomtools::polyline_type points;
-						points.push_back(a_hit.get_position_start());
-						points.push_back(a_hit.get_position_stop());
-						TPolyLine3D *mc_path = base_renderer::make_polyline(points);
-						_objects->Add(mc_path);
-						mc_path->SetLineColor(line_color);
-						mc_path->SetLineWidth(line_width);
-						mc_path->SetLineStyle(line_style);
-					}
-				}  // end of category list
-			}
+	    if (hit_aux.has_flag(browser_tracks::HIGHLIGHT_FLAG)) {  //  &&
+	      // a_hit.get_auxiliaries().has_flag(mctools::hit_utils::HIT_VISU_HIGHLIGHTED_KEY)) {
+	      line_width += 3;
+	      TPolyMarker3D *mark1 = base_renderer::make_polymarker(a_hit.get_position_start());
+	      _objects->Add(mark1);
+	      mark1->SetMarkerColor(kRed);
+	      // mark1->SetMarkerStyle(kPlus);
+	      mark1->SetMarkerStyle(kOpenCrossX);
+	      TPolyMarker3D *mark2 = base_renderer::make_polymarker(a_hit.get_position_stop());
+	      _objects->Add(mark2);
+	      mark2->SetMarkerColor(kRed);
+	      mark2->SetMarkerStyle(kCircle);
+	    }
+	    geomtools::polyline_type points;
+	    points.push_back(a_hit.get_position_start());
+	    points.push_back(a_hit.get_position_stop());
+	    TPolyLine3D *mc_path = base_renderer::make_polyline(points);
+	    _objects->Add(mc_path);
+	    mc_path->SetLineColor(line_color);
+	    mc_path->SetLineWidth(line_width);
+	    mc_path->SetLineStyle(line_style);
+	  }
+	}  // end of category list
+      }
 
-			void visual_track_renderer::push_mc_legend() {
-				const style_manager &style_mgr = style_manager::get_instance();
-				const std::map<std::string, style_manager::particle_properties> &particles =
-					style_mgr.get_particles_properties();
+      void visual_track_renderer::push_mc_legend() {
+	const style_manager &style_mgr = style_manager::get_instance();
+	const std::map<std::string, style_manager::particle_properties> &particles =
+	  style_mgr.get_particles_properties();
 
-				double x = 1.00;
-				double y = 0.97;
-				const double dx = 0.05;
+	double x = 1.00;
+	double y = 0.97;
+	const double dx = 0.05;
 
-				for (const auto &particle : particles) {
-					const std::string particle_name = particle.first;
-					const style_manager::particle_properties particle_properties = particle.second;
+	for (const auto &particle : particles) {
+	  const std::string particle_name = particle.first;
+	  const style_manager::particle_properties particle_properties = particle.second;
 
-					if (!particle_properties._visibility_) {
-						continue;
-					}
+	  if (!particle_properties._visibility_) {
+	    continue;
+	  }
 
-					auto *legend = new TLatex;
-					_objects->Add(legend);
-					legend->SetNDC();
-					legend->SetTextAlign(31);
-					legend->SetTextSize(0.04);
-					legend->SetTextFont(42);
-					legend->SetTextColor(particle_properties._color_);
+	  auto *legend = new TLatex;
+	  _objects->Add(legend);
+	  legend->SetNDC();
+	  legend->SetTextAlign(31);
+	  legend->SetTextSize(0.04);
+	  legend->SetTextFont(42);
+	  legend->SetTextColor(particle_properties._color_);
 
-					const std::string latex = particle_properties._latex_name_;
-					legend->SetText(x -= dx, y, latex.c_str());
-				}
+	  const std::string latex = particle_properties._latex_name_;
+	  legend->SetText(x -= dx, y, latex.c_str());
+	}
 
-				// Add a latest legend text for particles not in the previous list
-				auto *legend = new TLatex;
-				_objects->Add(legend);
-				legend->SetNDC();
-				legend->SetTextAlign(31);
-				legend->SetTextSize(0.04);
-				legend->SetTextFont(42);
-				legend->SetTextColor(style_mgr.get_particle_color("others"));
-				legend->SetText(x -= dx, y, "others");
-			}
+	// Add a latest legend text for particles not in the previous list
+	auto *legend = new TLatex;
+	_objects->Add(legend);
+	legend->SetNDC();
+	legend->SetTextAlign(31);
+	legend->SetTextSize(0.04);
+	legend->SetTextFont(42);
+	legend->SetTextColor(style_mgr.get_particle_color("others"));
+	legend->SetText(x -= dx, y, "others");
+      }
 
-			void visual_track_renderer::push_reconstructed_tracks() {
-				const io::event_record &event = _server->get_event();
-				const auto &pt_data = event.get<snemo::datamodel::particle_track_data>(io::PTD_LABEL);
+      void visual_track_renderer::push_reconstructed_tracks() {
+	const io::event_record &event = _server->get_event();
+	const auto &pt_data = event.get<snemo::datamodel::particle_track_data>(io::PTD_LABEL);
 
-				if (!pt_data.hasParticles()) {
-					DT_LOG_DEBUG(options_manager::get_instance().get_logging_priority(),
-											 "Event has no reconstructed particles");
-					return;
-				}
+	if (!pt_data.hasParticles()) {
+	  DT_LOG_DEBUG(options_manager::get_instance().get_logging_priority(),
+		       "Event has no reconstructed particles");
+	  return;
+	}
 
-				// Show non-associated calorimeters
-				if (pt_data.hasIsolatedCalorimeters()) {
-					const snemo::datamodel::CalorimeterHitHdlCollection &calos = pt_data.isolatedCalorimeters();
-					for (const auto &calo : calos) {
-						const snemo::datamodel::calibrated_calorimeter_hit &a_calo = calo.get();
-						const geomtools::geom_id &a_calo_gid = a_calo.get_geom_id();
-						this->highlight_geom_id(a_calo_gid,
-																		style_manager::get_instance().get_calibrated_data_color());
-						if (!options_manager::get_instance().get_option_flag(SHOW_CALIBRATED_INFO)) {
-							const double energy = a_calo.get_energy() / CLHEP::MeV;
-							const double sigma_e = a_calo.get_sigma_energy() / CLHEP::MeV;
-							const double time = a_calo.get_time() / CLHEP::ns;
-							const double sigma_t = a_calo.get_sigma_time() / CLHEP::ns;
+	// Show non-associated calorimeters
+	if (pt_data.hasIsolatedCalorimeters()) {
+	  const snemo::datamodel::CalorimeterHitHdlCollection &calos = pt_data.isolatedCalorimeters();
+	  for (const auto &calo : calos) {
+	    const snemo::datamodel::calibrated_calorimeter_hit &a_calo = calo.get();
+	    const geomtools::geom_id &a_calo_gid = a_calo.get_geom_id();
+	    this->highlight_geom_id(a_calo_gid,
+				    style_manager::get_instance().get_calibrated_data_color());
+	    if (!options_manager::get_instance().get_option_flag(SHOW_CALIBRATED_INFO)) {
+	      const double energy = a_calo.get_energy() / CLHEP::MeV;
+	      const double sigma_e = a_calo.get_sigma_energy() / CLHEP::MeV;
+	      const double time = a_calo.get_time() / CLHEP::ns;
+	      const double sigma_t = a_calo.get_sigma_time() / CLHEP::ns;
 
-							// Save z position inside text and then parse it
-							std::ostringstream text_to_parse;
-							text_to_parse.precision(2);
-							text_to_parse << std::fixed << "#splitline"
-														<< "{E = " << energy << " #pm " << sigma_e << " MeV}"
-														<< "{t  = " << time << " #pm " << sigma_t << " ns}";
-							this->highlight_geom_id(a_calo_gid,
-																			style_manager::get_instance().get_calibrated_data_color(),
-																			text_to_parse.str());
-						}
-					}  // end of calorimeter list
-				} else {
-					DT_LOG_DEBUG(options_manager::get_instance().get_logging_priority(),
-											 "No calorimeter hits unassociated to particle track");
-				}
+	      // Save z position inside text and then parse it
+	      std::ostringstream text_to_parse;
+	      text_to_parse.precision(2);
+	      text_to_parse << std::fixed << "#splitline"
+			    << "{E = " << energy << " #pm " << sigma_e << " MeV}"
+			    << "{t  = " << time << " #pm " << sigma_t << " ns}";
+	      this->highlight_geom_id(a_calo_gid,
+				      style_manager::get_instance().get_calibrated_data_color(),
+				      text_to_parse.str());
+	    }
+	  }  // end of calorimeter list
+	} else {
+	  DT_LOG_DEBUG(options_manager::get_instance().get_logging_priority(),
+		       "No calorimeter hits unassociated to particle track");
+	}
 
-				for (const auto &particle : pt_data.particles()) {
-					const snemo::datamodel::particle_track &a_particle = particle.get();
+	for (const auto &particle : pt_data.particles()) {
+	  const snemo::datamodel::particle_track &a_particle = particle.get();
 
-					if (a_particle.get_auxiliaries().has_key(browser_tracks::CHECKED_FLAG) &&
-							!a_particle.get_auxiliaries().has_flag(browser_tracks::CHECKED_FLAG)) {
-						continue;
-					}
+	  if (a_particle.get_auxiliaries().has_key(browser_tracks::CHECKED_FLAG) &&
+	      !a_particle.get_auxiliaries().has_flag(browser_tracks::CHECKED_FLAG)) {
+	    continue;
+	  }
 
-					// Get color from charge
-					size_t color = 0;
-					if (a_particle.get_charge() == snemo::datamodel::particle_track::CHARGE_NEUTRAL) {
-						color = style_manager::get_instance().get_particle_color("gamma");
-					} else if (a_particle.get_charge() == snemo::datamodel::particle_track::CHARGE_NEGATIVE) {
-						color = style_manager::get_instance().get_particle_color("electron");
-					} else if (a_particle.get_charge() == snemo::datamodel::particle_track::CHARGE_POSITIVE) {
-						color = style_manager::get_instance().get_particle_color("positron");
-					} else if (a_particle.get_charge() == snemo::datamodel::particle_track::CHARGE_UNDEFINED) {
-						color = style_manager::get_instance().get_particle_color("alpha");
-					}
+	  // Get color from charge
+	  size_t color = 0;
+	  if (a_particle.get_charge() == snemo::datamodel::particle_track::CHARGE_NEUTRAL) {
+	    color = style_manager::get_instance().get_particle_color("gamma");
+	  } else if (a_particle.get_charge() == snemo::datamodel::particle_track::CHARGE_NEGATIVE) {
+	    color = style_manager::get_instance().get_particle_color("electron");
+	  } else if (a_particle.get_charge() == snemo::datamodel::particle_track::CHARGE_POSITIVE) {
+	    color = style_manager::get_instance().get_particle_color("positron");
+	  } else if (a_particle.get_charge() == snemo::datamodel::particle_track::CHARGE_UNDEFINED) {
+	    color = style_manager::get_instance().get_particle_color("alpha");
+	  }
 
-					// Show reconstructed vertices
-					if (a_particle.has_vertices()) {
-						const snemo::datamodel::VertexHdlCollection & vertices =
-							a_particle.get_vertices();
-						for (const auto & a_vertex : vertices) {
-							const geomtools::blur_spot & a_spot = a_vertex->get_spot();
-							const geomtools::vector_3d & a_position = a_spot.get_position();
-							{
-								TPolyMarker3D * mark = base_renderer::make_polymarker(a_position);
-								_objects->Add(mark);
-								mark->SetMarkerColor(color);
-								// mark->SetMarkerStyle(kStar);
-								mark->SetMarkerStyle(kOpenCrossX);
-							}
-							if (a_vertex->get_auxiliaries().has_flag(browser_tracks::HIGHLIGHT_FLAG)) {
-								TPolyMarker3D *mark = base_renderer::make_polymarker(a_position);
-								_objects->Add(mark);
-								mark->SetMarkerColor(color);
-								mark->SetMarkerStyle(kCircle);
-							}
-						}  // end of vertex list
+	  // Show reconstructed vertices
+	  if (a_particle.has_vertices()) {
+	    const snemo::datamodel::VertexHdlCollection & vertices =
+	      a_particle.get_vertices();
+	    for (const auto & a_vertex : vertices) {
+	      const geomtools::blur_spot & a_spot = a_vertex->get_spot();
+	      const geomtools::vector_3d & a_position = a_spot.get_position();
+	      {
+		TPolyMarker3D * mark = base_renderer::make_polymarker(a_position);
+		_objects->Add(mark);
+		mark->SetMarkerColor(color);
+		// mark->SetMarkerStyle(kStar);
+		mark->SetMarkerStyle(kOpenCrossX);
+	      }
+	      {
+		auto from = a_vertex->get_from();
+		auto fromPoint = a_particle.get_trajectory().get_pattern().get_first();
+		if (from == snemo::datamodel::VERTEX_FROM_LAST) {
+		  fromPoint = a_particle.get_trajectory().get_pattern().get_last();
+		}
+		TPolyMarker3D * fromMark = base_renderer::make_polymarker(fromPoint);
+		_objects->Add(fromMark);
+		fromMark->SetMarkerColor(color);
+		fromMark->SetMarkerStyle(kOpenCircle);
+		geomtools::polyline_type polyVertices;
+		polyVertices.push_back(fromPoint);
+		polyVertices.push_back(a_position);
+		TPolyLine3D * extrapolatedTrack = base_renderer::make_polyline(polyVertices);
+		_objects->Add(extrapolatedTrack);
+		extrapolatedTrack->SetLineColor(color);
+		extrapolatedTrack->SetLineStyle(kDashed);
+	      }
+	      if (a_vertex->get_auxiliaries().has_flag(browser_tracks::HIGHLIGHT_FLAG)) {
+		TPolyMarker3D *mark = base_renderer::make_polymarker(a_position);
+		_objects->Add(mark);
+		mark->SetMarkerColor(color);
+		mark->SetMarkerStyle(kCircle);
+	      }
+	      
+	    } // end of vertex list
 
-						// Gamma tracks
-						if (a_particle.get_charge() == snemo::datamodel::particle_track::CHARGE_NEUTRAL) {
-							geomtools::polyline_type polyVertices;
-							for (const auto & a_vertex : vertices) {
-								polyVertices.push_back(a_vertex->get_spot().get_position());
-							}
-							TPolyLine3D * track = base_renderer::make_polyline(polyVertices);
-							_objects->Add(track);
-							track->SetLineColor(color);
-							if (a_particle.get_auxiliaries().has_flag("__gamma_from_annihilation")) {
-								track->SetLineStyle(kDashDotted);
-							} else {
-								track->SetLineStyle(kDashed);
-							}
-							// track->SetLineWidth(line_width);
-						}
+	    // Gamma tracks
+	    if (a_particle.get_charge() == snemo::datamodel::particle_track::CHARGE_NEUTRAL) {
+	      geomtools::polyline_type polyVertices;
+	      for (const auto & a_vertex : vertices) {
+		polyVertices.push_back(a_vertex->get_spot().get_position());
+	      }
+	      TPolyLine3D * track = base_renderer::make_polyline(polyVertices);
+	      _objects->Add(track);
+	      track->SetLineColor(color);
+	      if (a_particle.get_auxiliaries().has_flag("__gamma_from_annihilation")) {
+		track->SetLineStyle(kDashDotted);
+	      } else {
+		track->SetLineStyle(kDashed);
+	      }
+	      // track->SetLineWidth(line_width);
+	    }
 
-					} else {
-						DT_LOG_DEBUG(options_manager::get_instance().get_logging_priority(),
-												 "No vertex associated to particle track");
-					}
+	  } else {
+	    DT_LOG_DEBUG(options_manager::get_instance().get_logging_priority(),
+			 "No vertex associated to particle track");
+	  }
 
-					// Show associated calorimeters
-					if (a_particle.has_associated_calorimeter_hits()) {
-						const snemo::datamodel::CalorimeterHitHdlCollection & calos =
-							a_particle.get_associated_calorimeter_hits();
-						for (const auto & calo : calos) {
-							const snemo::datamodel::calibrated_calorimeter_hit &a_calo = calo.get();
-							const geomtools::geom_id &a_calo_gid = a_calo.get_geom_id();
-							this->highlight_geom_id(a_calo_gid, color);
-							const double energy = a_calo.get_energy();
-							const double sigma_e = a_calo.get_sigma_energy();
-							const double time = a_calo.get_time();
-							const double sigma_t = a_calo.get_sigma_time();
+	  // Show associated calorimeters
+	  if (a_particle.has_associated_calorimeter_hits()) {
+	    const snemo::datamodel::CalorimeterHitHdlCollection & calos =
+	      a_particle.get_associated_calorimeter_hits();
+	    for (const auto & calo : calos) {
+	      const snemo::datamodel::calibrated_calorimeter_hit &a_calo = calo.get();
+	      const geomtools::geom_id &a_calo_gid = a_calo.get_geom_id();
+	      this->highlight_geom_id(a_calo_gid, color);
+	      const double energy = a_calo.get_energy();
+	      const double sigma_e = a_calo.get_sigma_energy();
+	      const double time = a_calo.get_time();
+	      const double sigma_t = a_calo.get_sigma_time();
 
-							// Save z position inside text and then parse it
-							std::ostringstream oss;
-							oss.precision(2);
-							oss << std::fixed << "#splitline{E = ";
-							utils::root_utilities::get_prettified_energy(oss, energy, sigma_e, true);
-							oss << "}{t  = ";
-							utils::root_utilities::get_prettified_time(oss, time, sigma_t, true);
-							oss << "}";
-							this->highlight_geom_id(a_calo_gid, color, oss.str());
-						}  // end of calorimeter list
-					} else {
-						DT_LOG_DEBUG(options_manager::get_instance().get_logging_priority(),
-												 "No calorimeter hits associated to particle track");
-					}
+	      // Save z position inside text and then parse it
+	      std::ostringstream oss;
+	      oss.precision(2);
+	      oss << std::fixed << "#splitline{E = ";
+	      utils::root_utilities::get_prettified_energy(oss, energy, sigma_e, true);
+	      oss << "}{t  = ";
+	      utils::root_utilities::get_prettified_time(oss, time, sigma_t, true);
+	      oss << "}";
+	      this->highlight_geom_id(a_calo_gid, color, oss.str());
+	    }  // end of calorimeter list
+	  } else {
+	    DT_LOG_DEBUG(options_manager::get_instance().get_logging_priority(),
+			 "No calorimeter hits associated to particle track");
+	  }
 
-					// Show attached fit
-					if (a_particle.has_trajectory()) {
-						const snemo::datamodel::tracker_trajectory &a_trajectory = a_particle.get_trajectory();
-						const snemo::datamodel::base_trajectory_pattern &a_pattern = a_trajectory.get_pattern();
-						const auto &iw3dr =
-							dynamic_cast<const geomtools::i_wires_3d_rendering &>(a_pattern.get_shape());
-						TPolyLine3D *track = base_renderer::make_track(iw3dr);
-						_objects->Add(track);
-						track->SetLineColor(color);
-					}
-				}
-			}
+	  // Show attached fit
+	  if (a_particle.has_trajectory()) {
+	    const snemo::datamodel::tracker_trajectory &a_trajectory = a_particle.get_trajectory();
+	    const snemo::datamodel::base_trajectory_pattern &a_pattern = a_trajectory.get_pattern();
+	    const auto &iw3dr =
+	      dynamic_cast<const geomtools::i_wires_3d_rendering &>(a_pattern.get_shape());
+	    TPolyLine3D *track = base_renderer::make_track(iw3dr);
+	    _objects->Add(track);
+	    track->SetLineColor(color);
+	  }
+	}
+      }
 	
-		} // end of namespace view
+    } // end of namespace view
 
-	} // end of namespace visualization
+  } // end of namespace visualization
 
 } // end of namespace snemo

--- a/programs/flvisualize/styles/snemo_demonstrator_default.sty
+++ b/programs/flvisualize/styles/snemo_demonstrator_default.sty
@@ -21,14 +21,15 @@ color_palette : string[7] = "#FF4136" "#0074D9" "#2ECC40" "#FFDC00" "#FF851B" \
 [name="geometry_settings"]
 
 #@description List of volumes to take care
-volume_category_list : string[8] = "module"            \
+volume_category_list : string[9] = "module"            \
                                    "calorimeter_block" \
                                    "calorimeter_pmt"   \
                                    "xcalo_block"       \
                                    "gveto_block"       \
                                    "drift_cell_core"   \
                                    "source_pad"        \
-                                   "source_pad_bulk"
+                                   "source_pad_bulk" \
+                                   "source_calibration_carrier"
 
 #@description Volume visibility (visible/invisible/disable)
 module.visibility                   : string = "invisible"
@@ -39,6 +40,7 @@ gveto_block.visibility              : string = "invisible"
 drift_cell_core.visibility          : string = "visible"
 source_pad.visibility               : string = "visible"
 source_pad_bulk.visibility          : string = "visible"
+source_calibration_carrier.visibility : string = "vinvisible"
 
 #@description Volume color
 module.color            : string = "#FF0000"
@@ -51,6 +53,7 @@ drift_cell_core.color   : string = "#222222"
 # source_pad_bulk.color   : string = "#65513E"
 source_pad.color        : string = "#9872b9"
 source_pad_bulk.color   : string = "#9872b9"
+source_calibration_carrier.color : string = "#11AA11"
 
 #########################################################
 

--- a/source/falaise/snemo/simulation/arbitrary_event_generator_injector.h
+++ b/source/falaise/snemo/simulation/arbitrary_event_generator_injector.h
@@ -98,8 +98,8 @@ namespace snemo {
       ///
       /// Format of a single setup file (datatools::multi_properties):
       /// 
-      /// #@key_label  "name"
-      /// #@meta_label "type"
+      /// \#\@key_label  "name"
+      /// \#\@meta_label "type"
       ///
       /// [name="pg_1" type="pg_type_1"]
       /// param_1 : type_1 = value_1


### PR DESCRIPTION
- fix a bug with _max extrapolation length XY_ cut
- use the solid shape of the Bi207 source carrier (cm scale) in place of the tiny Bi207 source spot deposit (mm scale)
- add feature in flvisualization: now display extrapolated segment from the end points of the trajectory to the associated extrapolated vertex on calo , source pad or calib source.