### PR TITLE
Fix browser crash for particle track has no trajectory

### DIFF
--- a/programs/flvisualize/EventBrowser/browser_tracks.cc
+++ b/programs/flvisualize/EventBrowser/browser_tracks.cc
@@ -397,7 +397,10 @@ void browser_tracks::_update_simulated_data() {
           mctools::simulated_data::hit_handle_collection_type &hit_collection =
               sd.grab_step_hits(category);
           for (auto &it_hit : hit_collection) {
-            mctools::base_step_hit &a_step = it_hit.grab();
+						if (not it_hit.has_data()) {
+							continue;
+						}
+						mctools::base_step_hit &a_step = it_hit.grab();
             datatools::properties &a_auxiliaries = a_step.grab_auxiliaries();
 
             std::string name = a_step.get_particle_name();
@@ -543,8 +546,11 @@ void browser_tracks::_update_simulated_data() {
         ihit += hit_collection.size();
 
         for (auto &it_hit : hit_collection) {
-          mctools::base_step_hit &a_step = it_hit.grab();
-
+					if (not it_hit.has_data()) {
+						continue;
+					}
+					mctools::base_step_hit &a_step = it_hit.grab();
+					
           std::string hex_str;
           if (a_step.get_auxiliaries().has_key(COLOR_FLAG)) {
             a_step.get_auxiliaries().fetch(COLOR_FLAG, hex_str);
@@ -595,6 +601,9 @@ void browser_tracks::_update_simulated_data() {
             sd.grab_step_hits("gg");
 
         for (auto &it_hit : hit_collection) {
+					if (not it_hit.has_data()) {
+						continue;
+					}
           mctools::base_step_hit &a_step = it_hit.grab();
 
           // If color is available, add a color box close to the item:
@@ -684,7 +693,9 @@ void browser_tracks::_update_digitized_data() {
     snemo::datamodel::CalorimeterDigiHitHdlCollection &dc_collection = udd.grab_calorimeter_hits();
 
     for (auto &it_hit : dc_collection) {
-
+			if (not it_hit.has_data()) {
+				continue;
+			}
       snemo::datamodel::calorimeter_digitized_hit &a_hit = it_hit.grab();
 
 			// Show only HT or LT hit
@@ -750,6 +761,9 @@ void browser_tracks::_update_digitized_data() {
     snemo::datamodel::TrackerDigiHitHdlCollection &dt_collection = udd.grab_tracker_hits();
 
     for (auto &it_hit : dt_collection) {
+			if (not it_hit.has_data()) {
+				continue;
+			}
       snemo::datamodel::tracker_digitized_hit &a_hit = it_hit.grab();
 
       // Add subsubitem:
@@ -831,6 +845,9 @@ void browser_tracks::_update_precalibrated_data() {
     snemo::datamodel::PreCalibratedCalorimeterHitHdlCollection &pcc_collection = pcd.calorimeter_hits();
 
     for (auto &it_hit : pcc_collection) {
+			if (not it_hit.has_data()) {
+				continue;
+			}
       snemo::datamodel::precalibrated_calorimeter_hit &a_hit = it_hit.grab();
 
       // Add subsubitem:
@@ -891,6 +908,9 @@ void browser_tracks::_update_precalibrated_data() {
     snemo::datamodel::PreCalibratedTrackerHitHdlCollection &pct_collection = pcd.tracker_hits();
 
     for (auto &it_hit : pct_collection) {
+			if (not it_hit.has_data()) {
+				continue;
+			}
       snemo::datamodel::precalibrated_tracker_hit & a_hit = it_hit.grab();
 
       // Add subsubitem:
@@ -987,7 +1007,10 @@ void browser_tracks::_update_calibrated_data() {
     snemo::datamodel::CalorimeterHitHdlCollection &cc_collection = cd.calorimeter_hits();
 
     for (auto &it_hit : cc_collection) {
-      snemo::datamodel::calibrated_calorimeter_hit &a_hit = it_hit.grab();
+			if (not it_hit.has_data()) {
+				continue;
+			}
+			snemo::datamodel::calibrated_calorimeter_hit &a_hit = it_hit.grab();
 
       std::string hex_str;
       if (a_hit.get_auxiliaries().has_key(COLOR_FLAG)) {
@@ -1048,6 +1071,9 @@ void browser_tracks::_update_calibrated_data() {
     snemo::datamodel::TrackerHitHdlCollection &ct_collection = cd.tracker_hits();
 
     for (auto &it_hit : ct_collection) {
+			if (not it_hit.has_data()) {
+				continue;
+			}
       snemo::datamodel::calibrated_tracker_hit & a_hit = it_hit.grab();
 
       // Add subsubitem:
@@ -1140,6 +1166,9 @@ void browser_tracks::_update_tracker_clustering_data() {
   }
 
   for (auto &cluster_solution : tcd.solutions()) {
+		if (not cluster_solution.has_data()) {
+			continue;
+		}
     // Get current tracker solution:
     snemo::datamodel::tracker_clustering_solution &a_solution = cluster_solution.grab();
 
@@ -1179,6 +1208,9 @@ void browser_tracks::_update_tracker_clustering_data() {
     // Get clusters stored in the current tracker solution:
     snemo::datamodel::TrackerClusterHdlCollection &clusters = a_solution.get_clusters();
     for (auto &cluster : clusters) {
+			if (not cluster.has_data()) {
+				continue;
+			}
       // Get current tracker cluster:
       snemo::datamodel::tracker_cluster &a_cluster = cluster.grab();
 
@@ -1303,6 +1335,11 @@ void browser_tracks::_update_tracker_trajectory_data() {
   snemo::datamodel::TrackerTrajectorySolutionHdlCollection &trajectory_solutions =
       ttd.get_solutions();
   for (auto &trajectory_solution : trajectory_solutions) {
+		if (not trajectory_solution.has_data()) {
+			DT_LOG_WARNING(datatools::logger::PRIO_WARNING,
+										 "Trajectory solution has no data");
+			continue;
+		}
     // Get current tracker solution:
     snemo::datamodel::tracker_trajectory_solution & a_solution = trajectory_solution.grab();
 
@@ -1358,6 +1395,11 @@ void browser_tracks::_update_tracker_trajectory_data() {
     // Get trajectories stored in the current tracker trajectory solution:
     snemo::datamodel::TrackerTrajectoryHdlCollection & trajectories = a_solution.grab_trajectories();
     for (auto & thisTrajectory : trajectories) {
+			if (not thisTrajectory.has_data()) {
+				DT_LOG_WARNING(datatools::logger::PRIO_WARNING,
+										 "Trajectory has no data");
+				continue;
+			}
       // Get current tracker trajectory:
       snemo::datamodel::tracker_trajectory & a_trajectory = thisTrajectory.grab();
 
@@ -1542,6 +1584,9 @@ void browser_tracks::_update_particle_track_data() {
     snemo::datamodel::CalorimeterHitHdlCollection &cc_collection = ptd.isolatedCalorimeters();
 
     for (auto &it_hit : cc_collection) {
+			if (not it_hit.has_data()) {
+				continue;
+			}
       snemo::datamodel::calibrated_calorimeter_hit &a_hit = it_hit.grab();
 
       // Add subsubitem:
@@ -1583,6 +1628,9 @@ void browser_tracks::_update_particle_track_data() {
 
   for (auto & particle : ptd.particles()) {
     // Get current particle track:
+		if (not particle.has_data()) {
+			continue;
+		}
     snemo::datamodel::particle_track & a_particle = particle.grab();
 
     // Add item:
@@ -1699,6 +1747,9 @@ void browser_tracks::_update_particle_track_data() {
           a_particle.get_associated_calorimeter_hits();
 
       for (auto & it_hit : cc_collection) {
+				if (not it_hit.has_data()) {
+					continue;
+				}
         snemo::datamodel::calibrated_calorimeter_hit &a_hit = it_hit.grab();
 
         // Add subsubitem:

--- a/programs/flvisualize/EventBrowser/calorimeter_hit_renderer.cc
+++ b/programs/flvisualize/EventBrowser/calorimeter_hit_renderer.cc
@@ -81,6 +81,9 @@ namespace snemo {
 	}
 
 	for (const auto& it_hit : hit_collection) {
+	  if (not it_hit.has_data()) {
+	    continue;
+	  }
 	  const mctools::base_step_hit& a_hit = it_hit.get();
 
 	  const geomtools::vector_3d& pstart = a_hit.get_position_start();
@@ -141,6 +144,9 @@ namespace snemo {
 	}
 
 	for (const auto& it_hit : dc_collection) {
+	  if (not it_hit.has_data()) {
+	    continue;
+	  }
 	  const snemo::datamodel::calorimeter_digitized_hit& a_hit = it_hit.get();
 
 	  // Geom ID fix
@@ -279,6 +285,9 @@ namespace snemo {
 	}
 
 	for (const auto& it_hit : pcc_collection) {
+	  if (not it_hit.has_data()) {
+	    continue;
+	  }
 	  const snemo::datamodel::precalibrated_calorimeter_hit& a_hit = it_hit.get();
 
 	  this->highlight_geom_id(a_hit.get_geom_id(), style_manager::get_instance().get_precalibrated_data_color());
@@ -426,6 +435,9 @@ namespace snemo {
 	}
 
 	for (const auto& it_hit : cc_collection) {
+	  if (not it_hit.has_data()) {
+	    continue;
+	  }
 	  const snemo::datamodel::calibrated_calorimeter_hit& a_hit = it_hit.get();
 
 	  this->highlight_geom_id(a_hit.get_geom_id(),

--- a/programs/flvisualize/EventBrowser/log.h
+++ b/programs/flvisualize/EventBrowser/log.h
@@ -10,16 +10,29 @@
 // - Boost:
 #include <boost/current_function.hpp>
 
+
+#define FL_LOG_DEVEL_IF(Condition, Message)				\
+  { if (Condition) {							\
+      std::ostringstream _fl_xxx_message;				\
+      _fl_xxx_message << Message;					\
+      std::ostringstream _fl_xxx_out;					\
+      _fl_xxx_out << "[devel:" << BOOST_CURRENT_FUNCTION << ":" << __LINE__ << "] "; \
+      _fl_xxx_out << _fl_xxx_message.str();				\
+      std::cerr << _fl_xxx_out.str() << std::endl;			\
+    }}
+
 #define FL_LOG_DEVEL(Message)
+
 /*
 #define FL_LOG_DEVEL(Message)						\
-  {                                                                     \
-    std::ostringstream _fl_xxx_message;					\
-    _fl_xxx_message << Message;						\
-    std::ostringstream _fl_xxx_out;					\
-    _fl_xxx_out << "[devel:" << BOOST_CURRENT_FUNCTION << ":" << __LINE__ << "] "; \
-    _fl_xxx_out << _fl_xxx_message.str();				\
-    std::cerr << _fl_xxx_out.str() << std::endl;			\
-  }
+{									\
+std::ostringstream _fl_xxx_message;					\
+_fl_xxx_message << Message;						\
+std::ostringstream _fl_xxx_out;						\
+_fl_xxx_out << "[devel:" << BOOST_CURRENT_FUNCTION << ":" << __LINE__ << "] "; \
+_fl_xxx_out << _fl_xxx_message.str();					\
+std::cerr << _fl_xxx_out.str() << std::endl;				\
+}
 */
+
 #endif  // FALAISE_SNEMO_VISUALIZATION_LOG_H

--- a/programs/flvisualize/EventBrowser/snemo_draw_manager.cc
+++ b/programs/flvisualize/EventBrowser/snemo_draw_manager.cc
@@ -37,7 +37,7 @@ namespace snemo {
 
       // ctor:
       snemo_draw_manager::snemo_draw_manager(const io::event_server* server_) {
-	FL_LOG_DEVEL("Entering...");
+	// FL_LOG_DEVEL("Entering...");
 	_server_ = server_;
 
 	_objects_ = new TObjArray(1000);
@@ -49,7 +49,7 @@ namespace snemo {
 	_calorimeter_hit_renderer_.initialize(_server_, _objects_, _text_objects_);
 	_tracker_hit_renderer_.initialize(_server_, _objects_, _text_objects_);
 	_visual_track_renderer_.initialize(_server_, _objects_, _text_objects_);
-	FL_LOG_DEVEL("Exiting...");
+	// FL_LOG_DEVEL("Exiting...");
       }
 
       // dtor:
@@ -60,11 +60,11 @@ namespace snemo {
       TObjArray* snemo_draw_manager::get_text_objects() { return _text_objects_; }
 
       void snemo_draw_manager::update() {
-	FL_LOG_DEVEL("Entering...");
+	// FL_LOG_DEVEL("Entering...");
 	if (!_server_->is_initialized()) {
 	  DT_LOG_DEBUG(options_manager::get_instance().get_logging_priority(),
 		       "Event server is not initialized !");
-	  FL_LOG_DEVEL("Exiting...");
+	  // FL_LOG_DEVEL("Exiting...");
 	  return;
 	}
 
@@ -124,14 +124,14 @@ namespace snemo {
 		       "Event has no tracker trajectory data");
 	}
 
-	// Add 'tracker_trajectory_data' objects:
+	// Add 'particle_track_data' objects:
 	if (_server_->get_event().has(io::PTD_LABEL)) {
 	  this->_add_particle_track_data();
 	} else {
 	  DT_LOG_DEBUG(options_manager::get_instance().get_logging_priority(),
 		       "Event has no particle track data");
 	}
-	FL_LOG_DEVEL("Exiting...");
+	// FL_LOG_DEVEL("Exiting...");
       }
 
       void snemo_draw_manager::draw() { _objects_->Draw(); }
@@ -139,7 +139,7 @@ namespace snemo {
       void snemo_draw_manager::draw_text() { _text_objects_->Draw(); }
 
       void snemo_draw_manager::reset() {
-	FL_LOG_DEVEL("Entering...");
+	// FL_LOG_DEVEL("Entering...");
 	this->snemo_draw_manager::clear();
 
 	delete _objects_;
@@ -151,24 +151,24 @@ namespace snemo {
 	_calorimeter_hit_renderer_.reset();
 	_tracker_hit_renderer_.reset();
 	_visual_track_renderer_.reset();
-	FL_LOG_DEVEL("Exiting...");
+	// FL_LOG_DEVEL("Exiting...");
       }
 
       void snemo_draw_manager::clear() {
-	FL_LOG_DEVEL("Entering...");
+	// FL_LOG_DEVEL("Entering...");
 	_calorimeter_hit_renderer_.clear();
-	FL_LOG_DEVEL("calorimeter_hit_renderer cleared.");
+	// FL_LOG_DEVEL("calorimeter_hit_renderer cleared.");
 	_tracker_hit_renderer_.clear();
-	FL_LOG_DEVEL("tracker_hit_renderer cleared.");
+	// FL_LOG_DEVEL("tracker_hit_renderer cleared.");
 	_visual_track_renderer_.clear();
-	FL_LOG_DEVEL("visual_track_renderer cleared.");
-	FL_LOG_DEVEL("About to delete " << _objects_->GetEntries() << " objects");
+	// FL_LOG_DEVEL("visual_track_renderer cleared.");
+	// FL_LOG_DEVEL("About to delete " << _objects_->GetEntries() << " objects");
 	_objects_->Delete();
-	FL_LOG_DEVEL("objects deleted.");
-	FL_LOG_DEVEL("About to delete " << _text_objects_->GetEntries() << " text objects");
+	// FL_LOG_DEVEL("objects deleted.");
+	// FL_LOG_DEVEL("About to delete " << _text_objects_->GetEntries() << " text objects");
 	_text_objects_->Delete();
-	FL_LOG_DEVEL("text objects deleted.");
-	FL_LOG_DEVEL("Exiting...");
+	// FL_LOG_DEVEL("text objects deleted.");
+	// FL_LOG_DEVEL("Exiting...");
       }
 
       /***************************************************
@@ -176,7 +176,7 @@ namespace snemo {
        ***************************************************/
 
       void snemo_draw_manager::_add_simulated_data() {
-	FL_LOG_DEVEL("Entering...");
+	// FL_LOG_DEVEL("Entering...");
 	const options_manager& options_mgr = options_manager::get_instance();
 
 	if (options_mgr.get_option_flag(SHOW_MC_VERTEX)) {
@@ -195,18 +195,18 @@ namespace snemo {
 	if (options_mgr.get_option_flag(SHOW_EVENT_HEADER)) {
 	  _visual_track_renderer_.push_data_legend();
 	}
-	FL_LOG_DEVEL("Exiting...");
+	// FL_LOG_DEVEL("Exiting...");
       }
 
       void snemo_draw_manager::_add_simulated_vertex_() {
-	FL_LOG_DEVEL("Entering...");
+	// FL_LOG_DEVEL("Entering...");
 	const io::event_record& event = _server_->get_event();
 	const auto& sim_data = event.get<mctools::simulated_data>(io::SD_LABEL);
 
 	if (!sim_data.has_vertex()) {
 	  DT_LOG_INFORMATION(options_manager::get_instance().get_logging_priority(),
 			     "Simulated data has no vertex");
-	  FL_LOG_DEVEL("Exiting...");
+	  // FL_LOG_DEVEL("Exiting...");
 	  return;
 	}
 
@@ -232,11 +232,11 @@ namespace snemo {
 	    break;
 	  }
 	}
-	FL_LOG_DEVEL("Exiting...");
+	// FL_LOG_DEVEL("Exiting...");
       }
 
       void snemo_draw_manager::_add_simulated_hits_() {
-	FL_LOG_DEVEL("Entering...");
+	// FL_LOG_DEVEL("Entering...");
 	const options_manager& options_mgr = options_manager::get_instance();
 	if (options_mgr.get_option_flag(SHOW_MC_CALORIMETER_HITS)) {
 	  const std::string& setup_label_name =
@@ -252,7 +252,7 @@ namespace snemo {
 	if (options_mgr.get_option_flag(SHOW_MC_TRACKER_HITS)) {
 	  _tracker_hit_renderer_.push_simulated_hits("gg");
 	}
-	FL_LOG_DEVEL("Exiting...");
+	// FL_LOG_DEVEL("Exiting...");
       }
 
       /****************************************************
@@ -260,12 +260,12 @@ namespace snemo {
        ****************************************************/
 
       void snemo_draw_manager::_add_event_header_data() {
-	FL_LOG_DEVEL("Entering...");
+	// FL_LOG_DEVEL("Entering...");
 	const options_manager& options_mgr = options_manager::get_instance();
 	if (options_mgr.get_option_flag(SHOW_EVENT_HEADER)) {
 	  _visual_track_renderer_.push_data_legend();
 	}
-	FL_LOG_DEVEL("Exiting...");
+	// FL_LOG_DEVEL("Exiting...");
       }
 
       /****************************************************
@@ -273,13 +273,13 @@ namespace snemo {
        ****************************************************/
 
       void snemo_draw_manager::_add_digitized_data() {
-	FL_LOG_DEVEL("Entering...");
+	// FL_LOG_DEVEL("Entering...");
 	const options_manager& options_mgr = options_manager::get_instance();
 	if (options_mgr.get_option_flag(SHOW_DIGITIZED_HITS)) {
 	  _calorimeter_hit_renderer_.push_digitized_hits();
 	  _tracker_hit_renderer_.push_digitized_hits();
 	}
-	FL_LOG_DEVEL("Exiting...");
+	// FL_LOG_DEVEL("Exiting...");
       }
 
       /****************************************************
@@ -287,13 +287,13 @@ namespace snemo {
        ****************************************************/
 
       void snemo_draw_manager::_add_precalibrated_data() {
-	FL_LOG_DEVEL("Entering...");
+	// FL_LOG_DEVEL("Entering...");
 	const options_manager& options_mgr = options_manager::get_instance();
 	if (options_mgr.get_option_flag(SHOW_PRECALIBRATED_HITS)) {
 	  _calorimeter_hit_renderer_.push_precalibrated_hits();
 	  _tracker_hit_renderer_.push_precalibrated_hits();
 	}
-	FL_LOG_DEVEL("Exiting...");
+	// FL_LOG_DEVEL("Exiting...");
       }
 
       /****************************************************
@@ -301,13 +301,13 @@ namespace snemo {
        ****************************************************/
 
       void snemo_draw_manager::_add_calibrated_data() {
-	FL_LOG_DEVEL("Entering...");
+	// FL_LOG_DEVEL("Entering...");
 	const options_manager& options_mgr = options_manager::get_instance();
 	if (options_mgr.get_option_flag(SHOW_CALIBRATED_HITS)) {
 	  _calorimeter_hit_renderer_.push_calibrated_hits();
 	  _tracker_hit_renderer_.push_calibrated_hits();
 	}
-	FL_LOG_DEVEL("Exiting...");
+	// FL_LOG_DEVEL("Exiting...");
       }
 
       /************************************************************
@@ -315,12 +315,12 @@ namespace snemo {
        ************************************************************/
 
       void snemo_draw_manager::_add_tracker_clustering_data() {
-	FL_LOG_DEVEL("Entering...");
+	// FL_LOG_DEVEL("Entering...");
 	const options_manager& options_mgr = options_manager::get_instance();
 	if (options_mgr.get_option_flag(SHOW_TRACKER_CLUSTERED_HITS)) {
 	  _tracker_hit_renderer_.push_clustered_hits();
 	}
-	FL_LOG_DEVEL("Exiting...");
+	// FL_LOG_DEVEL("Exiting...");
       }
 
       /************************************************************

--- a/programs/flvisualize/EventBrowser/tracker_hit_renderer.cc
+++ b/programs/flvisualize/EventBrowser/tracker_hit_renderer.cc
@@ -62,14 +62,15 @@ namespace snemo {
 
       void tracker_hit_renderer::push_simulated_hits(const std::string & hit_category_)
       {
-        FL_LOG_DEVEL("Entering...");
+        // FL_LOG_DEVEL("Entering...");
         const io::event_record & event = _server->get_event();
+ 	if (not event.has(io::SD_LABEL)) return;
         const auto & sim_data = event.get<mctools::simulated_data>(io::SD_LABEL);
 
         if (!sim_data.has_step_hits(hit_category_)) {
           DT_LOG_INFORMATION(options_manager::get_instance().get_logging_priority(),
                              "Event has no '" << hit_category_ << "' tracker hits");
-          FL_LOG_DEVEL("Exiting...");
+          // FL_LOG_DEVEL("Exiting...");
           return;
         }
 
@@ -79,10 +80,13 @@ namespace snemo {
         if (hit_collection.empty()) {
           DT_LOG_INFORMATION(options_manager::get_instance().get_logging_priority(),
                              "No tracker hits");
-          FL_LOG_DEVEL("Exiting...");
+          // FL_LOG_DEVEL("Exiting...");
           return;
         }
-
+	if (not hit_collection.front().has_data()) {
+	  return;
+	}
+ 
         // time gradient color
         double hit_start_time = hit_collection.front().get().get_time_start();
         double hit_stop_time = hit_collection.front().get().get_time_start();
@@ -91,14 +95,24 @@ namespace snemo {
           options_manager::get_instance().get_option_flag(SHOW_GG_TIME_GRADIENT);
         if (geiger_with_gradient) {
           for (const auto & it_hit : hit_collection) {
-            hit_start_time = std::min(it_hit.get().get_time_start(), hit_start_time);
+	    if (not it_hit.has_data()) {
+	      DT_LOG_WARNING(datatools::logger::PRIO_ALWAYS, // options_manager::get_instance().get_logging_priority(),
+			     "Hit from collection '" << hit_category_ << "' is not set!");
+	      continue;
+	    }
+	    hit_start_time = std::min(it_hit.get().get_time_start(), hit_start_time);
             hit_stop_time = std::max(it_hit.get().get_time_start(), hit_stop_time);
           }
         }
 
         for (const auto & it_hit : hit_collection) {
-          const mctools::base_step_hit & a_step = it_hit.get();
-
+	  if (not it_hit.has_data()) {
+	    DT_LOG_WARNING(datatools::logger::PRIO_ALWAYS, // options_manager::get_instance().get_logging_priority(),
+			   "Hit from collection '" << hit_category_ << "' is not set!");
+	    continue;
+	  }
+ 	  const mctools::base_step_hit & a_step = it_hit.get();
+	  
           // draw the Geiger avalanche path:
           auto * gg_path = new TPolyLine3D;
           _objects->Add(gg_path);
@@ -178,12 +192,13 @@ namespace snemo {
             gg_drift->SetLineWidth(line_width);
           } // end of "show geiger drift circle" condition
         } // end of step collection
-        FL_LOG_DEVEL("Exiting...");
+        // FL_LOG_DEVEL("Exiting...");
         return;
       }
 
       void tracker_hit_renderer::push_digitized_hits() {
 	const io::event_record &event = _server->get_event();
+ 	if (not event.has(io::UDD_LABEL)) return;
 	const auto &digi_data = event.get<snemo::datamodel::unified_digitized_data>(io::UDD_LABEL);
 
 	const snemo::datamodel::TrackerDigiHitHdlCollection &dt_collection = digi_data.get_tracker_hits();
@@ -195,6 +210,11 @@ namespace snemo {
 	}
 
 	for (const auto &it_hit : dt_collection) {
+	  if (not it_hit.has_data()) {
+	    DT_LOG_WARNING(datatools::logger::PRIO_ALWAYS, // options_manager::get_instance().get_logging_priority(),
+			   "Tracker digitized hit is not set!");
+	    continue;
+	  }
 	  const snemo::datamodel::tracker_digitized_hit &a_hit = it_hit.get();
 	  tracker_hit_renderer::_make_digitized_geiger_hit(a_hit);
 	}
@@ -204,6 +224,7 @@ namespace snemo {
       {
         // FL_LOG_DEVEL("Entering...");
         const io::event_record & event = _server->get_event();
+ 	if (not event.has(io::pCD_LABEL)) return;
         const auto & precalib_data = event.get<snemo::datamodel::precalibrated_data>(io::pCD_LABEL);
 
         const snemo::datamodel::PreCalibratedTrackerHitHdlCollection & pct_collection = precalib_data.tracker_hits();
@@ -216,7 +237,12 @@ namespace snemo {
         }
 
         for (const auto & it_hit : pct_collection) {
-          const snemo::datamodel::precalibrated_tracker_hit & a_hit = it_hit.get();
+	  if (not it_hit.has_data()) {
+	    DT_LOG_WARNING(datatools::logger::PRIO_ALWAYS, // options_manager::get_instance().get_logging_priority(),
+			   "Precalibrated tracker hit is not set!");
+	    continue;
+	  }
+	  const snemo::datamodel::precalibrated_tracker_hit & a_hit = it_hit.get();
 
 	  // this->highlight_geom_id(a_hit.get_geom_id(), style_manager::get_instance().get_precalibrated_data_color());
 	  tracker_hit_renderer::_make_precalibrated_geiger_hit(a_hit);
@@ -227,8 +253,9 @@ namespace snemo {
 
       void tracker_hit_renderer::push_calibrated_hits()
       {
-        FL_LOG_DEVEL("Entering...");
+        // FL_LOG_DEVEL("Entering...");
         const io::event_record & event = _server->get_event();
+ 	if (not event.has(io::CD_LABEL)) return;
         const auto & calib_data = event.get<snemo::datamodel::calibrated_data>(io::CD_LABEL);
 
         const snemo::datamodel::TrackerHitHdlCollection & ct_collection = calib_data.tracker_hits();
@@ -236,27 +263,37 @@ namespace snemo {
         if (ct_collection.empty()) {
           DT_LOG_INFORMATION(options_manager::get_instance().get_logging_priority(),
                              "No calibrated tracker hits");
-          FL_LOG_DEVEL("Exiting...");
+          // FL_LOG_DEVEL("Exiting...");
           return;
         }
 
         for (const auto & it_hit : ct_collection) {
-          const snemo::datamodel::calibrated_tracker_hit & a_hit = it_hit.get();
+	  if (not it_hit.has_data()) {
+	    DT_LOG_INFORMATION(options_manager::get_instance().get_logging_priority(),
+			       "Calibrated tracker hit is not set!");
+	    continue;
+	  }
+	  const snemo::datamodel::calibrated_tracker_hit & a_hit = it_hit.get();
           tracker_hit_renderer::_make_calibrated_geiger_hit(a_hit, false);
         }
-        FL_LOG_DEVEL("Exiting...");
+        // FL_LOG_DEVEL("Exiting...");
         return;
       }
 
       void tracker_hit_renderer::push_clustered_hits()
       {
-        FL_LOG_DEVEL("Entering...");
+        // FL_LOG_DEVEL("Entering...");
         const io::event_record & event = _server->get_event();
         const auto & tracker_clustered_data =
           event.get<snemo::datamodel::tracker_clustering_data>(io::TCD_LABEL);
 
         for (const auto & cluster_solution : tracker_clustered_data.solutions()) {
-          // Get current tracker solution:
+	  if (not cluster_solution.has_data()) {
+	    DT_LOG_INFORMATION(options_manager::get_instance().get_logging_priority(),
+			       "Cluster solution solution is not set!");
+	    continue;
+	  }
+           // Get current tracker solution:
           const snemo::datamodel::tracker_clustering_solution &a_solution = cluster_solution.get();
 
           // Check solution properties:
@@ -334,7 +371,7 @@ namespace snemo {
             } // end of gg hits
           } // end of cluster loop
         } // end of solution loop
-        FL_LOG_DEVEL("Exiting...");
+        // FL_LOG_DEVEL("Exiting...");
         return;
       }
 
@@ -342,12 +379,18 @@ namespace snemo {
       {
         FL_LOG_DEVEL("Entering...");
         const io::event_record & event = _server->get_event();
+	if (not event.has(io::TTD_LABEL)) return;
         const auto & tracker_trajectory_data =
           event.get<snemo::datamodel::tracker_trajectory_data>(io::TTD_LABEL);
 
         const snemo::datamodel::TrackerTrajectorySolutionHdlCollection & trajectory_solutions =
           tracker_trajectory_data.get_solutions();
         for (const auto & isolution : trajectory_solutions) {
+	  if (not isolution.has_data()) {
+	    DT_LOG_WARNING(datatools::logger::PRIO_ALWAYS, //options_manager::get_instance().get_logging_priority(),
+			   "Tracker trajectory solution is not set!");
+	    continue;
+	  }
           // Get current tracker trajectory solution:
           const snemo::datamodel::tracker_trajectory_solution & a_solution = isolution.get();
 
@@ -366,6 +409,11 @@ namespace snemo {
             a_solution.get_trajectories();
 
           for (const auto & itrajectory : trajectories) {
+	    if (not itrajectory.has_data()) {
+	      DT_LOG_WARNING(datatools::logger::PRIO_ALWAYS, // options_manager::get_instance().get_logging_priority(),
+			     "Tracker trajectory is not set!");
+	      continue;
+	    }
             // Get current tracker trajectory:
             const snemo::datamodel::tracker_trajectory & a_trajectory = itrajectory.get();
 

--- a/programs/flvisualize/EventBrowser/visual_track_renderer.cc
+++ b/programs/flvisualize/EventBrowser/visual_track_renderer.cc
@@ -93,6 +93,9 @@ namespace snemo {
 	  }
 
 	  for (const auto &it_hit : hit_collection) {
+	    if (not it_hit.has_data()) {
+	      continue;
+	    }
 	    const mctools::base_step_hit &a_hit = it_hit.get();
 	    std::string particle_name = a_hit.get_particle_name();
 
@@ -252,6 +255,7 @@ namespace snemo {
 
       void visual_track_renderer::push_reconstructed_tracks()
       {
+	FL_LOG_DEVEL("Entering...");
 	style_manager &style_mgr = style_manager::get_instance();
 	const io::event_record &event = _server->get_event();
 	const auto &pt_data = event.get<snemo::datamodel::particle_track_data>(io::PTD_LABEL);
@@ -259,6 +263,7 @@ namespace snemo {
 	if (!pt_data.hasParticles()) {
 	  DT_LOG_DEBUG(options_manager::get_instance().get_logging_priority(),
 		       "Event has no reconstructed particles");
+	  FL_LOG_DEVEL("Exiting...");
 	  return;
 	}
 
@@ -266,6 +271,11 @@ namespace snemo {
 	if (pt_data.hasIsolatedCalorimeters()) {
 	  const snemo::datamodel::CalorimeterHitHdlCollection &calos = pt_data.isolatedCalorimeters();
 	  for (const auto &calo : calos) {
+	    if (not calo.has_data()) {
+	      DT_LOG_WARNING(options_manager::get_instance().get_logging_priority(),
+			     "Event has no reconstructed particles");
+	      continue;
+	    }
 	    const snemo::datamodel::calibrated_calorimeter_hit &a_calo = calo.get();
 	    const geomtools::geom_id &a_calo_gid = a_calo.get_geom_id();
 	    this->highlight_geom_id(a_calo_gid,
@@ -292,7 +302,14 @@ namespace snemo {
 		       "No calorimeter hits unassociated to particle track");
 	}
 
+	int particleCount = -1;
 	for (const auto &particle : pt_data.particles()) {
+	  particleCount++;
+	  if (not particle.has_data()) {
+	    DT_LOG_WARNING(options_manager::get_instance().get_logging_priority(),
+			   "Particle #" << particleCount << "'s handle is not set");
+	    continue;
+	  }
 	  const snemo::datamodel::particle_track &a_particle = particle.get();
 
 	  if (a_particle.get_auxiliaries().has_key(browser_tracks::CHECKED_FLAG) &&
@@ -331,22 +348,30 @@ namespace snemo {
 		mark->SetMarkerStyle(kOpenCrossX);
 	      }
 	      {
-		auto from = a_vertex->get_from();
-		auto fromPoint = a_particle.get_trajectory().get_pattern().get_first();
-		if (from == snemo::datamodel::VERTEX_FROM_LAST) {
-		  fromPoint = a_particle.get_trajectory().get_pattern().get_last();
+		if (not a_particle.get_trajectory_handle().has_data()) {
+		  DT_LOG_WARNING(options_manager::get_instance().get_logging_priority(),
+				 "Particle #" << particleCount << "'s trajectory handle is not set"
+				 << " (charge=" << snemo::datamodel::particle_track::to_string(a_particle.get_charge()) << ")"
+				 );
+		  
+		} else {
+		  auto from = a_vertex->get_from();
+		  auto fromPoint = a_particle.get_trajectory().get_pattern().get_first();
+		  if (from == snemo::datamodel::VERTEX_FROM_LAST) {
+		    fromPoint = a_particle.get_trajectory().get_pattern().get_last();
+		  }
+		  TPolyMarker3D * fromMark = base_renderer::make_polymarker(fromPoint);
+		  _objects->Add(fromMark);
+		  fromMark->SetMarkerColor(effectiveColor);
+		  fromMark->SetMarkerStyle(kOpenCircle);
+		  geomtools::polyline_type polyVertices;
+		  polyVertices.push_back(fromPoint);
+		  polyVertices.push_back(a_position);
+		  TPolyLine3D * extrapolatedTrack = base_renderer::make_polyline(polyVertices);
+		  _objects->Add(extrapolatedTrack);
+		  extrapolatedTrack->SetLineColor(effectiveColor);
+		  extrapolatedTrack->SetLineStyle(kDashed);
 		}
-		TPolyMarker3D * fromMark = base_renderer::make_polymarker(fromPoint);
-		_objects->Add(fromMark);
-		fromMark->SetMarkerColor(effectiveColor);
-		fromMark->SetMarkerStyle(kOpenCircle);
-		geomtools::polyline_type polyVertices;
-		polyVertices.push_back(fromPoint);
-		polyVertices.push_back(a_position);
-		TPolyLine3D * extrapolatedTrack = base_renderer::make_polyline(polyVertices);
-		_objects->Add(extrapolatedTrack);
-		extrapolatedTrack->SetLineColor(effectiveColor);
-		extrapolatedTrack->SetLineStyle(kDashed);
 	      }
 	      if (a_vertex->get_auxiliaries().has_flag(browser_tracks::HIGHLIGHT_FLAG)) {
 		TPolyMarker3D *mark = base_renderer::make_polymarker(a_position);
@@ -384,6 +409,9 @@ namespace snemo {
 	    const snemo::datamodel::CalorimeterHitHdlCollection & calos =
 	      a_particle.get_associated_calorimeter_hits();
 	    for (const auto & calo : calos) {
+	      if (not calo.has_data()) {
+		continue;
+	      }
 	      const snemo::datamodel::calibrated_calorimeter_hit &a_calo = calo.get();
 	      const geomtools::geom_id &a_calo_gid = a_calo.get_geom_id();
 	      this->highlight_geom_id(a_calo_gid, color);


### PR DESCRIPTION
When a reconstructed particle track (from the PTD bank) has no valid reconstructed trajectory (from tracker and vertex extrapolation infos), the browser crashed because of a missing test of the handle having no data. 